### PR TITLE
Respect EF Core naming conventions and default to jobly schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,8 @@ Default: no auth (open access).
 ### Key Design Decisions
 
 - **No raw SQL** — all queries use EF Core LINQ. No `_context.Set<>()` subqueries inside `.Select()` projections — use navigation properties or two-step fetch instead.
+- **Naming conventions respected** — entity configurations do NOT use `.ToTable()`, so EF Core naming conventions (e.g., `UseSnakeCaseNamingConvention()`) can transform table/column names freely. Schema is set via `entity.Metadata.SetSchema()` to avoid re-pinning table names.
+- **Default schema** — All Jobly tables default to the `"jobly"` schema. Configurable via `JoblyConfiguration.Schema`. Set to `null` for the database's default schema.
 - **TimeProvider** — all production code uses injectable `TimeProvider` instead of `DateTime.UtcNow`. Registered as `TryAddSingleton(TimeProvider.System)` in `AddJobly`. Test code can use `DateTime.UtcNow` directly.
 - **DbContext must be registered as Scoped** (not Transient). The outbox pattern requires the publisher and application code to share the same DbContext instance within a scope.
 - Everything is a Job. `ParentJobId` replaces both the old MessageId and BatchId foreign keys.

--- a/src/core/Jobly.Core/Configuration.cs
+++ b/src/core/Jobly.Core/Configuration.cs
@@ -6,6 +6,8 @@ public class JoblyConfiguration
 
     public string DefaultQueue { get; set; } = "default";
 
+    public string? Schema { get; set; } = "jobly";
+
     /// <summary>
     /// How long completed and deleted jobs are retained before cleanup.
     /// Failed jobs are never auto-expired.

--- a/src/core/Jobly.Core/Data/Interceptors/RowLockInterceptor.cs
+++ b/src/core/Jobly.Core/Data/Interceptors/RowLockInterceptor.cs
@@ -1,5 +1,5 @@
 using System.Data.Common;
-using Jobly.Core.Entities;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Jobly.Core.Interceptors;
@@ -56,12 +56,16 @@ public class PostgresRowLockInterceptor : DbCommandInterceptor
     }
 }
 
-public class SqlServerRowLockInterceptor : DbCommandInterceptor
+public partial class SqlServerRowLockInterceptor : DbCommandInterceptor
 {
+    // Matches the first FROM [table] AS [alias] or FROM [schema].[table] AS [alias] pattern
+    [GeneratedRegex(@"(FROM\s+(?:\[\w+\]\.)*\[\w+\]\s+AS\s+\[\w+\])")]
+    private static partial Regex FromClausePattern();
+
     public override InterceptionResult<DbDataReader> ReaderExecuting(
-    DbCommand command,
-    CommandEventData eventData,
-    InterceptionResult<DbDataReader> result)
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result)
     {
         ManipulateCommand(command);
 
@@ -84,15 +88,15 @@ public class SqlServerRowLockInterceptor : DbCommandInterceptor
         if (command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableJob}", StringComparison.Ordinal)
             && !command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableJobWait}", StringComparison.Ordinal))
         {
-            command.CommandText = command.CommandText.Replace($"FROM [{nameof(Job)}] AS [j]", $"FROM [{nameof(Job)}] AS [j] WITH (ROWLOCK, UPDLOCK, READPAST)", StringComparison.Ordinal);
+            command.CommandText = FromClausePattern().Replace(command.CommandText, "$1 WITH (ROWLOCK, UPDLOCK, READPAST)", 1);
         }
         else if (command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableJobWait}", StringComparison.Ordinal))
         {
-            command.CommandText = command.CommandText.Replace($"FROM [{nameof(Job)}] AS [j]", $"FROM [{nameof(Job)}] AS [j] WITH (ROWLOCK, UPDLOCK)", StringComparison.Ordinal);
+            command.CommandText = FromClausePattern().Replace(command.CommandText, "$1 WITH (ROWLOCK, UPDLOCK)", 1);
         }
         else if (command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableCounter}", StringComparison.Ordinal))
         {
-            command.CommandText = command.CommandText.Replace("FROM [Counter] AS [c]", "FROM [Counter] AS [c] WITH (ROWLOCK, UPDLOCK, READPAST)", StringComparison.Ordinal);
+            command.CommandText = FromClausePattern().Replace(command.CommandText, "$1 WITH (ROWLOCK, UPDLOCK, READPAST)", 1);
         }
     }
 }

--- a/src/core/Jobly.Core/JoblyModelCustomizer.cs
+++ b/src/core/Jobly.Core/JoblyModelCustomizer.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Jobly.Core;
 
@@ -13,6 +15,9 @@ internal sealed class JoblyModelCustomizer : RelationalModelCustomizer
     public override void Customize(ModelBuilder modelBuilder, DbContext context)
     {
         base.Customize(modelBuilder, context);
-        modelBuilder.AddOutboxStateEntity();
+
+        var config = context.GetService<IOptions<JoblyConfiguration>>()?.Value;
+        var schema = config != null ? config.Schema : "jobly";
+        modelBuilder.AddOutboxStateEntity(schema);
     }
 }

--- a/src/core/Jobly.Core/ServiceConfiguration.cs
+++ b/src/core/Jobly.Core/ServiceConfiguration.cs
@@ -141,25 +141,24 @@ public static class ServiceConfiguration
         return optionsBuilder;
     }
 
-    public static void AddOutboxStateEntity(this ModelBuilder modelBuilder)
+    public static void AddOutboxStateEntity(this ModelBuilder modelBuilder, string? schema = "jobly")
     {
-        AddJobEntity(modelBuilder);
-        AddRecurringJobEntity(modelBuilder);
-        AddRecurringJobLogEntity(modelBuilder);
-        AddServerEntity(modelBuilder);
-        AddWorkerEntity(modelBuilder);
-        AddWorkerGroupEntity(modelBuilder);
-        AddJobLogEntity(modelBuilder);
-        AddStatisticEntity(modelBuilder);
-        AddCounterEntity(modelBuilder);
-        AddServerTaskEntity(modelBuilder);
-        AddServerLogEntity(modelBuilder);
+        AddJobEntity(modelBuilder, schema);
+        AddRecurringJobEntity(modelBuilder, schema);
+        AddRecurringJobLogEntity(modelBuilder, schema);
+        AddServerEntity(modelBuilder, schema);
+        AddWorkerEntity(modelBuilder, schema);
+        AddWorkerGroupEntity(modelBuilder, schema);
+        AddJobLogEntity(modelBuilder, schema);
+        AddStatisticEntity(modelBuilder, schema);
+        AddCounterEntity(modelBuilder, schema);
+        AddServerTaskEntity(modelBuilder, schema);
+        AddServerLogEntity(modelBuilder, schema);
     }
 
-    private static void AddJobEntity(ModelBuilder modelBuilder)
+    private static void AddJobEntity(ModelBuilder modelBuilder, string? schema)
     {
         var job = modelBuilder.Entity<Job>();
-        job.ToTable(nameof(Job));
 
         job.Property(p => p.Id);
         job.HasKey(p => p.Id);
@@ -203,12 +202,13 @@ public static class ServiceConfiguration
         job.HasIndex(p => p.ConcurrencyKey);
 
         job.Property(p => p.Metadata);
+
+        job.Metadata.SetSchema(schema);
     }
 
-    private static void AddRecurringJobEntity(ModelBuilder modelBuilder)
+    private static void AddRecurringJobEntity(ModelBuilder modelBuilder, string? schema)
     {
         var recurringJob = modelBuilder.Entity<RecurringJob>();
-        recurringJob.ToTable(nameof(RecurringJob));
 
         recurringJob.Property(p => p.Id);
         recurringJob.HasKey(p => p.Id);
@@ -223,12 +223,13 @@ public static class ServiceConfiguration
         recurringJob.Property(p => p.LastExecution);
 
         recurringJob.Property(p => p.Version).IsConcurrencyToken();
+
+        recurringJob.Metadata.SetSchema(schema);
     }
 
-    private static void AddRecurringJobLogEntity(ModelBuilder modelBuilder)
+    private static void AddRecurringJobLogEntity(ModelBuilder modelBuilder, string? schema)
     {
         var log = modelBuilder.Entity<RecurringJobLog>();
-        log.ToTable(nameof(RecurringJobLog));
 
         log.Property(p => p.Id);
         log.HasKey(p => p.Id);
@@ -241,12 +242,13 @@ public static class ServiceConfiguration
 
         log.HasIndex(p => p.JobId);
         log.HasOne(p => p.Job).WithMany().HasForeignKey(p => p.JobId).OnDelete(DeleteBehavior.SetNull);
+
+        log.Metadata.SetSchema(schema);
     }
 
-    private static void AddServerEntity(ModelBuilder modelBuilder)
+    private static void AddServerEntity(ModelBuilder modelBuilder, string? schema)
     {
         var server = modelBuilder.Entity<Server>();
-        server.ToTable(nameof(Server));
 
         server.Property(p => p.Id);
         server.HasKey(p => p.Id);
@@ -258,12 +260,13 @@ public static class ServiceConfiguration
         server.Property(p => p.ServiceCount);
 
         server.Property(p => p.PausedAt);
+
+        server.Metadata.SetSchema(schema);
     }
 
-    private static void AddWorkerEntity(ModelBuilder modelBuilder)
+    private static void AddWorkerEntity(ModelBuilder modelBuilder, string? schema)
     {
         var worker = modelBuilder.Entity<Worker>();
-        worker.ToTable(nameof(Worker));
 
         worker.Property(p => p.Id);
         worker.HasKey(p => p.Id);
@@ -280,12 +283,13 @@ public static class ServiceConfiguration
         worker.HasOne(p => p.WorkerGroup)
             .WithMany()
             .HasForeignKey(p => p.WorkerGroupId);
+
+        worker.Metadata.SetSchema(schema);
     }
 
-    private static void AddWorkerGroupEntity(ModelBuilder modelBuilder)
+    private static void AddWorkerGroupEntity(ModelBuilder modelBuilder, string? schema)
     {
         var wg = modelBuilder.Entity<WorkerGroup>();
-        wg.ToTable(nameof(WorkerGroup));
 
         wg.Property(p => p.Id);
         wg.HasKey(p => p.Id);
@@ -299,12 +303,13 @@ public static class ServiceConfiguration
         wg.HasOne(p => p.Server)
             .WithMany()
             .HasForeignKey(p => p.ServerId);
+
+        wg.Metadata.SetSchema(schema);
     }
 
-    private static void AddJobLogEntity(ModelBuilder modelBuilder)
+    private static void AddJobLogEntity(ModelBuilder modelBuilder, string? schema)
     {
         var jobLog = modelBuilder.Entity<JobLog>();
-        jobLog.ToTable(nameof(JobLog));
 
         jobLog.Property(p => p.Id);
         jobLog.HasKey(p => p.Id);
@@ -319,24 +324,26 @@ public static class ServiceConfiguration
         jobLog.Property(p => p.WorkerId);
 
         jobLog.HasIndex(p => p.JobId);
+
+        jobLog.Metadata.SetSchema(schema);
     }
 
-    private static void AddStatisticEntity(ModelBuilder modelBuilder)
+    private static void AddStatisticEntity(ModelBuilder modelBuilder, string? schema)
     {
         var stat = modelBuilder.Entity<Statistic>();
-        stat.ToTable(nameof(Statistic));
 
         stat.Property(p => p.Key);
         stat.HasKey(p => p.Key);
         stat.Property(p => p.Value);
 
         // No seed data — Statistic rows are created by the counter aggregator on demand.
+
+        stat.Metadata.SetSchema(schema);
     }
 
-    private static void AddCounterEntity(ModelBuilder modelBuilder)
+    private static void AddCounterEntity(ModelBuilder modelBuilder, string? schema)
     {
         var counter = modelBuilder.Entity<Counter>();
-        counter.ToTable(nameof(Counter));
 
         counter.Property(p => p.Id);
         counter.HasKey(p => p.Id);
@@ -344,12 +351,13 @@ public static class ServiceConfiguration
         counter.Property(p => p.Value);
 
         counter.HasIndex(p => p.Key);
+
+        counter.Metadata.SetSchema(schema);
     }
 
-    private static void AddServerTaskEntity(ModelBuilder modelBuilder)
+    private static void AddServerTaskEntity(ModelBuilder modelBuilder, string? schema)
     {
         var serverTask = modelBuilder.Entity<ServerTask>();
-        serverTask.ToTable(nameof(ServerTask));
 
         serverTask.Property(p => p.Id);
         serverTask.HasKey(p => p.Id);
@@ -367,12 +375,13 @@ public static class ServiceConfiguration
             .OnDelete(DeleteBehavior.Cascade);
 
         serverTask.HasIndex(p => p.ServerId);
+
+        serverTask.Metadata.SetSchema(schema);
     }
 
-    private static void AddServerLogEntity(ModelBuilder modelBuilder)
+    private static void AddServerLogEntity(ModelBuilder modelBuilder, string? schema)
     {
         var serverLog = modelBuilder.Entity<ServerLog>();
-        serverLog.ToTable(nameof(ServerLog));
 
         serverLog.Property(p => p.Id);
         serverLog.HasKey(p => p.Id);
@@ -391,5 +400,7 @@ public static class ServiceConfiguration
         serverLog.HasIndex(p => p.ServerId);
         serverLog.HasIndex(p => p.ServerTaskId);
         serverLog.HasIndex(p => p.Timestamp);
+
+        serverLog.Metadata.SetSchema(schema);
     }
 }

--- a/src/core/Jobly.Tests/Fixtures/FixtureHelper.cs
+++ b/src/core/Jobly.Tests/Fixtures/FixtureHelper.cs
@@ -1,0 +1,32 @@
+using Jobly.Core.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Jobly.Tests.Fixtures;
+
+internal static class FixtureHelper
+{
+    internal static Respawn.Graph.Table[] GetServerTablesToIgnore(DbContext context)
+    {
+        var model = context.Model;
+
+        return
+        [
+            ToRespawnTable(model, typeof(Server)),
+            ToRespawnTable(model, typeof(Jobly.Core.Data.Entities.Worker)),
+            ToRespawnTable(model, typeof(WorkerGroup)),
+            ToRespawnTable(model, typeof(ServerTask)),
+            ToRespawnTable(model, typeof(ServerLog)),
+        ];
+    }
+
+    private static Respawn.Graph.Table ToRespawnTable(Microsoft.EntityFrameworkCore.Metadata.IModel model, Type entityType)
+    {
+        var entityModel = model.FindEntityType(entityType)!;
+        var tableName = entityModel.GetTableName()!;
+        var schema = entityModel.GetSchema();
+
+        return schema != null
+            ? new Respawn.Graph.Table(schema, tableName)
+            : new Respawn.Graph.Table(tableName);
+    }
+}

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlIntegrationFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlIntegrationFixture.cs
@@ -1,3 +1,4 @@
+using Jobly.Core.Data.Entities;
 using Jobly.Core.Interceptors;
 using Jobly.Tests.Integration;
 using Microsoft.EntityFrameworkCore;
@@ -31,7 +32,7 @@ public class PostgreSqlIntegrationFixture : IAsyncLifetime, IDatabaseFixture
         _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
         {
             DbAdapter = DbAdapter.Postgres,
-            TablesToIgnore = [new Respawn.Graph.Table("Server"), new Respawn.Graph.Table("Worker"), new Respawn.Graph.Table("WorkerGroup"), new Respawn.Graph.Table("ServerTask"), new Respawn.Graph.Table("ServerLog")],
+            TablesToIgnore = FixtureHelper.GetServerTablesToIgnore(context),
         });
 
         TestServer = await JoblyTestServer.StartAsync(this);

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlMultiServerFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlMultiServerFixture.cs
@@ -36,7 +36,7 @@ public class PostgreSqlMultiServerFixture : IAsyncLifetime, IMultiServerDatabase
         _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
         {
             DbAdapter = DbAdapter.Postgres,
-            TablesToIgnore = [new Respawn.Graph.Table("Server"), new Respawn.Graph.Table("Worker"), new Respawn.Graph.Table("WorkerGroup"), new Respawn.Graph.Table("ServerTask"), new Respawn.Graph.Table("ServerLog")],
+            TablesToIgnore = FixtureHelper.GetServerTablesToIgnore(context),
         });
 
         Server1 = await JoblyTestServer.StartAsync(this, config => config.WorkerCount = 3);

--- a/src/core/Jobly.Tests/Fixtures/SqlServerIntegrationFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerIntegrationFixture.cs
@@ -31,7 +31,7 @@ public class SqlServerIntegrationFixture : IAsyncLifetime, IDatabaseFixture
         _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
         {
             DbAdapter = DbAdapter.SqlServer,
-            TablesToIgnore = [new Respawn.Graph.Table("Server"), new Respawn.Graph.Table("Worker"), new Respawn.Graph.Table("WorkerGroup"), new Respawn.Graph.Table("ServerTask"), new Respawn.Graph.Table("ServerLog")],
+            TablesToIgnore = FixtureHelper.GetServerTablesToIgnore(context),
         });
 
         TestServer = await JoblyTestServer.StartAsync(this);

--- a/src/core/Jobly.Tests/Fixtures/SqlServerMultiServerFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerMultiServerFixture.cs
@@ -36,7 +36,7 @@ public class SqlServerMultiServerFixture : IAsyncLifetime, IMultiServerDatabaseF
         _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
         {
             DbAdapter = DbAdapter.SqlServer,
-            TablesToIgnore = [new Respawn.Graph.Table("Server"), new Respawn.Graph.Table("Worker"), new Respawn.Graph.Table("WorkerGroup"), new Respawn.Graph.Table("ServerTask"), new Respawn.Graph.Table("ServerLog")],
+            TablesToIgnore = FixtureHelper.GetServerTablesToIgnore(context),
         });
 
         Server1 = await JoblyTestServer.StartAsync(this, config => config.WorkerCount = 3);

--- a/src/core/Jobly.Tests/Unit/NamingConventionTests.cs
+++ b/src/core/Jobly.Tests/Unit/NamingConventionTests.cs
@@ -1,0 +1,148 @@
+using Jobly.Core;
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public class NamingConventionTests
+{
+    [Fact]
+    public void JoblyEntities_UsePascalCaseTableNames_WhenNoConventionApplied()
+    {
+        var options = new DbContextOptionsBuilder<TestContext>()
+            .UseSqlServer("Server=dummy")
+            .Options;
+
+        using var context = new TestContext(options);
+        var model = context.Model;
+
+        model.FindEntityType(typeof(Job))!.GetTableName().ShouldBe("Job");
+        model.FindEntityType(typeof(RecurringJob))!.GetTableName().ShouldBe("RecurringJob");
+        model.FindEntityType(typeof(JobLog))!.GetTableName().ShouldBe("JobLog");
+        model.FindEntityType(typeof(Server))!.GetTableName().ShouldBe("Server");
+        model.FindEntityType(typeof(Jobly.Core.Data.Entities.Worker))!.GetTableName().ShouldBe("Worker");
+        model.FindEntityType(typeof(WorkerGroup))!.GetTableName().ShouldBe("WorkerGroup");
+        model.FindEntityType(typeof(Counter))!.GetTableName().ShouldBe("Counter");
+        model.FindEntityType(typeof(Statistic))!.GetTableName().ShouldBe("Statistic");
+        model.FindEntityType(typeof(ServerTask))!.GetTableName().ShouldBe("ServerTask");
+        model.FindEntityType(typeof(ServerLog))!.GetTableName().ShouldBe("ServerLog");
+    }
+
+    [Fact]
+    public void JoblyEntities_UseSnakeCaseTableNames_WhenSnakeCaseConventionApplied()
+    {
+        var options = new DbContextOptionsBuilder<TestContext>()
+            .UseNpgsql("Host=dummy")
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        using var context = new TestContext(options);
+        var model = context.Model;
+
+        model.FindEntityType(typeof(Job))!.GetTableName().ShouldBe("job");
+        model.FindEntityType(typeof(RecurringJob))!.GetTableName().ShouldBe("recurring_job");
+        model.FindEntityType(typeof(RecurringJobLog))!.GetTableName().ShouldBe("recurring_job_log");
+        model.FindEntityType(typeof(JobLog))!.GetTableName().ShouldBe("job_log");
+        model.FindEntityType(typeof(Server))!.GetTableName().ShouldBe("server");
+        model.FindEntityType(typeof(Jobly.Core.Data.Entities.Worker))!.GetTableName().ShouldBe("worker");
+        model.FindEntityType(typeof(WorkerGroup))!.GetTableName().ShouldBe("worker_group");
+        model.FindEntityType(typeof(Counter))!.GetTableName().ShouldBe("counter");
+        model.FindEntityType(typeof(Statistic))!.GetTableName().ShouldBe("statistic");
+        model.FindEntityType(typeof(ServerTask))!.GetTableName().ShouldBe("server_task");
+        model.FindEntityType(typeof(ServerLog))!.GetTableName().ShouldBe("server_log");
+    }
+
+    [Fact]
+    public void JoblyEntities_UseSnakeCaseColumnNames_WhenSnakeCaseConventionApplied()
+    {
+        var options = new DbContextOptionsBuilder<TestContext>()
+            .UseNpgsql("Host=dummy")
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        using var context = new TestContext(options);
+        var jobEntity = context.Model.FindEntityType(typeof(Job))!;
+
+        jobEntity.FindProperty(nameof(Job.CurrentState))!.GetColumnName().ShouldBe("current_state");
+        jobEntity.FindProperty(nameof(Job.CreateTime))!.GetColumnName().ShouldBe("create_time");
+        jobEntity.FindProperty(nameof(Job.ScheduleTime))!.GetColumnName().ShouldBe("schedule_time");
+        jobEntity.FindProperty(nameof(Job.ParentJobId))!.GetColumnName().ShouldBe("parent_job_id");
+        jobEntity.FindProperty(nameof(Job.HandlerType))!.GetColumnName().ShouldBe("handler_type");
+        jobEntity.FindProperty(nameof(Job.ConcurrencyKey))!.GetColumnName().ShouldBe("concurrency_key");
+        jobEntity.FindProperty(nameof(Job.CancellationMode))!.GetColumnName().ShouldBe("cancellation_mode");
+    }
+
+    [Fact]
+    public void JoblyEntities_UseDefaultJoblySchema()
+    {
+        var options = new DbContextOptionsBuilder<TestContext>()
+            .UseSqlServer("Server=dummy")
+            .Options;
+
+        using var context = new TestContext(options);
+        var model = context.Model;
+
+        model.FindEntityType(typeof(Job))!.GetSchema().ShouldBe("jobly");
+        model.FindEntityType(typeof(RecurringJob))!.GetSchema().ShouldBe("jobly");
+        model.FindEntityType(typeof(JobLog))!.GetSchema().ShouldBe("jobly");
+        model.FindEntityType(typeof(Server))!.GetSchema().ShouldBe("jobly");
+        model.FindEntityType(typeof(Jobly.Core.Data.Entities.Worker))!.GetSchema().ShouldBe("jobly");
+        model.FindEntityType(typeof(Counter))!.GetSchema().ShouldBe("jobly");
+    }
+
+    [Fact]
+    public void JoblyEntities_UseCustomSchema_WhenOverridden()
+    {
+        var options = new DbContextOptionsBuilder<SchemaTestContext>()
+            .UseSqlServer("Server=dummy")
+            .Options;
+
+        using var context = new SchemaTestContext(options);
+        var model = context.Model;
+
+        model.FindEntityType(typeof(Job))!.GetSchema().ShouldBe("custom");
+    }
+
+    [Fact]
+    public void JoblyEntities_UseNullSchema_WhenSetToNull()
+    {
+        var options = new DbContextOptionsBuilder<NullSchemaTestContext>()
+            .UseSqlServer("Server=dummy")
+            .Options;
+
+        using var context = new NullSchemaTestContext(options);
+        var model = context.Model;
+
+        model.FindEntityType(typeof(Job))!.GetSchema().ShouldBeNull();
+    }
+}
+
+internal class SchemaTestContext : DbContext
+{
+    public SchemaTestContext(DbContextOptions<SchemaTestContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.AddOutboxStateEntity("custom");
+    }
+}
+
+internal class NullSchemaTestContext : DbContext
+{
+    public NullSchemaTestContext(DbContextOptions<NullSchemaTestContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.AddOutboxStateEntity(null);
+    }
+}

--- a/src/core/Jobly.Tests/Unit/SqlServerRowLockInterceptorTests.cs
+++ b/src/core/Jobly.Tests/Unit/SqlServerRowLockInterceptorTests.cs
@@ -1,0 +1,102 @@
+using System.Data;
+using System.Data.Common;
+using Jobly.Core.Interceptors;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public class SqlServerRowLockInterceptorTests
+{
+    private readonly SqlServerRowLockInterceptor _interceptor = new();
+
+    [Fact]
+    public void ManipulateCommand_WithDefaultTableName_AddsReadPastHint()
+    {
+        var command = CreateCommand($"""
+            -- {InterceptorConstants.RowLockTableJob}
+            SELECT TOP(1) [j].[Id], [j].[CurrentState]
+            FROM [Job] AS [j]
+            WHERE [j].[Kind] = 1
+            """);
+
+        _interceptor.ReaderExecuting(command, null!, default);
+
+        command.CommandText.ShouldContain("FROM [Job] AS [j] WITH (ROWLOCK, UPDLOCK, READPAST)");
+    }
+
+    [Fact]
+    public void ManipulateCommand_WithSchemaQualifiedTableName_AddsReadPastHint()
+    {
+        var command = CreateCommand($"""
+            -- {InterceptorConstants.RowLockTableJob}
+            SELECT TOP(1) [j].[Id], [j].[CurrentState]
+            FROM [jobly].[Job] AS [j]
+            WHERE [j].[Kind] = 1
+            """);
+
+        _interceptor.ReaderExecuting(command, null!, default);
+
+        command.CommandText.ShouldContain("FROM [jobly].[Job] AS [j] WITH (ROWLOCK, UPDLOCK, READPAST)");
+    }
+
+    [Fact]
+    public void ManipulateCommand_WithWaitTag_AddsUpdLockWithoutReadPast()
+    {
+        var command = CreateCommand($"""
+            -- {InterceptorConstants.RowLockTableJobWait}
+            SELECT TOP(1) [j].[Id]
+            FROM [jobly].[Job] AS [j]
+            WHERE [j].[Id] = @p0
+            """);
+
+        _interceptor.ReaderExecuting(command, null!, default);
+
+        command.CommandText.ShouldContain("FROM [jobly].[Job] AS [j] WITH (ROWLOCK, UPDLOCK)");
+        command.CommandText.ShouldNotContain("READPAST");
+    }
+
+    [Fact]
+    public void ManipulateCommand_WithCounterTag_AddsReadPastHint()
+    {
+        var command = CreateCommand($"""
+            -- {InterceptorConstants.RowLockTableCounter}
+            SELECT TOP(1) [c].[Id], [c].[Key]
+            FROM [jobly].[Counter] AS [c]
+            WHERE [c].[Key] = @p0
+            """);
+
+        _interceptor.ReaderExecuting(command, null!, default);
+
+        command.CommandText.ShouldContain("FROM [jobly].[Counter] AS [c] WITH (ROWLOCK, UPDLOCK, READPAST)");
+    }
+
+    private static DbCommand CreateCommand(string commandText)
+    {
+        return new FakeDbCommand { CommandText = commandText };
+    }
+
+    private sealed class FakeDbCommand : DbCommand
+    {
+        public override string CommandText { get; set; } = string.Empty;
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection? DbConnection { get; set; }
+        protected override DbParameterCollection DbParameterCollection => null!;
+        protected override DbTransaction? DbTransaction { get; set; }
+
+        public override void Cancel() { }
+
+        public override int ExecuteNonQuery() => 0;
+
+        public override object? ExecuteScalar() => null;
+
+        public override void Prepare() { }
+
+        protected override DbParameter CreateDbParameter() => null!;
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => null!;
+    }
+}

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,6 +4,14 @@
 > It is read at the start of every `/project:moberg-implement` session.
 > Commit this file — it is institutional memory for the team.
 
+## 2026-04-09 — Naming conventions & schema support
+
+- EF Core's `.ToTable(nameof(Entity))` via Fluent API sets the table name with `ConfigurationSource.Explicit`, which prevents `EFCore.NamingConventions` from transforming it (conventions have lower priority than explicit config). To let naming conventions work, don't call `.ToTable()` — let EF Core use the CLR type name as the default (convention-sourced).
+- When Respawn's `TablesToIgnore` uses hardcoded table names, they break when naming conventions transform those names. Resolve table names from the EF model instead (`model.FindEntityType(typeof(Entity))!.GetTableName()`).
+- Using `entity.Metadata.SetSchema(schema)` sets schema without re-pinning the table name — this is the correct way to assign schema while preserving naming convention freedom. Don't use `.ToTable(name, schema)` which sets both explicitly.
+- `null`-coalescing (`??`) on config properties silently discards explicit `null` values. When a user sets `Schema = null` to opt out, `config?.Schema ?? "jobly"` ignores their intent. Use `config != null ? config.Schema : "jobly"` to distinguish "no config" from "config with null".
+- The `SqlServerRowLockInterceptor` hardcoded table names for string replacement. Use regex against the `FROM [table] AS [alias]` pattern instead, so it works regardless of naming convention or schema.
+
 ## 2026-04-09 — Multi-server integration tests
 
 - `IBatchPublisher.StartNew()` and `ContinueBatchWith()` do NOT auto-save. Always call `batchPublisher.SaveChangesAsync()` after batch operations. The publisher and batch publisher are separate DI scopes — `publisher.SaveChangesAsync()` does not save the batch publisher's changes.


### PR DESCRIPTION
## Summary
- Remove explicit `.ToTable()` calls from all 11 entity configurations so EF Core naming conventions (e.g., `UseSnakeCaseNamingConvention()`) can transform table/column names freely
- Add `JoblyConfiguration.Schema` property (default `"jobly"`) — all Jobly tables live in the `jobly` schema by default, configurable to any value or `null` for the database default
- Fix `SqlServerRowLockInterceptor` to use regex pattern matching instead of hardcoded table names, so lock hints work regardless of naming convention or schema
- Update Respawn `TablesToIgnore` in all 4 integration fixtures to resolve table names from the EF model via `FixtureHelper`

## Test plan
- [x] 6 naming convention tests (PascalCase default, snake_case tables, snake_case columns, default schema, custom schema, null schema)
- [x] 4 SQL Server interceptor tests (default table, schema-qualified table, wait lock, counter lock)
- [x] Full test suite: 598 pass, 0 fail (310 PostgreSQL + 288 SQL Server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)