### PR TITLE
Add EnableHandlerLogging config option

### DIFF
--- a/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
@@ -51,7 +51,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    private JoblyWorkerService<TestContext> CreateWorker()
+    private JoblyWorkerService<TestContext> CreateWorker(bool enableHandlerLogging = true)
     {
         var services = new ServiceCollection();
         services.AddJobHandlers(typeof(HandlerLogTestsBase).Assembly);
@@ -68,6 +68,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
             WorkerCount = 1,
             ServerId = ServerId,
             Queues = DefaultQueues,
+            EnableHandlerLogging = enableHandlerLogging,
         });
         services.AddSingleton<IOptions<JoblyWorkerConfiguration>>(workerConfig);
         services.AddSingleton<IOptions<JoblyConfiguration>>(workerConfig);
@@ -257,6 +258,74 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         // Each should have its own logs
         logs1.ShouldContain(l => l.Message.Contains("Processing logging request", StringComparison.Ordinal));
         logs2.ShouldContain(l => l.Message.Contains("About to fail", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_HandlerLoggingDisabled_HandlerLogsNotWritten()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(LoggingRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new LoggingRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(enableHandlerLogging: false);
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var handlerLogs = await readCtx.Set<JobLog>()
+            .Where(x => x.JobId == jobId)
+            .Where(x => x.EventType == "Log")
+            .ToListAsync();
+
+        handlerLogs.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_HandlerLoggingDisabled_StateLogsStillWritten()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(LoggingRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new LoggingRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(enableHandlerLogging: false);
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var allLogs = await readCtx.Set<JobLog>()
+            .Where(x => x.JobId == jobId)
+            .ToListAsync();
+
+        allLogs.ShouldContain(x => string.Equals(x.EventType, "Processing", StringComparison.Ordinal));
+        allLogs.ShouldContain(x => string.Equals(x.EventType, "Completed", StringComparison.Ordinal));
     }
 }
 

--- a/src/core/Jobly.Tests/Unit/PauseStateHolderTests.cs
+++ b/src/core/Jobly.Tests/Unit/PauseStateHolderTests.cs
@@ -102,10 +102,12 @@ public class PauseStateHolderTests
         var tornReadsDetected = 0;
         var readerDone = false;
         var iterations = 0;
+        using var readerStarted = new ManualResetEventSlim(false);
 
         // Reader: continuously check IsPaused — should always be true
         var readerTask = Task.Run(() =>
         {
+            readerStarted.Set();
             while (!Volatile.Read(ref readerDone))
             {
                 if (!holder.IsPaused(groupId))
@@ -116,6 +118,9 @@ public class PauseStateHolderTests
                 Interlocked.Increment(ref iterations);
             }
         });
+
+        // Wait for reader to start before writing, so it doesn't starve under thread pool contention
+        readerStarted.Wait();
 
         // Writer: rapidly alternate between state A and state B
         for (var i = 0; i < 100_000; i++)

--- a/src/core/Jobly.Worker/Configuration.cs
+++ b/src/core/Jobly.Worker/Configuration.cs
@@ -79,6 +79,13 @@ public class JoblyWorkerConfiguration : JoblyConfiguration
     public int? MaxExpirableJobCount { get; set; }
 
     /// <summary>
+    /// When true (default), handler ILogger output is captured and written to the JobLog table.
+    /// When false, only system state-transition logs (Processing, Completed, Failed, etc.) are written.
+    /// Disabling reduces database write overhead for high-throughput workloads.
+    /// </summary>
+    public bool EnableHandlerLogging { get; set; } = true;
+
+    /// <summary>
     /// When true, uses a single dispatcher per worker group that batch-fetches jobs
     /// and distributes them to workers, reducing per-job DB overhead.
     /// When false (default), each worker independently fetches its own jobs.

--- a/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
@@ -123,7 +123,11 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             PerfTrace.Mark(PerfTrace.ExecuteHandler);
             _logger.LogInformation("Worker {workerId} executing job {id}", _workerId, job.Id);
 
-            JobLogContext.Current = logCollector;
+            if (_configuration.EnableHandlerLogging)
+            {
+                JobLogContext.Current = logCollector;
+            }
+
             JobExecutionContext.Current = new JobExecutionInfo
             {
                 JobId = job.Id,
@@ -154,7 +158,10 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             PerfTrace.Mark(PerfTrace.BeginTransaction2);
             await using var endTransaction = await context.Database.BeginTransactionAsync(default);
             UpdateJobState(context, job, null, handlerStopwatch.Elapsed.TotalMilliseconds);
-            await SaveJobLogs(context, logCollector);
+            if (_configuration.EnableHandlerLogging)
+            {
+                await SaveJobLogs(context, logCollector);
+            }
 
             PerfTrace.Mark(PerfTrace.SaveCompleted);
             await context.SaveChangesAsync(default);
@@ -188,7 +195,11 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
                 DurationMs = handlerStopwatch?.Elapsed.TotalMilliseconds,
                 WorkerId = _workerId,
             });
-            await SaveJobLogs(context, logCollector);
+            if (_configuration.EnableHandlerLogging)
+            {
+                await SaveJobLogs(context, logCollector);
+            }
+
             await context.SaveChangesAsync(default);
             await endTransaction.CommitAsync(default);
         }
@@ -203,7 +214,10 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
 
             await using var endTransaction = await context.Database.BeginTransactionAsync(default);
             UpdateJobState(context, job, e, handlerStopwatch?.Elapsed.TotalMilliseconds);
-            await SaveJobLogs(context, logCollector);
+            if (_configuration.EnableHandlerLogging)
+            {
+                await SaveJobLogs(context, logCollector);
+            }
             await context.SaveChangesAsync(default);
             await endTransaction.CommitAsync(default);
         }

--- a/src/core/Jobly.Worker/JoblyWorkerService.cs
+++ b/src/core/Jobly.Worker/JoblyWorkerService.cs
@@ -140,7 +140,11 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
             PerfTrace.Mark(PerfTrace.ExecuteHandler);
             _logger.LogInformation("Worker {workerId} executing job {id}", _workerId, job.Id);
 
-            JobLogContext.Current = logCollector;
+            if (_configuration.EnableHandlerLogging)
+            {
+                JobLogContext.Current = logCollector;
+            }
+
             JobExecutionContext.Current = new JobExecutionInfo
             {
                 JobId = job.Id,
@@ -171,7 +175,10 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
             PerfTrace.Mark(PerfTrace.BeginTransaction2);
             await using var endTransaction = await context.Database.BeginTransactionAsync(default);
             UpdateJobState(context, job, null, handlerStopwatch.Elapsed.TotalMilliseconds);
-            await SaveJobLogs(context, logCollector);
+            if (_configuration.EnableHandlerLogging)
+            {
+                await SaveJobLogs(context, logCollector);
+            }
 
             PerfTrace.Mark(PerfTrace.SaveCompleted);
             await context.SaveChangesAsync(default);
@@ -206,7 +213,11 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
                 DurationMs = handlerStopwatch?.Elapsed.TotalMilliseconds,
                 WorkerId = _workerId,
             });
-            await SaveJobLogs(context, logCollector);
+            if (_configuration.EnableHandlerLogging)
+            {
+                await SaveJobLogs(context, logCollector);
+            }
+
             await context.SaveChangesAsync(default);
             await endTransaction.CommitAsync(default);
         }
@@ -221,7 +232,10 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
 
             await using var endTransaction = await context.Database.BeginTransactionAsync(default);
             UpdateJobState(context, job, e, handlerStopwatch?.Elapsed.TotalMilliseconds);
-            await SaveJobLogs(context, logCollector);
+            if (_configuration.EnableHandlerLogging)
+            {
+                await SaveJobLogs(context, logCollector);
+            }
             await context.SaveChangesAsync(default);
             await endTransaction.CommitAsync(default);
         }


### PR DESCRIPTION
## Summary
- Adds `EnableHandlerLogging` boolean property to `JoblyWorkerConfiguration` (default `true`)
- When `false`, handler/pipeline `ILogger` output is no longer captured and written to the `JobLog` table
- System state-transition logs (Created, Processing, Completed, Failed, etc.) remain unaffected
- Reduces database write overhead for high-throughput workloads that don't need handler log capture
- Fixes flaky `PauseStateHolder` atomicity test (thread pool starvation under full suite load)

## Test plan
- [x] `GetAndProcessJob_HandlerLoggingDisabled_HandlerLogsNotWritten` — verifies no `EventType="Log"` entries when disabled
- [x] `GetAndProcessJob_HandlerLoggingDisabled_StateLogsStillWritten` — verifies Processing/Completed logs still written
- [x] All existing handler log tests pass (6/6)
- [x] Full test suite passes — 592/592 (PostgreSQL + SQL Server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)