### PR TITLE
Add OpenTelemetry tracing, span attributes, events, and metrics

### DIFF
--- a/src/core/Jobly.Core/BatchPublisher.cs
+++ b/src/core/Jobly.Core/BatchPublisher.cs
@@ -111,10 +111,19 @@ public class BatchPublisher<TContext> : IBatchPublisher
         batchJob.TraceId = traceId ?? batchJob.Id;
         batchJob.SpawnedByJobId = spawnedBy;
 
+        string? parentSpanId = null;
+        if (Activity.Current?.SpanId is { } batchSpanId && batchSpanId != default)
+        {
+            parentSpanId = batchSpanId.ToHexString();
+        }
+
+        batchJob.ParentSpanId = parentSpanId;
+
         foreach (var childJob in batchChildJobs)
         {
             childJob.TraceId = batchJob.TraceId;
             childJob.SpawnedByJobId = spawnedBy;
+            childJob.ParentSpanId = parentSpanId;
         }
 
         var logs = new List<JobLog>();
@@ -138,6 +147,9 @@ public class BatchPublisher<TContext> : IBatchPublisher
             Timestamp = now,
             Message = $"Batch job created in queue \"{batchJob.Queue}\"",
         });
+
+        JoblyTelemetry.JobsEnqueued.Add(batchChildJobs.Count, new KeyValuePair<string, object?>("queue", batchJob.Queue), new KeyValuePair<string, object?>("kind", "job"));
+        JoblyTelemetry.JobsEnqueued.Add(1, new KeyValuePair<string, object?>("queue", batchJob.Queue), new KeyValuePair<string, object?>("kind", "batch"));
 
         _context.Set<Job>().AddRange(batchChildJobs);
         _context.Set<Job>().Add(batchJob);

--- a/src/core/Jobly.Core/Data/Entities/Job.cs
+++ b/src/core/Jobly.Core/Data/Entities/Job.cs
@@ -51,4 +51,5 @@ public class Job
     public string? ConcurrencyKey { get; set; }
 
     public string? Metadata { get; set; }
+    public string? ParentSpanId { get; set; }
 }

--- a/src/core/Jobly.Core/Data/Entities/Job.cs
+++ b/src/core/Jobly.Core/Data/Entities/Job.cs
@@ -51,5 +51,6 @@ public class Job
     public string? ConcurrencyKey { get; set; }
 
     public string? Metadata { get; set; }
+
     public string? ParentSpanId { get; set; }
 }

--- a/src/core/Jobly.Core/Logging/JoblyTelemetry.cs
+++ b/src/core/Jobly.Core/Logging/JoblyTelemetry.cs
@@ -47,7 +47,12 @@ public static class JoblyTelemetry
 
     private static bool IsValidSpanId(string? value)
     {
-        return value != null && value.Length == 16 && value.All(char.IsAsciiHexDigit);
+        if (value == null || value.Length != 16)
+        {
+            return false;
+        }
+
+        return value.All(char.IsAsciiHexDigit);
     }
 
     public static string GetShortTypeName(string? assemblyQualifiedName)

--- a/src/core/Jobly.Core/Logging/JoblyTelemetry.cs
+++ b/src/core/Jobly.Core/Logging/JoblyTelemetry.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Jobly.Core.Logging;
+
+public static class JoblyTelemetry
+{
+    public const string ServiceName = "Jobly";
+
+    public static readonly ActivitySource ActivitySource = new(ServiceName);
+    public static readonly Meter Meter = new(ServiceName);
+
+    public static readonly Histogram<double> JobDuration = Meter.CreateHistogram<double>(
+        "jobly.job.duration",
+        unit: "ms",
+        description: "Duration of job handler execution");
+
+    public static readonly UpDownCounter<long> JobsActive = Meter.CreateUpDownCounter<long>(
+        "jobly.job.active",
+        unit: "{job}",
+        description: "Number of jobs currently being processed");
+
+    public static readonly Counter<long> JobsCompleted = Meter.CreateCounter<long>(
+        "jobly.job.completed",
+        unit: "{job}",
+        description: "Total jobs that finished processing");
+
+    public static readonly Counter<long> JobsEnqueued = Meter.CreateCounter<long>(
+        "jobly.job.enqueued",
+        unit: "{job}",
+        description: "Total jobs enqueued for processing");
+
+    public static Activity StartJobActivity(Guid traceId, string? parentSpanId)
+    {
+        var activityTraceId = ActivityTraceId.CreateFromString(traceId.ToString("N").AsSpan());
+        var activityParentSpanId = IsValidSpanId(parentSpanId)
+            ? ActivitySpanId.CreateFromString(parentSpanId.AsSpan())
+            : default;
+        var parentContext = new ActivityContext(activityTraceId, activityParentSpanId, ActivityTraceFlags.None);
+
+        return ActivitySource.StartActivity("Jobly.Execute", ActivityKind.Consumer, parentContext)
+            ?? new Activity("Jobly.Execute")
+                .SetIdFormat(ActivityIdFormat.W3C)
+                .SetParentId(activityTraceId, activityParentSpanId, ActivityTraceFlags.None)
+                .Start();
+    }
+
+    private static bool IsValidSpanId(string? value)
+    {
+        if (value == null || value.Length != 16)
+        {
+            return false;
+        }
+
+        foreach (var c in value)
+        {
+            if (!char.IsAsciiHexDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static string GetShortTypeName(string? assemblyQualifiedName)
+    {
+        if (assemblyQualifiedName == null)
+        {
+            return "unknown";
+        }
+
+        var commaIndex = assemblyQualifiedName.IndexOf(',', StringComparison.Ordinal);
+
+        return commaIndex > 0 ? assemblyQualifiedName[..commaIndex] : assemblyQualifiedName;
+    }
+}

--- a/src/core/Jobly.Core/Logging/JoblyTelemetry.cs
+++ b/src/core/Jobly.Core/Logging/JoblyTelemetry.cs
@@ -47,20 +47,7 @@ public static class JoblyTelemetry
 
     private static bool IsValidSpanId(string? value)
     {
-        if (value == null || value.Length != 16)
-        {
-            return false;
-        }
-
-        foreach (var c in value)
-        {
-            if (!char.IsAsciiHexDigit(c))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return value != null && value.Length == 16 && value.All(char.IsAsciiHexDigit);
     }
 
     public static string GetShortTypeName(string? assemblyQualifiedName)

--- a/src/core/Jobly.Core/Publisher.cs
+++ b/src/core/Jobly.Core/Publisher.cs
@@ -141,6 +141,13 @@ public class Publisher<TContext> : IPublisher
             msg.TraceId = msg.Id;
         }
 
+        if (Activity.Current?.SpanId is { } msgSpanId && msgSpanId != default)
+        {
+            msg.ParentSpanId = msgSpanId.ToHexString();
+        }
+
+        JoblyTelemetry.JobsEnqueued.Add(1, new KeyValuePair<string, object?>("queue", msg.Queue), new KeyValuePair<string, object?>("kind", "message"));
+
         await _context.Set<Job>().AddAsync(msg);
 
         return msg.Id;
@@ -268,6 +275,13 @@ public class Publisher<TContext> : IPublisher
         {
             newJob.TraceId = newJob.Id; // Root of a new trace
         }
+
+        if (Activity.Current?.SpanId is { } jobSpanId && jobSpanId != default)
+        {
+            newJob.ParentSpanId = jobSpanId.ToHexString();
+        }
+
+        JoblyTelemetry.JobsEnqueued.Add(1, new KeyValuePair<string, object?>("queue", newJob.Queue), new KeyValuePair<string, object?>("kind", "job"));
 
         await _context.Set<Job>().AddAsync(newJob);
         await _context.Set<JobLog>().AddAsync(new JobLog

--- a/src/core/Jobly.Tests/TestData/Handlers/ActivityCaptureCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/ActivityCaptureCommand.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+using Jobly.Core.Handlers;
+
+namespace Jobly.Tests.TestData.Handlers;
+
+public class ActivityCaptureRequest : IJob;
+
+public class ActivityCaptureCommand : IJobHandler<ActivityCaptureRequest>
+{
+    private readonly ActivityCapture _capture;
+
+    public ActivityCaptureCommand(ActivityCapture capture)
+    {
+        _capture = capture;
+    }
+
+    public Task HandleAsync(ActivityCaptureRequest message, CancellationToken ct)
+    {
+        var activity = Activity.Current;
+        if (activity != null)
+        {
+            _capture.TraceId = activity.TraceId.ToHexString();
+            _capture.SpanId = activity.SpanId.ToHexString();
+            _capture.ParentSpanId = activity.ParentSpanId.ToHexString();
+            _capture.Tags = activity.Tags.ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public class ActivityCapture
+{
+    public string? TraceId { get; set; }
+    public string? SpanId { get; set; }
+    public string? ParentSpanId { get; set; }
+    public Dictionary<string, string?> Tags { get; set; } = new();
+}

--- a/src/core/Jobly.Tests/TestData/Handlers/BarrierCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/BarrierCommand.cs
@@ -1,0 +1,27 @@
+using Jobly.Core.Handlers;
+
+namespace Jobly.Tests.TestData.Handlers;
+
+public class BarrierRequest : IJob;
+
+public class BarrierCommand : IJobHandler<BarrierRequest>
+{
+    private readonly BarrierSignal _signal;
+
+    public BarrierCommand(BarrierSignal signal)
+    {
+        _signal = signal;
+    }
+
+    public async Task HandleAsync(BarrierRequest message, CancellationToken cancellationToken)
+    {
+        _signal.Running.Release();
+        await _signal.CanFinish.WaitAsync(cancellationToken);
+    }
+}
+
+public class BarrierSignal
+{
+    public SemaphoreSlim Running { get; } = new(0);
+    public SemaphoreSlim CanFinish { get; } = new(0);
+}

--- a/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
@@ -1,0 +1,406 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Jobly.Core;
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.Logging;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Jobly.Worker;
+using Medallion.Threading;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public abstract class ActivityTraceTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+    private static readonly Guid ServerId = Guid.NewGuid();
+    private static readonly Guid WorkerId = Guid.NewGuid();
+    private static readonly string[] DefaultQueues = ["default"];
+
+    protected ActivityTraceTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Server>().Add(new Server
+        {
+            Id = ServerId,
+            StartedTime = DateTime.UtcNow,
+            LastHeartbeatTime = DateTime.UtcNow,
+            ServiceCount = 1,
+        });
+        ctx.Set<Jobly.Core.Data.Entities.Worker>().Add(new Jobly.Core.Data.Entities.Worker
+        {
+            Id = WorkerId,
+            ServerId = ServerId,
+            StartedTime = DateTime.UtcNow,
+            LastHeartbeatTime = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private (JoblyWorkerService<TestContext> Worker, ActivityCapture Capture) CreateWorker()
+    {
+        var capture = new ActivityCapture();
+        var services = new ServiceCollection();
+        services.AddJobHandlers(typeof(ActivityTraceTestsBase).Assembly);
+        services.AddPipelineBehaviors(typeof(ActivityTraceTestsBase).Assembly);
+        services.AddLogging(builder => builder.AddProvider(new JobLoggerProvider()));
+        services.AddScoped<TestContext>(_ => _fixture.CreateContext());
+        services.AddSingleton<CounterService>();
+        services.AddSingleton<MultiHandlerCounter>();
+        services.AddSingleton(capture);
+        services.AddScoped<JobContext>();
+        services.AddScoped<IJobContext>(x => x.GetRequiredService<JobContext>());
+
+        var workerConfig = new OptionsWrapper<JoblyWorkerConfiguration>(new JoblyWorkerConfiguration
+        {
+            WorkerCount = 1,
+            ServerId = ServerId,
+            Queues = DefaultQueues,
+            EnableHandlerLogging = true,
+        });
+        services.AddSingleton<IOptions<JoblyWorkerConfiguration>>(workerConfig);
+        services.AddSingleton<IOptions<JoblyConfiguration>>(workerConfig);
+
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var groupConfig = new WorkerGroupConfiguration
+        {
+            WorkerCount = 1,
+            Queues = DefaultQueues,
+        };
+
+        var worker = new JoblyWorkerService<TestContext>(
+            WorkerId,
+            scopeFactory,
+            new NullLogger<JoblyWorkerService<TestContext>>(),
+            workerConfig,
+            groupConfig,
+            TimeProvider.System,
+            new FakeLockProvider());
+
+        return (worker, capture);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_JobWithTraceId_ActivityHasMatchingTraceId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var traceId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = traceId,
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, capture) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        capture.TraceId.ShouldBe(traceId.ToString("N"));
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_JobWithTraceId_ActivityHasNonEmptySpanId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, capture) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        capture.SpanId.ShouldNotBeNullOrEmpty();
+        capture.SpanId.ShouldNotBe("0000000000000000");
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_JobWithoutTraceId_ActivityUsesJobIdAsTraceId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = null,
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, capture) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        capture.TraceId.ShouldBe(jobId.ToString("N"));
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_JobWithParentSpanId_ActivityHasMatchingParentId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var parentSpanId = ActivitySpanId.CreateRandom().ToHexString();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+            ParentSpanId = parentSpanId,
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, capture) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        capture.ParentSpanId.ShouldBe(parentSpanId);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_JobWithoutParentSpanId_ActivityHasEmptyParentId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+            ParentSpanId = null,
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, capture) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        capture.ParentSpanId.ShouldBe("0000000000000000");
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_AfterExecution_ActivityIsCleared()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, _) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        Activity.Current.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_HandlerThrows_ActivityIsCleared()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, _) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        Activity.Current.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_TwoJobs_EachGetsUniqueSpanId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var traceId = Guid.NewGuid();
+        var capture1 = new ActivityCapture();
+        var capture2 = new ActivityCapture();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = traceId,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow.AddMilliseconds(1),
+            Queue = "default",
+            TraceId = traceId,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Use shared capture — second execution overwrites first
+        var (worker, capture) = CreateWorker();
+
+        // Act — process first job
+        await worker.GetAndProcessJob(CancellationToken.None);
+        var firstSpanId = capture.SpanId;
+
+        // Process second job
+        await worker.GetAndProcessJob(CancellationToken.None);
+        var secondSpanId = capture.SpanId;
+
+        // Assert — same trace, different spans
+        firstSpanId.ShouldNotBeNullOrEmpty();
+        secondSpanId.ShouldNotBeNullOrEmpty();
+        firstSpanId.ShouldNotBe(secondSpanId);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_Completed_ActivityHasMessagingAttributes()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ActivityCaptureRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ActivityCaptureRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+        });
+        await ctx.SaveChangesAsync();
+
+        var (worker, capture) = CreateWorker();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        capture.Tags["messaging.system"].ShouldBe("jobly");
+        capture.Tags["messaging.operation.name"].ShouldBe("process");
+        capture.Tags["messaging.destination.name"].ShouldBe("default");
+        capture.Tags["messaging.message.id"].ShouldBe(jobId.ToString());
+        capture.Tags["jobly.job.kind"].ShouldBe("Job");
+        capture.Tags["jobly.job.type"].ShouldNotBeNull();
+    }
+}
+
+[Collection("PostgreSql")]
+public class ActivityTraceTests_PostgreSql : ActivityTraceTestsBase
+{
+    public ActivityTraceTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+}
+
+[Collection("SqlServer")]
+[Trait("Category", "SqlServer")]
+public class ActivityTraceTests_SqlServer : ActivityTraceTestsBase
+{
+    public ActivityTraceTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+}

--- a/src/core/Jobly.Tests/Unit/JoblyTelemetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/JoblyTelemetryTests.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+using Jobly.Core.Logging;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+/// <summary>
+/// Pure unit tests for JoblyTelemetry — no database, no collection fixture.
+/// </summary>
+public class JoblyTelemetryTests
+{
+    [Fact]
+    public void GetShortTypeName_AssemblyQualifiedName_ReturnsNameWithoutAssembly()
+    {
+        var result = JoblyTelemetry.GetShortTypeName("MyApp.Handlers.SendReport, MyApp, Version=1.0.0.0");
+
+        result.ShouldBe("MyApp.Handlers.SendReport");
+    }
+
+    [Fact]
+    public void GetShortTypeName_PlainTypeName_ReturnsAsIs()
+    {
+        var result = JoblyTelemetry.GetShortTypeName("MyApp.Handlers.SendReport");
+
+        result.ShouldBe("MyApp.Handlers.SendReport");
+    }
+
+    [Fact]
+    public void GetShortTypeName_Null_ReturnsUnknown()
+    {
+        var result = JoblyTelemetry.GetShortTypeName(null);
+
+        result.ShouldBe("unknown");
+    }
+
+    [Fact]
+    public void GetShortTypeName_EmptyString_ReturnsEmpty()
+    {
+        var result = JoblyTelemetry.GetShortTypeName(string.Empty);
+
+        result.ShouldBe(string.Empty);
+    }
+
+    [Fact]
+    public void StartJobActivity_ValidParentSpanId_SetsParentId()
+    {
+        var traceId = Guid.NewGuid();
+        var parentSpanId = ActivitySpanId.CreateRandom().ToHexString();
+
+        var activity = JoblyTelemetry.StartJobActivity(traceId, parentSpanId);
+
+        activity.ParentSpanId.ToHexString().ShouldBe(parentSpanId);
+        activity.Stop();
+        activity.Dispose();
+    }
+
+    [Fact]
+    public void StartJobActivity_MalformedParentSpanId_DoesNotThrow()
+    {
+        var traceId = Guid.NewGuid();
+
+        var activity = JoblyTelemetry.StartJobActivity(traceId, "not-a-valid-hex");
+
+        activity.ShouldNotBeNull();
+        activity.ParentSpanId.ToHexString().ShouldBe("0000000000000000");
+        activity.Stop();
+        activity.Dispose();
+    }
+
+    [Fact]
+    public void StartJobActivity_TooShortParentSpanId_DoesNotThrow()
+    {
+        var traceId = Guid.NewGuid();
+
+        var activity = JoblyTelemetry.StartJobActivity(traceId, "abc");
+
+        activity.ShouldNotBeNull();
+        activity.ParentSpanId.ToHexString().ShouldBe("0000000000000000");
+        activity.Stop();
+        activity.Dispose();
+    }
+
+    [Fact]
+    public void StartJobActivity_NullParentSpanId_SetsDefaultParentId()
+    {
+        var traceId = Guid.NewGuid();
+
+        var activity = JoblyTelemetry.StartJobActivity(traceId, null);
+
+        activity.ShouldNotBeNull();
+        activity.ParentSpanId.ToHexString().ShouldBe("0000000000000000");
+        activity.Stop();
+        activity.Dispose();
+    }
+}

--- a/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
+++ b/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
@@ -1,0 +1,513 @@
+using System.Diagnostics.Metrics;
+using System.Text.Json;
+using Jobly.Core;
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.Logging;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Jobly.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public abstract class OTelMetricsTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+    private static readonly Guid ServerId = Guid.NewGuid();
+    private static readonly Guid WorkerId = Guid.NewGuid();
+
+    protected OTelMetricsTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Server>().Add(new Server
+        {
+            Id = ServerId,
+            StartedTime = DateTime.UtcNow,
+            LastHeartbeatTime = DateTime.UtcNow,
+            ServiceCount = 1,
+        });
+        ctx.Set<Jobly.Core.Data.Entities.Worker>().Add(new Jobly.Core.Data.Entities.Worker
+        {
+            Id = WorkerId,
+            ServerId = ServerId,
+            StartedTime = DateTime.UtcNow,
+            LastHeartbeatTime = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private JoblyWorkerService<TestContext> CreateWorker(string queue, BarrierSignal? barrier = null)
+    {
+        var queues = new[] { queue };
+        var services = new ServiceCollection();
+        services.AddJobHandlers(typeof(OTelMetricsTestsBase).Assembly);
+        services.AddPipelineBehaviors(typeof(OTelMetricsTestsBase).Assembly);
+        services.AddLogging(builder => builder.AddProvider(new JobLoggerProvider()));
+        services.AddScoped<TestContext>(_ => _fixture.CreateContext());
+        services.AddSingleton<CounterService>();
+        services.AddSingleton<MultiHandlerCounter>();
+        services.AddSingleton<ActivityCapture>();
+        services.AddSingleton(barrier ?? new BarrierSignal());
+        services.AddScoped<JobContext>();
+        services.AddScoped<IJobContext>(x => x.GetRequiredService<JobContext>());
+
+        var workerConfig = new OptionsWrapper<JoblyWorkerConfiguration>(new JoblyWorkerConfiguration
+        {
+            WorkerCount = 1,
+            ServerId = ServerId,
+            Queues = queues,
+            EnableHandlerLogging = true,
+        });
+        services.AddSingleton<IOptions<JoblyWorkerConfiguration>>(workerConfig);
+        services.AddSingleton<IOptions<JoblyConfiguration>>(workerConfig);
+
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var groupConfig = new WorkerGroupConfiguration
+        {
+            WorkerCount = 1,
+            Queues = queues,
+        };
+
+        return new JoblyWorkerService<TestContext>(
+            WorkerId,
+            scopeFactory,
+            new NullLogger<JoblyWorkerService<TestContext>>(),
+            workerConfig,
+            groupConfig,
+            TimeProvider.System,
+            new FakeLockProvider());
+    }
+
+    private static bool HasTag(ReadOnlySpan<KeyValuePair<string, object?>> tags, string key, string value)
+    {
+        foreach (var tag in tags)
+        {
+            if (string.Equals(tag.Key, key, StringComparison.Ordinal)
+                && string.Equals(tag.Value?.ToString(), value, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_Completed_RecordsDurationMetric()
+    {
+        // Arrange — unique queue isolates from parallel tests
+        var queue = $"metrics-duration-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = queue,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(queue);
+        double recordedDuration = -1;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.duration", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue))
+            {
+                recordedDuration = value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        recordedDuration.ShouldBeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_Completed_RecordsCompletedMetricWithSucceededStatus()
+    {
+        // Arrange
+        var queue = $"metrics-completed-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = queue,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(queue);
+        long completedCount = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.completed", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue) && HasTag(tags, "status", "succeeded"))
+            {
+                completedCount += value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        completedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_Failed_RecordsCompletedMetricWithFailedStatus()
+    {
+        // Arrange
+        var queue = $"metrics-failed-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = queue,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(queue);
+        long failedCount = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.completed", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue) && HasTag(tags, "status", "failed"))
+            {
+                failedCount += value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        failedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task Enqueue_RecordsEnqueuedMetric()
+    {
+        // Arrange — publisher uses unique queue, no worker needed
+        var queue = $"metrics-enqueue-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration { DefaultQueue = queue }), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
+        long enqueuedCount = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.enqueued", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue))
+            {
+                enqueuedCount += value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await publisher.Enqueue(new UnitRequest(), queue);
+
+        // Assert
+        enqueuedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_IncrementsAndDecrementsActiveMetric()
+    {
+        // Arrange
+        var queue = $"metrics-active-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = queue,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(queue);
+        long activeNet = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.active", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue))
+            {
+                activeNet += value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert — +1 before handler, -1 in finally = net 0
+        activeNet.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_TwoWorkersConcurrently_ActiveMetricReachesTwo()
+    {
+        // Arrange — two barrier jobs on same queue
+        var queue = $"metrics-concurrent-{Guid.NewGuid():N}";
+        var barrier = new BarrierSignal();
+        var ctx = _fixture.CreateContext();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(BarrierRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new BarrierRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = queue,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(BarrierRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new BarrierRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow.AddMilliseconds(1),
+            Queue = queue,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker1 = CreateWorker(queue, barrier);
+        var worker2 = CreateWorker(queue, barrier);
+        long peakActive = 0;
+        long currentActive = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.active", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue))
+            {
+                var newActive = Interlocked.Add(ref currentActive, value);
+                long oldPeak;
+                do
+                {
+                    oldPeak = Interlocked.Read(ref peakActive);
+                }
+                while (newActive > oldPeak && Interlocked.CompareExchange(ref peakActive, newActive, oldPeak) != oldPeak);
+            }
+        });
+        listener.Start();
+
+        // Act — start both workers concurrently
+        var task1 = worker1.GetAndProcessJob(CancellationToken.None);
+        var task2 = worker2.GetAndProcessJob(CancellationToken.None);
+
+        // Wait for both handlers to be running
+        await barrier.Running.WaitAsync();
+        await barrier.Running.WaitAsync();
+
+        // Both are active now — release them
+        barrier.CanFinish.Release(2);
+        await Task.WhenAll(task1, task2);
+
+        // Assert
+        peakActive.ShouldBe(2);
+        Interlocked.Read(ref currentActive).ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_FailedWithRetries_RecordsRetriedStatus()
+    {
+        // Arrange
+        var queue = $"metrics-retry-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = queue,
+            MaxRetries = 3,
+            RetriedTimes = 0,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(queue);
+        long retriedCount = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.completed", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue) && HasTag(tags, "status", "retried"))
+            {
+                retriedCount += value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        retriedCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task StartBatch_RecordsEnqueuedMetricForBatchAndChildren()
+    {
+        // Arrange
+        var queue = $"metrics-batch-{Guid.NewGuid():N}";
+        var ctx = _fixture.CreateContext();
+        var batchPublisher = new BatchPublisher<TestContext>(ctx, Options.Create(new JoblyConfiguration { DefaultQueue = queue }), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
+        long jobEnqueued = 0;
+        long batchEnqueued = 0;
+
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "Jobly", StringComparison.Ordinal)
+                && string.Equals(instrument.Name, "jobly.job.enqueued", StringComparison.Ordinal))
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+        {
+            if (HasTag(tags, "queue", queue) && HasTag(tags, "kind", "job"))
+            {
+                jobEnqueued += value;
+            }
+
+            if (HasTag(tags, "queue", queue) && HasTag(tags, "kind", "batch"))
+            {
+                batchEnqueued += value;
+            }
+        });
+        listener.Start();
+
+        // Act
+        await batchPublisher.StartNew(new List<UnitRequest> { new(), new(), new() });
+
+        // Assert
+        jobEnqueued.ShouldBe(3);
+        batchEnqueued.ShouldBe(1);
+    }
+}
+
+[Collection("PostgreSql")]
+public class OTelMetricsTests_PostgreSql : OTelMetricsTestsBase
+{
+    public OTelMetricsTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+}
+
+[Collection("SqlServer")]
+[Trait("Category", "SqlServer")]
+public class OTelMetricsTests_SqlServer : OTelMetricsTestsBase
+{
+    public OTelMetricsTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+}

--- a/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
+++ b/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
@@ -1,0 +1,315 @@
+using System.Diagnostics;
+using Jobly.Core;
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.Logging;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Jobly.Worker.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public abstract class SpanPropagationTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+
+    protected SpanPropagationTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync() => await _fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private static Publisher<TestContext> CreatePublisher(TestContext ctx)
+    {
+        return new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
+    }
+
+    private static BatchPublisher<TestContext> CreateBatchPublisher(TestContext ctx)
+    {
+        return new BatchPublisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
+    }
+
+    private static IServiceScopeFactory BuildScopeFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddJobHandlers(typeof(SpanPropagationTestsBase).Assembly);
+        services.AddSingleton<MultiHandlerCounter>();
+        var provider = services.BuildServiceProvider();
+
+        return provider.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    // --- Publisher.Enqueue ---
+
+    [Fact]
+    public async Task Enqueue_WithActiveActivity_CapturesParentSpanId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var publisher = CreatePublisher(ctx);
+
+        using var activity = new Activity("test")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        // Act
+        var id = await publisher.Enqueue(new UnitRequest());
+        await ctx.SaveChangesAsync();
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>()
+            .Where(x => x.Id == id)
+            .FirstOrDefaultAsync();
+
+        job.ShouldNotBeNull();
+        job.ParentSpanId.ShouldBe(activity.SpanId.ToHexString());
+    }
+
+    [Fact]
+    public async Task Enqueue_WithoutActivity_ParentSpanIdIsNull()
+    {
+        // Arrange
+        var previousActivity = Activity.Current;
+        Activity.Current = null;
+
+        try
+        {
+            var ctx = _fixture.CreateContext();
+            var publisher = CreatePublisher(ctx);
+
+            // Act
+            var id = await publisher.Enqueue(new UnitRequest());
+            await ctx.SaveChangesAsync();
+
+            // Assert
+            var readCtx = _fixture.CreateContext();
+            var job = await readCtx.Set<Job>()
+                .Where(x => x.Id == id)
+                .FirstOrDefaultAsync();
+
+            job.ShouldNotBeNull();
+            job.ParentSpanId.ShouldBeNull();
+        }
+        finally
+        {
+            Activity.Current = previousActivity;
+        }
+    }
+
+    // --- Publisher.Publish (Message) ---
+
+    [Fact]
+    public async Task Publish_WithActiveActivity_CapturesParentSpanId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var publisher = CreatePublisher(ctx);
+
+        using var activity = new Activity("test")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        // Act
+        var id = await publisher.Publish(new SingleHandlerMessage());
+        await ctx.SaveChangesAsync();
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>()
+            .Where(x => x.Id == id)
+            .FirstOrDefaultAsync();
+
+        job.ShouldNotBeNull();
+        job.ParentSpanId.ShouldBe(activity.SpanId.ToHexString());
+    }
+
+    // --- BatchPublisher ---
+
+    [Fact]
+    public async Task StartBatch_WithActiveActivity_CapturesParentSpanIdOnBatchAndChildren()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var batchPublisher = CreateBatchPublisher(ctx);
+
+        using var activity = new Activity("test")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        // Act
+        var batchId = await batchPublisher.StartNew(new List<UnitRequest>
+        {
+            new(),
+            new(),
+        });
+        await ctx.SaveChangesAsync();
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var batch = await readCtx.Set<Job>()
+            .Where(x => x.Id == batchId)
+            .FirstOrDefaultAsync();
+
+        batch.ShouldNotBeNull();
+        batch.ParentSpanId.ShouldBe(activity.SpanId.ToHexString());
+
+        var children = await readCtx.Set<Job>()
+            .Where(x => x.ParentJobId == batchId)
+            .ToListAsync();
+
+        children.Count.ShouldBe(2);
+        foreach (var child in children)
+        {
+            child.ParentSpanId.ShouldBe(activity.SpanId.ToHexString());
+        }
+    }
+
+    // --- MessageRoutingTask propagation ---
+
+    [Fact]
+    public async Task MessageRouting_PropagatesParentSpanIdToChildJobs()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var parentSpanId = ActivitySpanId.CreateRandom().ToHexString();
+        var messageId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = messageId,
+            Kind = JobKind.Message,
+            CurrentState = State.Enqueued,
+            Type = typeof(SingleHandlerMessage).AssemblyQualifiedName,
+            Message = "{}",
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+            ParentSpanId = parentSpanId,
+        });
+        await ctx.SaveChangesAsync();
+
+        var scopeFactory = BuildScopeFactory();
+
+        // Act
+        var routeCtx = _fixture.CreateContext();
+        await MessageRoutingTask<TestContext>.RunMessageRouting(routeCtx, scopeFactory, TimeProvider.System, CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var children = await readCtx.Set<Job>()
+            .Where(x => x.ParentJobId == messageId)
+            .Where(x => x.Kind == JobKind.Job)
+            .ToListAsync();
+
+        children.Count.ShouldBeGreaterThan(0);
+        foreach (var child in children)
+        {
+            child.ParentSpanId.ShouldBe(parentSpanId);
+        }
+    }
+
+    [Fact]
+    public async Task MessageRouting_MessageWithNullParentSpanId_ChildJobsHaveNullParentSpanId()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var messageId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = messageId,
+            Kind = JobKind.Message,
+            CurrentState = State.Enqueued,
+            Type = typeof(SingleHandlerMessage).AssemblyQualifiedName,
+            Message = "{}",
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            TraceId = Guid.NewGuid(),
+            ParentSpanId = null,
+        });
+        await ctx.SaveChangesAsync();
+
+        var scopeFactory = BuildScopeFactory();
+
+        // Act
+        var routeCtx = _fixture.CreateContext();
+        await MessageRoutingTask<TestContext>.RunMessageRouting(routeCtx, scopeFactory, TimeProvider.System, CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var children = await readCtx.Set<Job>()
+            .Where(x => x.ParentJobId == messageId)
+            .Where(x => x.Kind == JobKind.Job)
+            .ToListAsync();
+
+        children.Count.ShouldBeGreaterThan(0);
+        foreach (var child in children)
+        {
+            child.ParentSpanId.ShouldBeNull();
+        }
+    }
+
+    // --- Publisher inside handler (JobExecutionContext active) ---
+
+    [Fact]
+    public async Task Enqueue_InsideHandlerWithActivity_CapturesHandlerSpanId()
+    {
+        // Arrange — simulate handler execution context with an active Activity
+        var ctx = _fixture.CreateContext();
+        var publisher = CreatePublisher(ctx);
+
+        using var activity = new Activity("Jobly.Execute")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        var parentTraceId = Guid.NewGuid();
+        JobExecutionContext.Current = new JobExecutionInfo
+        {
+            JobId = Guid.NewGuid(),
+            TraceId = parentTraceId,
+            MetadataJson = null,
+        };
+
+        try
+        {
+            // Act
+            var id = await publisher.Enqueue(new UnitRequest());
+            await ctx.SaveChangesAsync();
+
+            // Assert
+            var readCtx = _fixture.CreateContext();
+            var job = await readCtx.Set<Job>()
+                .Where(x => x.Id == id)
+                .FirstOrDefaultAsync();
+
+            job.ShouldNotBeNull();
+            job.ParentSpanId.ShouldBe(activity.SpanId.ToHexString());
+            job.TraceId.ShouldBe(parentTraceId);
+        }
+        finally
+        {
+            JobExecutionContext.Current = null;
+            activity.Stop();
+        }
+    }
+}
+
+[Collection("PostgreSql")]
+public class SpanPropagationTests_PostgreSql : SpanPropagationTestsBase
+{
+    public SpanPropagationTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+}
+
+[Collection("SqlServer")]
+[Trait("Category", "SqlServer")]
+public class SpanPropagationTests_SqlServer : SpanPropagationTestsBase
+{
+    public SpanPropagationTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+}

--- a/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
@@ -117,6 +117,15 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
         using var jobCts = new CancellationTokenSource();
         var monitorTask = RunJobMonitor(job.Id, logCollector, jobCts, cancellationToken);
 
+        var activity = JoblyTelemetry.StartJobActivity(job.TraceId ?? job.Id, job.ParentSpanId);
+        var jobTypeName = JoblyTelemetry.GetShortTypeName(job.Type);
+        activity.SetTag("messaging.system", "jobly");
+        activity.SetTag("messaging.operation.name", "process");
+        activity.SetTag("messaging.destination.name", job.Queue);
+        activity.SetTag("messaging.message.id", job.Id.ToString());
+        activity.SetTag("jobly.job.type", jobTypeName);
+        activity.SetTag("jobly.job.kind", job.Kind.ToString());
+        JoblyTelemetry.JobsActive.Add(1, new KeyValuePair<string, object?>("queue", job.Queue));
         Stopwatch? handlerStopwatch = null;
         try
         {
@@ -146,6 +155,16 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             await ExecuteJob(job, scope.ServiceProvider, jobCts.Token);
             handlerStopwatch.Stop();
 
+            var durationMs = handlerStopwatch.Elapsed.TotalMilliseconds;
+            activity.SetTag("jobly.job.status", "succeeded");
+            activity.SetTag("jobly.job.duration_ms", durationMs);
+            activity.AddEvent(new ActivityEvent("jobly.job.completed", tags: new ActivityTagsCollection
+            {
+                { "duration_ms", durationMs },
+            }));
+            JoblyTelemetry.JobDuration.Record(durationMs, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", "succeeded"));
+            JoblyTelemetry.JobsCompleted.Add(1, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", "succeeded"));
+
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
 
@@ -172,6 +191,9 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
         catch (OperationCanceledException) when (jobCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
             handlerStopwatch?.Stop();
+            activity.SetTag("jobly.job.status", "cancelled");
+            activity.AddEvent(new ActivityEvent("jobly.job.cancelled"));
+            JoblyTelemetry.JobsCompleted.Add(1, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", "cancelled"));
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
             _logger.LogInformation("Job {id} was cancelled", job.Id);
@@ -206,6 +228,35 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
         catch (Exception e)
         {
             handlerStopwatch?.Stop();
+            var willRetry = job.RetriedTimes < job.MaxRetries;
+            var errorStatus = willRetry ? "retried" : "failed";
+            var errorDurationMs = handlerStopwatch?.Elapsed.TotalMilliseconds;
+            activity.SetStatus(ActivityStatusCode.Error, Truncate(e.Message, 256));
+            activity.SetTag("jobly.job.status", errorStatus);
+            if (job.RetriedTimes > 0 || willRetry)
+            {
+                activity.SetTag("jobly.job.retry_count", willRetry ? job.RetriedTimes + 1 : job.RetriedTimes);
+            }
+
+            if (willRetry)
+            {
+                activity.AddEvent(new ActivityEvent("jobly.job.retried", tags: new ActivityTagsCollection
+                {
+                    { "retry_count", job.RetriedTimes + 1 },
+                    { "max_retries", job.MaxRetries },
+                }));
+            }
+            else
+            {
+                activity.AddEvent(new ActivityEvent("jobly.job.failed", tags: new ActivityTagsCollection
+                {
+                    { "exception.type", e.GetType().FullName },
+                    { "exception.message", e.Message },
+                }));
+            }
+
+            JoblyTelemetry.JobDuration.Record(errorDurationMs ?? 0, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", errorStatus));
+            JoblyTelemetry.JobsCompleted.Add(1, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", errorStatus));
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
             _logger.LogError(e, "Error executing job {id}", job.Id);
@@ -213,7 +264,7 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             await monitorTask;
 
             await using var endTransaction = await context.Database.BeginTransactionAsync(default);
-            UpdateJobState(context, job, e, handlerStopwatch?.Elapsed.TotalMilliseconds);
+            UpdateJobState(context, job, e, errorDurationMs);
             if (_configuration.EnableHandlerLogging)
             {
                 await SaveJobLogs(context, logCollector);
@@ -223,6 +274,9 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
         }
         finally
         {
+            JoblyTelemetry.JobsActive.Add(-1, new KeyValuePair<string, object?>("queue", job.Queue));
+            activity.Stop();
+            activity.Dispose();
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
 
@@ -403,5 +457,10 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
     {
         context.Set<Counter>().Add(new Counter { Key = totalKey, Value = 1 });
         context.Set<Counter>().Add(new Counter { Key = hourlyKey, Value = 1 });
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        return value.Length <= maxLength ? value : value[..maxLength];
     }
 }

--- a/src/core/Jobly.Worker/JoblyWorkerService.cs
+++ b/src/core/Jobly.Worker/JoblyWorkerService.cs
@@ -134,6 +134,15 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
         using var jobCts = new CancellationTokenSource();
         var monitorTask = RunJobMonitor(job.Id, logCollector, jobCts, cancellationToken);
 
+        var activity = JoblyTelemetry.StartJobActivity(job.TraceId ?? job.Id, job.ParentSpanId);
+        var jobTypeName = JoblyTelemetry.GetShortTypeName(job.Type);
+        activity.SetTag("messaging.system", "jobly");
+        activity.SetTag("messaging.operation.name", "process");
+        activity.SetTag("messaging.destination.name", job.Queue);
+        activity.SetTag("messaging.message.id", job.Id.ToString());
+        activity.SetTag("jobly.job.type", jobTypeName);
+        activity.SetTag("jobly.job.kind", job.Kind.ToString());
+        JoblyTelemetry.JobsActive.Add(1, new KeyValuePair<string, object?>("queue", job.Queue));
         Stopwatch? handlerStopwatch = null;
         try
         {
@@ -163,6 +172,16 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
             await ExecuteJob(job, scope.ServiceProvider, jobCts.Token);
             handlerStopwatch.Stop();
 
+            var durationMs = handlerStopwatch.Elapsed.TotalMilliseconds;
+            activity.SetTag("jobly.job.status", "succeeded");
+            activity.SetTag("jobly.job.duration_ms", durationMs);
+            activity.AddEvent(new ActivityEvent("jobly.job.completed", tags: new ActivityTagsCollection
+            {
+                { "duration_ms", durationMs },
+            }));
+            JoblyTelemetry.JobDuration.Record(durationMs, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", "succeeded"));
+            JoblyTelemetry.JobsCompleted.Add(1, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", "succeeded"));
+
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
 
@@ -190,6 +209,9 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
         {
             // Job was cancelled (deleted while running)
             handlerStopwatch?.Stop();
+            activity.SetTag("jobly.job.status", "cancelled");
+            activity.AddEvent(new ActivityEvent("jobly.job.cancelled"));
+            JoblyTelemetry.JobsCompleted.Add(1, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", "cancelled"));
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
             _logger.LogInformation("Job {id} was cancelled", job.Id);
@@ -224,6 +246,35 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
         catch (Exception e)
         {
             handlerStopwatch?.Stop();
+            var willRetry = job.RetriedTimes < job.MaxRetries;
+            var errorStatus = willRetry ? "retried" : "failed";
+            var errorDurationMs = handlerStopwatch?.Elapsed.TotalMilliseconds;
+            activity.SetStatus(ActivityStatusCode.Error, Truncate(e.Message, 256));
+            activity.SetTag("jobly.job.status", errorStatus);
+            if (job.RetriedTimes > 0 || willRetry)
+            {
+                activity.SetTag("jobly.job.retry_count", willRetry ? job.RetriedTimes + 1 : job.RetriedTimes);
+            }
+
+            if (willRetry)
+            {
+                activity.AddEvent(new ActivityEvent("jobly.job.retried", tags: new ActivityTagsCollection
+                {
+                    { "retry_count", job.RetriedTimes + 1 },
+                    { "max_retries", job.MaxRetries },
+                }));
+            }
+            else
+            {
+                activity.AddEvent(new ActivityEvent("jobly.job.failed", tags: new ActivityTagsCollection
+                {
+                    { "exception.type", e.GetType().FullName },
+                    { "exception.message", e.Message },
+                }));
+            }
+
+            JoblyTelemetry.JobDuration.Record(errorDurationMs ?? 0, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", errorStatus));
+            JoblyTelemetry.JobsCompleted.Add(1, new KeyValuePair<string, object?>("queue", job.Queue), new KeyValuePair<string, object?>("type", jobTypeName), new KeyValuePair<string, object?>("status", errorStatus));
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
             _logger.LogError(e, "Error executing job {id}", job.Id);
@@ -231,7 +282,7 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
             await monitorTask;
 
             await using var endTransaction = await context.Database.BeginTransactionAsync(default);
-            UpdateJobState(context, job, e, handlerStopwatch?.Elapsed.TotalMilliseconds);
+            UpdateJobState(context, job, e, errorDurationMs);
             if (_configuration.EnableHandlerLogging)
             {
                 await SaveJobLogs(context, logCollector);
@@ -241,6 +292,9 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
         }
         finally
         {
+            JoblyTelemetry.JobsActive.Add(-1, new KeyValuePair<string, object?>("queue", job.Queue));
+            activity.Stop();
+            activity.Dispose();
             JobLogContext.Current = null;
             JobExecutionContext.Current = null;
 
@@ -429,5 +483,10 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
     {
         context.Set<Counter>().Add(new Counter { Key = totalKey, Value = 1 });
         context.Set<Counter>().Add(new Counter { Key = hourlyKey, Value = 1 });
+    }
+
+    private static string Truncate(string value, int maxLength)
+    {
+        return value.Length <= maxLength ? value : value[..maxLength];
     }
 }

--- a/src/core/Jobly.Worker/ServiceConfiguration.cs
+++ b/src/core/Jobly.Worker/ServiceConfiguration.cs
@@ -79,7 +79,16 @@ public static class ServiceConfiguration
 
         services.AddSingleton<PauseStateHolder>();
 
-        services.AddLogging(builder => builder.AddProvider(new JobLoggerProvider()));
+        services.AddLogging(builder =>
+        {
+            builder.AddProvider(new JobLoggerProvider());
+            builder.Configure(options =>
+            {
+                options.ActivityTrackingOptions |= ActivityTrackingOptions.TraceId
+                    | ActivityTrackingOptions.SpanId
+                    | ActivityTrackingOptions.ParentId;
+            });
+        });
 
         // Register distributed locks — resolved lazily from the DbContext's connection string
         services.AddSingleton<IDistributedLockProvider>(sp =>

--- a/src/core/Jobly.Worker/Services/MessageRoutingTask.cs
+++ b/src/core/Jobly.Worker/Services/MessageRoutingTask.cs
@@ -111,6 +111,7 @@ public class MessageRoutingTask<TContext> : ServerTaskBase<TContext>
 
                 job.HandlerType = handlerType.AssemblyQualifiedName;
                 job.TraceId = message.TraceId;
+                job.ParentSpanId = message.ParentSpanId;
                 job.Metadata = message.Metadata;
 
                 context.Set<Job>().Add(job);

--- a/website/docs/features/tracing.md
+++ b/website/docs/features/tracing.md
@@ -56,3 +56,96 @@ When a message is routed to multiple handlers, all resulting jobs share a `Trace
 await publisher.Publish(new OrderNotification()); // Routes to EmailHandler + SlackHandler
 // Both jobs get the same TraceId
 ```
+
+## OpenTelemetry Integration
+
+Jobly produces OTel-standard distributed traces and metrics using `System.Diagnostics`. Everything is on by default with zero configuration.
+
+### Distributed Tracing
+
+Every job execution creates a `System.Diagnostics.Activity` with:
+
+- **TraceId** — matches the job's database `TraceId`
+- **SpanId** — unique per execution (new SpanId on retries)
+- **ParentSpanId** — the SpanId of whoever enqueued this job (HTTP request, another handler, etc.)
+
+This creates a proper trace tree across job chains:
+
+```
+HTTP Request (TraceId: T, SpanId: A)
+  └── Enqueue(ProcessOrder)      → Activity(TraceId: T, SpanId: B, ParentId: A)
+       └── Enqueue(ShipItem)     → Activity(TraceId: T, SpanId: C, ParentId: B)
+            └── Enqueue(Notify)  → Activity(TraceId: T, SpanId: D, ParentId: C)
+```
+
+Trace context is automatically propagated:
+- When a handler calls `publisher.Enqueue()`, the child job captures the handler's SpanId
+- When a message is routed to multiple handlers, all child jobs inherit the publisher's span
+- Batch children inherit the same parent span
+
+### Log Correlation
+
+`AddJoblyWorker` automatically configures `ActivityTrackingOptions` so TraceId, SpanId, and ParentId appear in your log output:
+
+```
+info: MyApp.Handlers.SendReport[0]
+      => SpanId:b7ad6b7169203331, TraceId:550e8400e29b41d4a716446655440000, ParentId:a1b2c3d4e5f60718
+      Sending report to user 42
+```
+
+No configuration needed — this works with the built-in console logger and any provider that supports scopes.
+
+### Span Attributes
+
+Each job execution span includes these tags:
+
+| Attribute | Example | Description |
+|-----------|---------|-------------|
+| `messaging.system` | `"jobly"` | OTel semantic convention |
+| `messaging.operation.name` | `"process"` | OTel semantic convention |
+| `messaging.destination.name` | `"default"` | Queue the job belongs to |
+| `messaging.message.id` | `"550e8400-..."` | Job ID |
+| `jobly.job.type` | `"MyApp.SendReport"` | .NET type name |
+| `jobly.job.kind` | `"Job"` | Job, Message, or Batch |
+| `jobly.job.status` | `"succeeded"` | Set after execution: `succeeded`, `failed`, `retried`, `cancelled` |
+| `jobly.job.duration_ms` | `142.5` | Handler execution time (on success) |
+| `jobly.job.retry_count` | `2` | Current retry count (only if retried) |
+
+On failure, `Activity.SetStatus(Error)` is called with the exception message.
+
+### Span Events
+
+Key lifecycle moments are recorded as events on the span:
+
+| Event | When | Attributes |
+|-------|------|------------|
+| `jobly.job.completed` | Handler succeeds | `duration_ms` |
+| `jobly.job.failed` | Handler throws (no retries left) | `exception.type`, `exception.message` |
+| `jobly.job.retried` | Handler throws (will retry) | `retry_count`, `max_retries` |
+| `jobly.job.cancelled` | Job cancelled while running | — |
+
+### Metrics
+
+Jobly exposes four metrics through a `System.Diagnostics.Metrics.Meter` named `"Jobly"`:
+
+| Metric | Type | Unit | Tags | Description |
+|--------|------|------|------|-------------|
+| `jobly.job.duration` | Histogram | `ms` | `queue`, `type`, `status` | Handler execution time |
+| `jobly.job.active` | UpDownCounter | `{job}` | `queue` | Currently processing jobs |
+| `jobly.job.completed` | Counter | `{job}` | `queue`, `type`, `status` | Jobs that finished processing |
+| `jobly.job.enqueued` | Counter | `{job}` | `queue`, `kind` | Jobs enqueued |
+
+The `status` tag is one of: `succeeded`, `failed`, `retried`, `cancelled`.
+The `kind` tag is one of: `job`, `message`, `batch`.
+
+### Exporting to OTel Backends
+
+To export traces and metrics to Jaeger, Prometheus, Datadog, etc., subscribe to the `"Jobly"` source and meter:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddSource("Jobly"))
+    .WithMetrics(m => m.AddMeter("Jobly"));
+```
+
+Without this, traces still appear in logs (via ActivityTrackingOptions) and metric calls are silent no-ops — no overhead.

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,38 @@ sidebar_position: 6
 
 # Releases
 
+## 0.6.0
+
+*2026-04-12*
+
+### New Features
+
+- **OpenTelemetry Distributed Tracing** — Every job execution creates a `System.Diagnostics.Activity` with W3C-format TraceId, SpanId, and ParentSpanId. Trace context is automatically propagated through job chains: when a handler enqueues a child job, the child's `ParentSpanId` links back to the handler's span. Message routing and batch creation also propagate span context. New `ParentSpanId` column on the Job entity stores the spawner's span ID.
+- **Span Attributes** — Job execution spans include OTel semantic convention tags (`messaging.system`, `messaging.destination.name`, `messaging.operation.name`, `messaging.message.id`) and Jobly-specific tags (`jobly.job.type`, `jobly.job.kind`, `jobly.job.status`, `jobly.job.duration_ms`, `jobly.job.retry_count`). Failed spans are marked with `ActivityStatusCode.Error`.
+- **Span Events** — Key lifecycle moments recorded as events on the span: `jobly.job.completed`, `jobly.job.failed` (with exception info), `jobly.job.retried` (with retry/max counts), `jobly.job.cancelled`.
+- **OTel Metrics** — Four `System.Diagnostics.Metrics` instruments via a `Meter` named `"Jobly"`: `jobly.job.duration` (histogram, ms), `jobly.job.active` (up-down counter), `jobly.job.completed` (counter with status tag), `jobly.job.enqueued` (counter with kind tag). All tagged by queue and type for filtering.
+- **Automatic Log Correlation** — `AddJoblyWorker` configures `ActivityTrackingOptions` so TraceId, SpanId, and ParentId appear in log output by default. No additional configuration needed.
+
+### Integration
+
+All features are on by default with zero configuration. To export to OTel backends:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddSource("Jobly"))
+    .WithMetrics(m => m.AddMeter("Jobly"));
+```
+
+### Migration
+
+This release adds a new nullable `ParentSpanId` column to the Job table. Run an EF Core migration after upgrading.
+
+### Stats
+
+- 658 tests (310 PostgreSQL + 310 SQL Server + 38 unit)
+
+---
+
 ## 0.5.0
 
 *2026-04-09*

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -30,6 +30,11 @@ builder.Services.AddOpenTelemetry()
 
 This release adds a new nullable `ParentSpanId` column to the Job table. Run an EF Core migration after upgrading.
 
+### Bug Fixes
+
+- **Distributed lock credential stripping** — Connection string resolution now reads from `DbContextOptions` RelationalOptionsExtension instead of `Database.GetConnectionString()`, which strips passwords via Npgsql `PersistSecurityInfo=false`. Also handles `NpgsqlDataSource` configurations.
+- **Server status indicators** — Dashboard servers page now shows heartbeat-based status dots: green (active), red (stale >30s), amber (paused). "Inactive" badge shown when heartbeat is stale.
+
 ### Stats
 
 - 658 tests (310 PostgreSQL + 310 SQL Server + 38 unit)


### PR DESCRIPTION
## Summary

- **Distributed tracing**: Every job execution creates a `System.Diagnostics.Activity` with W3C-format TraceId, SpanId, and ParentSpanId. Trace context propagates through job chains — handler → child job → grandchild job forms a proper OTel trace tree.
- **Span attributes & events**: OTel semantic convention tags (`messaging.system`, `messaging.destination.name`) and Jobly-specific tags (`jobly.job.type`, `jobly.job.status`, `jobly.job.duration_ms`). Lifecycle events for completed/failed/retried/cancelled.
- **Metrics**: Four `System.Diagnostics.Metrics` instruments via a Meter named `"Jobly"` — `jobly.job.duration` (histogram), `jobly.job.active` (up-down counter), `jobly.job.completed` (counter), `jobly.job.enqueued` (counter). All tagged by queue/type/status.
- **Automatic log correlation**: `AddJoblyWorker` configures `ActivityTrackingOptions` so TraceId, SpanId, and ParentId appear in log output by default.

Everything is on by default with zero configuration. To export to OTel backends:

```csharp
builder.Services.AddOpenTelemetry()
    .WithTracing(t => t.AddSource("Jobly"))
    .WithMetrics(m => m.AddMeter("Jobly"));
```

### Migration

New nullable `ParentSpanId` column on the Job table. Run an EF Core migration after upgrading.

## Test plan

- [x] Activity has correct TraceId/SpanId during handler execution (8 tests)
- [x] ParentSpanId propagated through Publisher, BatchPublisher, MessageRoutingTask (7 tests)
- [x] Span attributes verified on Activity (messaging.system, destination, kind, type)
- [x] Metrics: duration histogram, completed counter with status tag, enqueued counter, active up-down counter (5 tests)
- [x] Retry path: job with MaxRetries>0 records "retried" status
- [x] Batch enqueue: correct count for children and batch job
- [x] Concurrent workers: active metric peaks at 2 with two parallel workers
- [x] Malformed ParentSpanId: graceful fallback, no crash
- [x] GetShortTypeName: null, empty, plain, assembly-qualified edge cases
- [x] 658 tests total (310 PostgreSQL + 310 SQL Server + 38 unit), 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)