### PR TITLE
Fix scoped service resolution in singleton lock provider factory

### DIFF
--- a/src/core/Jobly.Tests/Unit/DistributedLockRegistrationTests.cs
+++ b/src/core/Jobly.Tests/Unit/DistributedLockRegistrationTests.cs
@@ -18,7 +18,7 @@ public class DistributedLockRegistrationTests
         services.AddDbContext<TestContext>(o => o.UseNpgsql("Host=localhost;Database=test;Username=user;Password=secret"));
         services.AddJoblyWorker<TestContext>();
 
-        using var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
         var provider = sp.GetRequiredService<IDistributedLockProvider>();
 
         provider.ShouldBeOfType<PostgresDistributedSynchronizationProvider>();
@@ -31,7 +31,7 @@ public class DistributedLockRegistrationTests
         services.AddDbContext<TestContext>(o => o.UseSqlServer("Server=localhost;Database=test;User Id=sa;Password=secret;TrustServerCertificate=True"));
         services.AddJoblyWorker<TestContext>();
 
-        using var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
         var provider = sp.GetRequiredService<IDistributedLockProvider>();
 
         provider.ShouldBeOfType<SqlDistributedSynchronizationProvider>();
@@ -56,7 +56,7 @@ public class DistributedLockRegistrationTests
         // Poison: any attempt to resolve TestContext will throw
         services.AddScoped<TestContext>(_ => throw new InvalidOperationException("DbContext should not be resolved for connection string"));
 
-        using var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
         var provider = sp.GetRequiredService<IDistributedLockProvider>();
 
         provider.ShouldBeOfType<PostgresDistributedSynchronizationProvider>();
@@ -75,7 +75,7 @@ public class DistributedLockRegistrationTests
         // Poison: any attempt to resolve TestContext will throw
         services.AddScoped<TestContext>(_ => throw new InvalidOperationException("DbContext should not be resolved for connection string"));
 
-        using var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
         var provider = sp.GetRequiredService<IDistributedLockProvider>();
 
         provider.ShouldBeOfType<SqlDistributedSynchronizationProvider>();
@@ -89,8 +89,9 @@ public class DistributedLockRegistrationTests
         services.AddDbContext<TestContext>(o => o.UseNpgsql(connectionString));
         services.AddJoblyWorker<TestContext>();
 
-        using var sp = services.BuildServiceProvider();
-        var options = sp.GetRequiredService<DbContextOptions<TestContext>>();
+        using var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = sp.CreateScope();
+        var options = scope.ServiceProvider.GetRequiredService<DbContextOptions<TestContext>>();
         var extension = options.Extensions.OfType<RelationalOptionsExtension>().FirstOrDefault();
 
         extension.ShouldNotBeNull();
@@ -104,7 +105,7 @@ public class DistributedLockRegistrationTests
         services.AddDbContext<TestContext>(o => o.UseNpgsql("Host=localhost;Database=test;Username=user;Password=secret"));
         services.AddJoblyWorker<TestContext>();
 
-        using var sp = services.BuildServiceProvider();
+        using var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
         var provider = sp.GetRequiredService<IDistributedLockProvider>();
         var distributedLock = provider.CreateLock("test-lock");
 

--- a/src/core/Jobly.Worker/ServiceConfiguration.cs
+++ b/src/core/Jobly.Worker/ServiceConfiguration.cs
@@ -95,13 +95,13 @@ public static class ServiceConfiguration
         // Database.GetConnectionString() may strip passwords (Npgsql PersistSecurityInfo=false).
         services.AddSingleton<IDistributedLockProvider>(sp =>
         {
-            var dbOptions = sp.GetRequiredService<DbContextOptions<TContext>>();
+            using var scope = sp.CreateScope();
+            var dbOptions = scope.ServiceProvider.GetRequiredService<DbContextOptions<TContext>>();
             var relationalExtension = dbOptions.Extensions.OfType<RelationalOptionsExtension>().FirstOrDefault();
             var connectionString = relationalExtension?.ConnectionString;
 
             if (connectionString is null)
             {
-                using var scope = sp.CreateScope();
                 var context = scope.ServiceProvider.GetRequiredService<TContext>();
                 connectionString = context.Database.GetConnectionString()
                     ?? throw new InvalidOperationException("Cannot resolve connection string for distributed locks.");


### PR DESCRIPTION
## Summary
- **Bug**: `IDistributedLockProvider` singleton factory resolved `DbContextOptions<TContext>` directly from root `IServiceProvider`, but `AddDbContext` registers it as scoped. This throws `InvalidOperationException` when scope validation is enabled (e.g. `WebApplication.CreateBuilder()` in Development).
- **Fix**: Create a scope inside the factory and resolve through it — the scope was already used in the fallback path, now it covers the primary path too.
- **Tests**: Enable `ValidateScopes = true` in all `DistributedLockRegistrationTests` to prevent regression.

## Test plan
- [x] All 6 `DistributedLockRegistrationTests` pass with scope validation enabled
- [x] Full PostgreSQL test suite passes (354 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)