### PR TITLE
Fix all 401 build warnings

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -258,6 +258,12 @@ dotnet_diagnostic.S6667.severity = none
 # S3260: Private classes should be sealed (handled by CA1852)
 dotnet_diagnostic.S3260.severity = none
 
+# S3011: Reflection accessibility bypass (intentional in JobDispatcher for cached generic dispatch)
+dotnet_diagnostic.S3011.severity = none
+
+# CA1711: Type names ending in 'Delegate'/'Collection' (delegate types and xUnit fixtures)
+dotnet_diagnostic.CA1711.severity = none
+
 # CA1000: Do not declare static members on generic types (test helpers by design)
 dotnet_diagnostic.CA1000.severity = none
 
@@ -492,8 +498,9 @@ dotnet_analyzer_diagnostic.category-StyleCop.CSharp.OrderingRules.severity = non
 # Test projects — relaxed rules
 # ============================================================
 [**/Jobly.Tests/**/*.cs]
-# SA1401: Public fields needed for Interlocked.Increment in test counters
+# SA1401/CA1051: Public fields needed for Interlocked.Increment in test counters
 dotnet_diagnostic.SA1401.severity = none
+dotnet_diagnostic.CA1051.severity = none
 # MA0025: Empty method body — intentional in test handlers
 dotnet_diagnostic.MA0025.severity = none
 # S112: General exceptions — intentional in test throw handlers
@@ -508,6 +515,8 @@ dotnet_diagnostic.SA1401.severity = none
 dotnet_diagnostic.S112.severity = none
 # CA1873: Logging argument evaluation — test handlers
 dotnet_diagnostic.CA1873.severity = none
+# CA1716: Namespace 'Shared' conflicts with reserved keyword — test project name is fixed
+dotnet_diagnostic.CA1716.severity = none
 
 [**/Jobly.TestApp/**.cs]
 # MA0047/S3903: File-scoped class in top-level program

--- a/src/core/Jobly.Core/Data/Interceptors/RowLockInterceptor.cs
+++ b/src/core/Jobly.Core/Data/Interceptors/RowLockInterceptor.cs
@@ -59,7 +59,7 @@ public class PostgresRowLockInterceptor : DbCommandInterceptor
 public partial class SqlServerRowLockInterceptor : DbCommandInterceptor
 {
     // Matches the first FROM [table] AS [alias] or FROM [schema].[table] AS [alias] pattern
-    [GeneratedRegex(@"(FROM\s+(?:\[\w+\]\.)*\[\w+\]\s+AS\s+\[\w+\])")]
+    [GeneratedRegex(@"(?<from>FROM\s+(?:\[\w+\]\.)*\[\w+\]\s+AS\s+\[\w+\])", RegexOptions.NonBacktracking | RegexOptions.ExplicitCapture)]
     private static partial Regex FromClausePattern();
 
     public override InterceptionResult<DbDataReader> ReaderExecuting(
@@ -88,15 +88,15 @@ public partial class SqlServerRowLockInterceptor : DbCommandInterceptor
         if (command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableJob}", StringComparison.Ordinal)
             && !command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableJobWait}", StringComparison.Ordinal))
         {
-            command.CommandText = FromClausePattern().Replace(command.CommandText, "$1 WITH (ROWLOCK, UPDLOCK, READPAST)", 1);
+            command.CommandText = FromClausePattern().Replace(command.CommandText, "${from} WITH (ROWLOCK, UPDLOCK, READPAST)", 1);
         }
         else if (command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableJobWait}", StringComparison.Ordinal))
         {
-            command.CommandText = FromClausePattern().Replace(command.CommandText, "$1 WITH (ROWLOCK, UPDLOCK)", 1);
+            command.CommandText = FromClausePattern().Replace(command.CommandText, "${from} WITH (ROWLOCK, UPDLOCK)", 1);
         }
         else if (command.CommandText.StartsWith($"-- {InterceptorConstants.RowLockTableCounter}", StringComparison.Ordinal))
         {
-            command.CommandText = FromClausePattern().Replace(command.CommandText, "$1 WITH (ROWLOCK, UPDLOCK, READPAST)", 1);
+            command.CommandText = FromClausePattern().Replace(command.CommandText, "${from} WITH (ROWLOCK, UPDLOCK, READPAST)", 1);
         }
     }
 }

--- a/src/core/Jobly.Core/Handlers/IPublishPipelineBehavior.cs
+++ b/src/core/Jobly.Core/Handlers/IPublishPipelineBehavior.cs
@@ -8,7 +8,7 @@ public class PublishContext<T> : IJobMetadata
 {
     public required T Job { get; init; }
 
-    public Dictionary<string, string> Metadata { get; init; } = new();
+    public Dictionary<string, string> Metadata { get; init; } = [];
 
     IReadOnlyDictionary<string, string> IJobMetadata.Metadata => Metadata;
 }

--- a/src/core/Jobly.Core/Logging/JobLogContext.cs
+++ b/src/core/Jobly.Core/Logging/JobLogContext.cs
@@ -33,6 +33,7 @@ public class JobLogCollector
         {
             list.Add(entry);
         }
+
         return list;
     }
 }

--- a/src/core/Jobly.Core/ServiceConfiguration.cs
+++ b/src/core/Jobly.Core/ServiceConfiguration.cs
@@ -337,7 +337,6 @@ public static class ServiceConfiguration
         stat.Property(p => p.Value);
 
         // No seed data — Statistic rows are created by the counter aggregator on demand.
-
         stat.Metadata.SetSchema(schema);
     }
 

--- a/src/core/Jobly.Tests/Fixtures/FakeLockProvider.cs
+++ b/src/core/Jobly.Tests/Fixtures/FakeLockProvider.cs
@@ -32,10 +32,22 @@ internal class FakeLock(string name, ConcurrentDictionary<string, bool> heldLock
     }
 
     public ValueTask<IDistributedSynchronizationHandle> AcquireAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
-        => new(Acquire(timeout, cancellationToken));
+    {
+        var handle = heldLocks.TryAdd(name, true)
+            ? new FakeHandle(name, heldLocks)
+            : throw new InvalidOperationException("Lock not acquired");
+
+        return new ValueTask<IDistributedSynchronizationHandle>(handle);
+    }
 
     public ValueTask<IDistributedSynchronizationHandle?> TryAcquireAsync(TimeSpan timeout = default, CancellationToken cancellationToken = default)
-        => new(TryAcquire(timeout, cancellationToken));
+    {
+        IDistributedSynchronizationHandle? handle = heldLocks.TryAdd(name, true)
+            ? new FakeHandle(name, heldLocks)
+            : null;
+
+        return new ValueTask<IDistributedSynchronizationHandle?>(handle);
+    }
 }
 
 internal class FakeHandle(string name, ConcurrentDictionary<string, bool> heldLocks) : IDistributedSynchronizationHandle
@@ -46,7 +58,8 @@ internal class FakeHandle(string name, ConcurrentDictionary<string, bool> heldLo
 
     public ValueTask DisposeAsync()
     {
-        Dispose();
+        heldLocks.TryRemove(name, out _);
+
         return default;
     }
 }

--- a/src/core/Jobly.Tests/Integration/BatchIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/BatchIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class BatchIntegrationTestsBase : IntegrationTestBase
 {
-    protected BatchIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected BatchIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenBatchOfFive_WhenAllComplete_ThenBatchFinalizes()
@@ -209,12 +212,18 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class BatchIntegrationTests_PostgreSql : BatchIntegrationTestsBase
 {
-    public BatchIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public BatchIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class BatchIntegrationTests_SqlServer : BatchIntegrationTestsBase
 {
-    public BatchIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public BatchIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/CancellationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/CancellationIntegrationTests.cs
@@ -9,7 +9,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
 {
-    protected CancellationIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected CancellationIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenProcessingJob_WhenDeleted_ThenHandlerIsCancelledAndLoggedAsCancelled()
@@ -53,7 +56,7 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
         await Server.WaitForJobLog(jobId, "CancellationRequested", timeout: TimeSpan.FromSeconds(5));
 
         var logs = await Server.GetJobLogs(jobId);
-        var cancellationLog = logs.First(l => l.EventType == "CancellationRequested");
+        var cancellationLog = logs.First(l => string.Equals(l.EventType, "CancellationRequested", StringComparison.Ordinal));
         cancellationLog.WorkerId.ShouldBeNull();
     }
 
@@ -74,11 +77,11 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
         var logs = await Server.GetJobLogs(jobId);
 
         // Worker-produced logs (Processing, Cancelled) should have a WorkerId
-        var processingLog = logs.FirstOrDefault(l => l.EventType == "Processing");
+        var processingLog = logs.FirstOrDefault(l => string.Equals(l.EventType, "Processing", StringComparison.Ordinal));
         processingLog.ShouldNotBeNull();
         processingLog.WorkerId.ShouldNotBeNull();
 
-        var cancelledLog = logs.First(l => l.EventType == "Cancelled");
+        var cancelledLog = logs.First(l => string.Equals(l.EventType, "Cancelled", StringComparison.Ordinal));
         cancelledLog.WorkerId.ShouldNotBeNull();
     }
 
@@ -107,12 +110,18 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class CancellationIntegrationTests_PostgreSql : CancellationIntegrationTestsBase
 {
-    public CancellationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public CancellationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class CancellationIntegrationTests_SqlServer : CancellationIntegrationTestsBase
 {
-    public CancellationIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public CancellationIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/ConcurrencyEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Integration/ConcurrencyEdgeCaseTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class ConcurrencyEdgeCaseTestsBase : IntegrationTestBase
 {
-    protected ConcurrencyEdgeCaseTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected ConcurrencyEdgeCaseTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenConcurrentDeleteOnSameJob_ThenOnlyOneDeleteRecorded()
@@ -108,12 +111,18 @@ public abstract class ConcurrencyEdgeCaseTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class ConcurrencyEdgeCaseTests_PostgreSql : ConcurrencyEdgeCaseTestsBase
 {
-    public ConcurrencyEdgeCaseTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public ConcurrencyEdgeCaseTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class ConcurrencyEdgeCaseTests_SqlServer : ConcurrencyEdgeCaseTestsBase
 {
-    public ConcurrencyEdgeCaseTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public ConcurrencyEdgeCaseTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/ConcurrencyIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ConcurrencyIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class ConcurrencyIntegrationTestsBase : IntegrationTestBase
 {
-    protected ConcurrencyIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected ConcurrencyIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenFiftyCounterJobs_WithFiveWorkers_ThenAllProcessedExactlyOnce()
@@ -111,12 +114,18 @@ public abstract class ConcurrencyIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class ConcurrencyIntegrationTests_PostgreSql : ConcurrencyIntegrationTestsBase
 {
-    public ConcurrencyIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public ConcurrencyIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class ConcurrencyIntegrationTests_SqlServer : ConcurrencyIntegrationTestsBase
 {
-    public ConcurrencyIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public ConcurrencyIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/ContinuationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ContinuationIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
 {
-    protected ContinuationIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected ContinuationIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenParentJob_WhenCompletes_ThenChildActivatesAndCompletes()
@@ -117,12 +120,18 @@ public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class ContinuationIntegrationTests_PostgreSql : ContinuationIntegrationTestsBase
 {
-    public ContinuationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public ContinuationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class ContinuationIntegrationTests_SqlServer : ContinuationIntegrationTestsBase
 {
-    public ContinuationIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public ContinuationIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
@@ -11,7 +11,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class EndToEndIntegrationTestsBase : IntegrationTestBase
 {
-    protected EndToEndIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected EndToEndIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenComplexWorkload_WhenProcessedByRealWorkers_ThenAllJobsReachTerminalState()
@@ -138,12 +141,18 @@ public abstract class EndToEndIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class EndToEndIntegrationTests_PostgreSql : EndToEndIntegrationTestsBase
 {
-    public EndToEndIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public EndToEndIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class EndToEndIntegrationTests_SqlServer : EndToEndIntegrationTestsBase
 {
-    public EndToEndIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public EndToEndIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/IntegrationTestBase.cs
+++ b/src/core/Jobly.Tests/Integration/IntegrationTestBase.cs
@@ -4,7 +4,7 @@ namespace Jobly.Tests.Integration;
 
 public abstract class IntegrationTestBase : IAsyncLifetime
 {
-    protected readonly IDatabaseFixture _fixture;
+    private readonly IDatabaseFixture _fixture;
 
     protected IntegrationTestBase(IDatabaseFixture fixture)
     {

--- a/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
+++ b/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
@@ -93,8 +93,8 @@ public class JoblyTestServer : IAsyncDisposable
     {
         var tempCtx = fixture.CreateContext();
         var connectionString = tempCtx.Database.GetConnectionString()!;
-        var isPostgres = tempCtx.Database.ProviderName?.Contains("Npgsql") == true;
-        tempCtx.Dispose();
+        var isPostgres = tempCtx.Database.ProviderName?.Contains("Npgsql", StringComparison.Ordinal) == true;
+        await tempCtx.DisposeAsync();
 
         var host = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
@@ -102,9 +102,13 @@ public class JoblyTestServer : IAsyncDisposable
                 services.AddDbContext<TestContext>(options =>
                 {
                     if (isPostgres)
+                    {
                         options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention();
+                    }
                     else
+                    {
                         options.UseSqlServer(connectionString);
+                    }
                 });
 
                 services.AddJobHandlers(typeof(JoblyTestServer).Assembly);
@@ -141,7 +145,7 @@ public class JoblyTestServer : IAsyncDisposable
     /// </summary>
     public async Task ReRegisterServer()
     {
-        using var scope = _host.Services.CreateScope();
+        await using var scope = _host.Services.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<TestContext>();
 
         // Check if server still exists (Respawn may have deleted it)
@@ -269,7 +273,8 @@ public class JoblyTestServer : IAsyncDisposable
             .ToListAsync();
     }
 
-    public T GetService<T>() where T : notnull
+    public T GetService<T>()
+        where T : notnull
         => _host.Services.GetRequiredService<T>();
 
     public async Task<Job> GetJob(Guid jobId)
@@ -282,6 +287,7 @@ public class JoblyTestServer : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        GC.SuppressFinalize(this);
         await _host.StopAsync();
         _host.Dispose();
     }

--- a/src/core/Jobly.Tests/Integration/MessageIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MessageIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class MessageIntegrationTestsBase : IntegrationTestBase
 {
-    protected MessageIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected MessageIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenSingleHandlerMessage_WhenPublished_ThenMessageCompletesAndHandlerExecutes()
@@ -156,12 +159,18 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class MessageIntegrationTests_PostgreSql : MessageIntegrationTestsBase
 {
-    public MessageIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public MessageIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class MessageIntegrationTests_SqlServer : MessageIntegrationTestsBase
 {
-    public MessageIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public MessageIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/MetadataIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MetadataIntegrationTests.cs
@@ -11,7 +11,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class MetadataIntegrationTestsBase : IntegrationTestBase
 {
-    protected MetadataIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected MetadataIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task PublishJob_WithPublishPipeline_MetadataPersistedAndAvailableInHandler()
@@ -88,12 +91,18 @@ public abstract class MetadataIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class MetadataIntegrationTests_PostgreSql : MetadataIntegrationTestsBase
 {
-    public MetadataIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public MetadataIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class MetadataIntegrationTests_SqlServer : MetadataIntegrationTestsBase
 {
-    public MetadataIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public MetadataIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/MultiServerTests.cs
+++ b/src/core/Jobly.Tests/Integration/MultiServerTests.cs
@@ -12,7 +12,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
 {
-    protected MultiServerTestsBase(IMultiServerDatabaseFixture fixture) : base(fixture) { }
+    protected MultiServerTestsBase(IMultiServerDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenManyJobs_WithTwoServers_ThenEachJobProcessedExactlyOnce()
@@ -436,12 +439,18 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
 [Collection("PostgreSql-MultiServer")]
 public class MultiServerTests_PostgreSql : MultiServerTestsBase
 {
-    public MultiServerTests_PostgreSql(PostgreSqlMultiServerFixture fixture) : base(fixture) { }
+    public MultiServerTests_PostgreSql(PostgreSqlMultiServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-MultiServer")]
 [Trait("Category", "SqlServer")]
 public class MultiServerTests_SqlServer : MultiServerTestsBase
 {
-    public MultiServerTests_SqlServer(SqlServerMultiServerFixture fixture) : base(fixture) { }
+    public MultiServerTests_SqlServer(SqlServerMultiServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/MutexIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MutexIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class MutexIntegrationTestsBase : IntegrationTestBase
 {
-    protected MutexIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected MutexIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenTwoJobsWithSameMutex_WhenProcessed_ThenSecondIsCancelled()
@@ -49,12 +52,18 @@ public abstract class MutexIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class MutexIntegrationTests_PostgreSql : MutexIntegrationTestsBase
 {
-    public MutexIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public MutexIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class MutexIntegrationTests_SqlServer : MutexIntegrationTestsBase
 {
-    public MutexIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public MutexIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/PauseIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/PauseIntegrationTests.cs
@@ -9,7 +9,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class PauseIntegrationTestsBase : IntegrationTestBase
 {
-    protected PauseIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected PauseIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     private async Task<Guid> GetFirstGroupId()
     {
@@ -28,6 +31,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
 
         await svc.PauseServer(Server.ServerId);
         await Server.WaitForPauseState(groupId, expectedPaused: true);
+        Server.PauseState.IsPaused(groupId).ShouldBeTrue();
 
         // Cleanup
         await svc.ResumeServer(Server.ServerId);
@@ -139,12 +143,18 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class PauseIntegrationTests_PostgreSql : PauseIntegrationTestsBase
 {
-    public PauseIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public PauseIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class PauseIntegrationTests_SqlServer : PauseIntegrationTestsBase
 {
-    public PauseIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public PauseIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/RealTimeLogIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RealTimeLogIntegrationTests.cs
@@ -9,7 +9,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class RealTimeLogIntegrationTestsBase : IntegrationTestBase
 {
-    protected RealTimeLogIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected RealTimeLogIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenProcessingJob_WhenHandlerLogs_ThenLogsAppearInDbBeforeCompletion()
@@ -102,12 +105,18 @@ public abstract class RealTimeLogIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class RealTimeLogIntegrationTests_PostgreSql : RealTimeLogIntegrationTestsBase
 {
-    public RealTimeLogIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public RealTimeLogIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class RealTimeLogIntegrationTests_SqlServer : RealTimeLogIntegrationTestsBase
 {
-    public RealTimeLogIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public RealTimeLogIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class RetryIntegrationTestsBase : IntegrationTestBase
 {
-    protected RetryIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected RetryIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenFailingJobWithThreeRetries_WhenProcessed_ThenRetriesThreeTimesThenFails()
@@ -80,12 +83,18 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class RetryIntegrationTests_PostgreSql : RetryIntegrationTestsBase
 {
-    public RetryIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public RetryIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class RetryIntegrationTests_SqlServer : RetryIntegrationTestsBase
 {
-    public RetryIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public RetryIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/TraceIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/TraceIntegrationTests.cs
@@ -10,7 +10,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class TraceIntegrationTestsBase : IntegrationTestBase
 {
-    protected TraceIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected TraceIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenSpawnChildJobRequest_WhenProcessed_ThenChildInheritsParentTraceId()
@@ -113,12 +116,18 @@ public abstract class TraceIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class TraceIntegrationTests_PostgreSql : TraceIntegrationTestsBase
 {
-    public TraceIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public TraceIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class TraceIntegrationTests_SqlServer : TraceIntegrationTestsBase
 {
-    public TraceIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public TraceIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Integration/TracePropagationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/TracePropagationIntegrationTests.cs
@@ -9,7 +9,10 @@ namespace Jobly.Tests.Integration;
 
 public abstract class TracePropagationIntegrationTestsBase : IntegrationTestBase
 {
-    protected TracePropagationIntegrationTestsBase(IDatabaseFixture fixture) : base(fixture) { }
+    protected TracePropagationIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
 
     [Fact]
     public async Task GivenJobThatSpawnsChild_ThenChildHasSpawnedByJobId()
@@ -87,12 +90,18 @@ public abstract class TracePropagationIntegrationTestsBase : IntegrationTestBase
 [Collection("PostgreSql-Integration")]
 public class TracePropagationIntegrationTests_PostgreSql : TracePropagationIntegrationTestsBase
 {
-    public TracePropagationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture) : base(fixture) { }
+    public TracePropagationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer-Integration")]
 [Trait("Category", "SqlServer")]
 public class TracePropagationIntegrationTests_SqlServer : TracePropagationIntegrationTestsBase
 {
-    public TracePropagationIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture) : base(fixture) { }
+    public TracePropagationIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/TestData/Handlers/ActivityCaptureCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/ActivityCaptureCommand.cs
@@ -14,7 +14,7 @@ public class ActivityCaptureCommand : IJobHandler<ActivityCaptureRequest>
         _capture = capture;
     }
 
-    public Task HandleAsync(ActivityCaptureRequest message, CancellationToken ct)
+    public Task HandleAsync(ActivityCaptureRequest message, CancellationToken cancellationToken)
     {
         var activity = Activity.Current;
         if (activity != null)
@@ -32,7 +32,10 @@ public class ActivityCaptureCommand : IJobHandler<ActivityCaptureRequest>
 public class ActivityCapture
 {
     public string? TraceId { get; set; }
+
     public string? SpanId { get; set; }
+
     public string? ParentSpanId { get; set; }
-    public Dictionary<string, string?> Tags { get; set; } = new();
+
+    public Dictionary<string, string?> Tags { get; set; } = [];
 }

--- a/src/core/Jobly.Tests/TestData/Handlers/BarrierCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/BarrierCommand.cs
@@ -23,5 +23,6 @@ public class BarrierCommand : IJobHandler<BarrierRequest>
 public class BarrierSignal
 {
     public SemaphoreSlim Running { get; } = new(0);
+
     public SemaphoreSlim CanFinish { get; } = new(0);
 }

--- a/src/core/Jobly.Tests/TestData/Handlers/CounterCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/CounterCommand.cs
@@ -11,7 +11,7 @@ public class CounterCommand : IJobHandler<CounterRequest>
 
     private readonly CounterService _counterService;
 
-    public Task HandleAsync(CounterRequest message, CancellationToken ct)
+    public Task HandleAsync(CounterRequest message, CancellationToken cancellationToken)
     {
         _counterService.Increment();
         return Task.CompletedTask;

--- a/src/core/Jobly.Tests/TestData/Handlers/MetadataCommands.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/MetadataCommands.cs
@@ -6,7 +6,7 @@ public class MetadataRequest : IJob;
 
 public class MetadataCommand(IJobContext jobContext, MetadataCapture capture) : IJobHandler<MetadataRequest>
 {
-    public Task HandleAsync(MetadataRequest message, CancellationToken ct)
+    public Task HandleAsync(MetadataRequest message, CancellationToken cancellationToken)
     {
         capture.CapturedMetadata = new Dictionary<string, string>(jobContext.Metadata);
         return Task.CompletedTask;

--- a/src/core/Jobly.Tests/TestData/Handlers/MultiHandlerCommands.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/MultiHandlerCommands.cs
@@ -25,6 +25,7 @@ public class SingleMessageHandler : IMessageHandler<SingleHandlerMessage>
 public class MultiHandlerCounter
 {
     public int CountA;
+
     public int CountB;
 
     public void IncrementA() => Interlocked.Increment(ref CountA);

--- a/src/core/Jobly.Tests/TestData/Handlers/PrecessLogCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/PrecessLogCommand.cs
@@ -12,15 +12,15 @@ public class PrecessLogCommand : IJobHandler<PrecessLogRequest>
         _context = context;
     }
 
-    public async Task HandleAsync(PrecessLogRequest message, CancellationToken ct)
+    public async Task HandleAsync(PrecessLogRequest message, CancellationToken cancellationToken)
     {
         var testTask = await _context.TestLogs
             .Where(x => x.Id == message.TestTaskId)
-            .FirstAsync(ct);
+            .FirstAsync(cancellationToken);
 
         testTask.ProcessedTime = DateTime.UtcNow;
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }
 

--- a/src/core/Jobly.Tests/TestData/Handlers/ProgressLogCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/ProgressLogCommand.cs
@@ -7,10 +7,10 @@ public class ProgressLogRequest : IJob;
 
 public class ProgressLogCommand(ILogger<ProgressLogCommand> logger) : IJobHandler<ProgressLogRequest>
 {
-    public async Task HandleAsync(ProgressLogRequest message, CancellationToken ct)
+    public async Task HandleAsync(ProgressLogRequest message, CancellationToken cancellationToken)
     {
         logger.LogInformation("Step 1 started");
         logger.LogWarning("Step 1 warning");
-        await Task.Delay(TimeSpan.FromSeconds(30), ct);
+        await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
     }
 }

--- a/src/core/Jobly.Tests/TestData/Handlers/ThrowExceptionCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/ThrowExceptionCommand.cs
@@ -4,7 +4,7 @@ namespace Jobly.Tests.TestData.Handlers;
 
 public class ThrowExceptionCommand : IJobHandler<ThrowExceptionRequest>
 {
-    public async Task HandleAsync(ThrowExceptionRequest message, CancellationToken ct)
+    public async Task HandleAsync(ThrowExceptionRequest message, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/src/core/Jobly.Tests/TestData/Handlers/UnitCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/UnitCommand.cs
@@ -4,7 +4,7 @@ namespace Jobly.Tests.TestData.Handlers;
 
 public class UnitCommand : IJobHandler<UnitRequest>
 {
-    public async Task HandleAsync(UnitRequest message, CancellationToken ct)
+    public async Task HandleAsync(UnitRequest message, CancellationToken cancellationToken)
     {
     }
 }

--- a/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
@@ -311,8 +311,6 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         // Arrange
         var ctx = _fixture.CreateContext();
         var traceId = Guid.NewGuid();
-        var capture1 = new ActivityCapture();
-        var capture2 = new ActivityCapture();
 
         ctx.Set<Job>().Add(new Job
         {
@@ -395,12 +393,18 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class ActivityTraceTests_PostgreSql : ActivityTraceTestsBase
 {
-    public ActivityTraceTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public ActivityTraceTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class ActivityTraceTests_SqlServer : ActivityTraceTestsBase
 {
-    public ActivityTraceTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public ActivityTraceTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/AuditFixRound2Tests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixRound2Tests.cs
@@ -51,6 +51,7 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
         var readCtx = _fixture.CreateContext();
         var job = await readCtx.Set<Job>().FindAsync(jobId);
         job.ShouldNotBeNull();
+
         // Should NOT be Enqueued — that would cause double execution while worker is still running
         job.CurrentState.ShouldNotBe(State.Enqueued, "Requeuing a Processing job would cause double execution");
     }
@@ -182,12 +183,18 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class AuditFixRound2Tests_PostgreSql : AuditFixRound2TestsBase
 {
-    public AuditFixRound2Tests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public AuditFixRound2Tests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class AuditFixRound2Tests_SqlServer : AuditFixRound2TestsBase
 {
-    public AuditFixRound2Tests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public AuditFixRound2Tests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/AuditFixRound3Tests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixRound3Tests.cs
@@ -151,12 +151,18 @@ public abstract class AuditFixRound3TestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class AuditFixRound3Tests_PostgreSql : AuditFixRound3TestsBase
 {
-    public AuditFixRound3Tests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public AuditFixRound3Tests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class AuditFixRound3Tests_SqlServer : AuditFixRound3TestsBase
 {
-    public AuditFixRound3Tests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public AuditFixRound3Tests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/AuditFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixTests.cs
@@ -30,9 +30,6 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    private static readonly Guid ServerId = Guid.NewGuid();
-    private static readonly string[] DefaultQueues = ["default"];
-
     /// <summary>
     /// CRITICAL #1: Stale recovery must respect CancellationMode.
     /// If a job has CancellationMode=Graceful (user called DeleteJob), stale recovery
@@ -177,12 +174,18 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class AuditFixTests_PostgreSql : AuditFixTestsBase
 {
-    public AuditFixTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public AuditFixTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class AuditFixTests_SqlServer : AuditFixTestsBase
 {
-    public AuditFixTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public AuditFixTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
@@ -240,12 +240,18 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class BackgroundTaskTests_PostgreSql : BackgroundTaskTestsBase
 {
-    public BackgroundTaskTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public BackgroundTaskTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class BackgroundTaskTests_SqlServer : BackgroundTaskTestsBase
 {
-    public BackgroundTaskTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public BackgroundTaskTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/BatchPublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/BatchPublisherTests.cs
@@ -233,12 +233,18 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class BatchPublisherUnitTests_PostgreSql : BatchPublisherUnitTestsBase
 {
-    public BatchPublisherUnitTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public BatchPublisherUnitTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class BatchPublisherUnitTests_SqlServer : BatchPublisherUnitTestsBase
 {
-    public BatchPublisherUnitTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public BatchPublisherUnitTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/BugFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/BugFixTests.cs
@@ -157,12 +157,18 @@ public abstract class BugFixTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class BugFixTests_PostgreSql : BugFixTestsBase
 {
-    public BugFixTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public BugFixTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class BugFixTests_SqlServer : BugFixTestsBase
 {
-    public BugFixTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public BugFixTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/CancellationModeTests.cs
+++ b/src/core/Jobly.Tests/Unit/CancellationModeTests.cs
@@ -117,12 +117,18 @@ public abstract class CancellationModeTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class CancellationModeTests_PostgreSql : CancellationModeTestsBase
 {
-    public CancellationModeTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public CancellationModeTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class CancellationModeTests_SqlServer : CancellationModeTestsBase
 {
-    public CancellationModeTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public CancellationModeTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
@@ -256,12 +256,18 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class CountBasedCleanupTests_PostgreSql : CountBasedCleanupTestsBase
 {
-    public CountBasedCleanupTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public CountBasedCleanupTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class CountBasedCleanupTests_SqlServer : CountBasedCleanupTestsBase
 {
-    public CountBasedCleanupTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public CountBasedCleanupTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
@@ -285,12 +285,18 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class CrashRecoveryTests_PostgreSql : CrashRecoveryTestsBase
 {
-    public CrashRecoveryTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public CrashRecoveryTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class CrashRecoveryTests_SqlServer : CrashRecoveryTestsBase
 {
-    public CrashRecoveryTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public CrashRecoveryTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/DashboardAuthTests.cs
+++ b/src/core/Jobly.Tests/Unit/DashboardAuthTests.cs
@@ -34,7 +34,7 @@ public class DashboardAuthTests
         // Apply middleware manually
         app.UseMiddleware<JoblyUIMiddleware>(options);
 
-        await app.StartAsync();
+        await app.StartAsync(CancellationToken.None);
         return (app, app.GetTestClient());
     }
 
@@ -44,7 +44,7 @@ public class DashboardAuthTests
         var (app, client) = await CreateApp();
         try
         {
-            var response = await client.GetAsync("/jobly/api/test");
+            var response = await client.GetAsync("/jobly/api/test", CancellationToken.None);
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
         finally
@@ -60,7 +60,7 @@ public class DashboardAuthTests
         var (app, client) = await CreateApp(o => o.UseBuiltInLogin<TestCredentialValidator>());
         try
         {
-            var response = await client.GetAsync("/jobly/api/test");
+            var response = await client.GetAsync("/jobly/api/test", CancellationToken.None);
             response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
         finally
@@ -80,7 +80,7 @@ public class DashboardAuthTests
                 new KeyValuePair<string, string>("username", "admin"),
                 new KeyValuePair<string, string>("password", "admin"),
             ]);
-            var response = await client.PostAsync("/jobly/api/auth/login", form);
+            var response = await client.PostAsync("/jobly/api/auth/login", form, CancellationToken.None);
 
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
             response.Headers.TryGetValues("Set-Cookie", out var cookies).ShouldBeTrue();
@@ -103,7 +103,7 @@ public class DashboardAuthTests
                 new KeyValuePair<string, string>("username", "admin"),
                 new KeyValuePair<string, string>("password", "wrong"),
             ]);
-            var response = await client.PostAsync("/jobly/api/auth/login", form);
+            var response = await client.PostAsync("/jobly/api/auth/login", form, CancellationToken.None);
 
             response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
@@ -125,7 +125,7 @@ public class DashboardAuthTests
                 new KeyValuePair<string, string>("username", "admin"),
                 new KeyValuePair<string, string>("password", "admin"),
             ]);
-            var loginResponse = await client.PostAsync("/jobly/api/auth/login", form);
+            var loginResponse = await client.PostAsync("/jobly/api/auth/login", form, CancellationToken.None);
             loginResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
 
             var setCookie = loginResponse.Headers.GetValues("Set-Cookie").First();
@@ -133,7 +133,7 @@ public class DashboardAuthTests
             client.DefaultRequestHeaders.Add("Cookie", cookieValue);
 
             // API should work now
-            var response = await client.GetAsync("/jobly/api/test");
+            var response = await client.GetAsync("/jobly/api/test", CancellationToken.None);
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
         finally
@@ -149,7 +149,7 @@ public class DashboardAuthTests
         var (app, client) = await CreateApp(o => o.Authorization = new DenyAllFilter());
         try
         {
-            var response = await client.GetAsync("/jobly/api/test");
+            var response = await client.GetAsync("/jobly/api/test", CancellationToken.None);
             response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
         }
         finally
@@ -172,7 +172,7 @@ public class DashboardAuthTests
             var handler = app.GetTestServer().CreateHandler();
             using var noRedirectClient = new HttpClient(handler) { BaseAddress = client.BaseAddress };
 
-            var response = await noRedirectClient.GetAsync("/jobly");
+            var response = await noRedirectClient.GetAsync("/jobly", CancellationToken.None);
             response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
             response.Headers.Location!.ToString().ShouldStartWith("/login");
         }
@@ -188,7 +188,7 @@ internal class TestCredentialValidator : IJoblyCredentialValidator
 {
     public Task<bool> ValidateAsync(string username, string password)
     {
-        return Task.FromResult(username == "admin" && password == "admin");
+        return Task.FromResult(string.Equals(username, "admin", StringComparison.Ordinal) && string.Equals(password, "admin", StringComparison.Ordinal));
     }
 }
 

--- a/src/core/Jobly.Tests/Unit/DashboardBreakdownTests.cs
+++ b/src/core/Jobly.Tests/Unit/DashboardBreakdownTests.cs
@@ -181,12 +181,18 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class DashboardBreakdownTests_PostgreSql : DashboardBreakdownTestsBase
 {
-    public DashboardBreakdownTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public DashboardBreakdownTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class DashboardBreakdownTests_SqlServer : DashboardBreakdownTestsBase
 {
-    public DashboardBreakdownTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public DashboardBreakdownTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/DistributedLockRegistrationTests.cs
+++ b/src/core/Jobly.Tests/Unit/DistributedLockRegistrationTests.cs
@@ -84,7 +84,7 @@ public class DistributedLockRegistrationTests
     [Fact]
     public void AddJoblyWorker_OptionsExtensionPreservesPassword_AfterJoblyWrapsOptions()
     {
-        var connectionString = "Host=localhost;Database=test;Username=user;Password=secret123";
+        const string connectionString = "Host=localhost;Database=test;Username=user;Password=secret123";
         var services = new ServiceCollection();
         services.AddDbContext<TestContext>(o => o.UseNpgsql(connectionString));
         services.AddJoblyWorker<TestContext>();

--- a/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
@@ -59,7 +59,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         var ctx = _fixture.CreateContext();
         await InsertExpiredJob(ctx);
 
-        var oldKey = "stats:failed:2020-01-01-10";
+        const string oldKey = "stats:failed:2020-01-01-10";
         ctx.Set<Statistic>().Add(new Statistic { Key = oldKey, Value = 5 });
         await ctx.SaveChangesAsync();
 
@@ -207,12 +207,18 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class ExpirationEdgeCaseTests_PostgreSql : ExpirationEdgeCaseTestsBase
 {
-    public ExpirationEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public ExpirationEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class ExpirationEdgeCaseTests_SqlServer : ExpirationEdgeCaseTestsBase
 {
-    public ExpirationEdgeCaseTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public ExpirationEdgeCaseTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/FailedJobTypeFilterTests.cs
+++ b/src/core/Jobly.Tests/Unit/FailedJobTypeFilterTests.cs
@@ -274,12 +274,18 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class FailedJobTypeFilterTests_PostgreSql : FailedJobTypeFilterTestsBase
 {
-    public FailedJobTypeFilterTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public FailedJobTypeFilterTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class FailedJobTypeFilterTests_SqlServer : FailedJobTypeFilterTestsBase
 {
-    public FailedJobTypeFilterTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public FailedJobTypeFilterTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
@@ -332,12 +332,18 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class HandlerLogTests_PostgreSql : HandlerLogTestsBase
 {
-    public HandlerLogTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public HandlerLogTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class HandlerLogTests_SqlServer : HandlerLogTestsBase
 {
-    public HandlerLogTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public HandlerLogTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/HourlyStatsTests.cs
+++ b/src/core/Jobly.Tests/Unit/HourlyStatsTests.cs
@@ -225,12 +225,18 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class HourlyStatsTests_PostgreSql : HourlyStatsTestsBase
 {
-    public HourlyStatsTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public HourlyStatsTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class HourlyStatsTests_SqlServer : HourlyStatsTestsBase
 {
-    public HourlyStatsTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public HourlyStatsTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/JobCommandServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobCommandServiceTests.cs
@@ -413,12 +413,18 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class JobCommandServiceTests_PostgreSql : JobCommandServiceTestsBase
 {
-    public JobCommandServiceTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public JobCommandServiceTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class JobCommandServiceTests_SqlServer : JobCommandServiceTestsBase
 {
-    public JobCommandServiceTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public JobCommandServiceTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/JobExpirationTimeoutTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobExpirationTimeoutTests.cs
@@ -90,12 +90,18 @@ public abstract class JobExpirationTimeoutTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class JobExpirationTimeoutTests_PostgreSql : JobExpirationTimeoutTestsBase
 {
-    public JobExpirationTimeoutTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public JobExpirationTimeoutTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class JobExpirationTimeoutTests_SqlServer : JobExpirationTimeoutTestsBase
 {
-    public JobExpirationTimeoutTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public JobExpirationTimeoutTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/JobGroupQueryServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobGroupQueryServiceTests.cs
@@ -273,12 +273,18 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class JobGroupQueryServiceTests_PostgreSql : JobGroupQueryServiceTestsBase
 {
-    public JobGroupQueryServiceTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public JobGroupQueryServiceTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class JobGroupQueryServiceTests_SqlServer : JobGroupQueryServiceTestsBase
 {
-    public JobGroupQueryServiceTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public JobGroupQueryServiceTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/JobLogCollectorTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobLogCollectorTests.cs
@@ -36,7 +36,7 @@ public class JobLogCollectorTests
     public async Task Drain_DoesNotLoseEntries_WhenAddAndDrainConcurrently()
     {
         var collector = new JobLogCollector { JobId = Guid.NewGuid() };
-        var totalEntries = 1000;
+        const int totalEntries = 1000;
         var allDrained = new List<Core.Data.Entities.JobLog>();
 
         // Producer: add entries from multiple threads

--- a/src/core/Jobly.Tests/Unit/JobLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobLogTests.cs
@@ -215,12 +215,18 @@ public abstract class JobLogTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class JobLogTests_PostgreSql : JobLogTestsBase
 {
-    public JobLogTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public JobLogTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class JobLogTests_SqlServer : JobLogTestsBase
 {
-    public JobLogTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public JobLogTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/JobQueryServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobQueryServiceTests.cs
@@ -270,12 +270,18 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class JobQueryServiceTests_PostgreSql : JobQueryServiceTestsBase
 {
-    public JobQueryServiceTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public JobQueryServiceTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class JobQueryServiceTests_SqlServer : JobQueryServiceTestsBase
 {
-    public JobQueryServiceTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public JobQueryServiceTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/MessageRoutingErrorTests.cs
+++ b/src/core/Jobly.Tests/Unit/MessageRoutingErrorTests.cs
@@ -176,12 +176,18 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class MessageRoutingErrorTests_PostgreSql : MessageRoutingErrorTestsBase
 {
-    public MessageRoutingErrorTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public MessageRoutingErrorTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class MessageRoutingErrorTests_SqlServer : MessageRoutingErrorTestsBase
 {
-    public MessageRoutingErrorTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public MessageRoutingErrorTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/MessageRoutingTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/MessageRoutingTaskTests.cs
@@ -188,12 +188,18 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class MessageRoutingTaskTests_PostgreSql : MessageRoutingTaskTestsBase
 {
-    public MessageRoutingTaskTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public MessageRoutingTaskTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class MessageRoutingTaskTests_SqlServer : MessageRoutingTaskTestsBase
 {
-    public MessageRoutingTaskTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public MessageRoutingTaskTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/MetadataPublishPipelineTests.cs
+++ b/src/core/Jobly.Tests/Unit/MetadataPublishPipelineTests.cs
@@ -26,7 +26,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    private static IServiceProvider BuildProvider(params object[] behaviors)
+    private static ServiceProvider BuildProvider(params object[] behaviors)
     {
         var services = new ServiceCollection();
         foreach (var behavior in behaviors)
@@ -40,7 +40,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #1: Multiple behaviors per type all run ---
-
     [Fact]
     public async Task Enqueue_MultipleBehaviors_AllBehaviorsRun()
     {
@@ -78,7 +77,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #2: CancellationToken flows to behaviors ---
-
     [Fact]
     public async Task Enqueue_CancellationToken_FlowsToBehavior()
     {
@@ -86,8 +84,8 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         var behavior = new CancellationTokenCaptureBehavior();
         var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, BuildProvider(behavior));
 
-        var id = await publisher.Enqueue(new UnitRequest());
-        await ctx.SaveChangesAsync();
+        await publisher.Enqueue(new UnitRequest());
+        await ctx.SaveChangesAsync(CancellationToken.None);
 
         // The behavior should have received CancellationToken.None (from the call site),
         // but it should NOT be a default struct — it should be the exact token passed through
@@ -96,7 +94,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #3: No behaviors → null metadata (not empty JSON) ---
-
     [Fact]
     public async Task Enqueue_NoBehaviors_MetadataIsNull()
     {
@@ -111,7 +108,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Ad-hoc metadata via JobParameters ---
-
     [Fact]
     public async Task Enqueue_WithJobParametersMetadata_MetadataPersisted()
     {
@@ -151,7 +147,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #5: Model metadata caching ---
-
     [Fact]
     public void UnifiedJobDetailModel_Metadata_CachedAcrossAccesses_1()
     {
@@ -166,14 +161,15 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     [Fact]
-    public void UnifiedJobDetailModel_Metadata_CachedAcrossAccesses()
+    public void UnifiedJobDetailModel_Metadata_CachedAcrossAccesses_WithMultipleKeys()
     {
-        var model = new UnifiedJobDetailModel { MetadataJson = """{"key":"value"}""" };
+        var model = new UnifiedJobDetailModel { MetadataJson = """{"key1":"value1","key2":"value2"}""" };
 
         var first = model.Metadata;
         var second = model.Metadata;
 
         first.ShouldNotBeNull();
+        first.Count.ShouldBe(2);
         second.ShouldNotBeNull();
         ReferenceEquals(first, second).ShouldBeTrue("Metadata should be the same instance on repeated access");
     }
@@ -186,7 +182,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: JobContext with null metadata → Metadata is empty dict, not null ---
-
     [Fact]
     public void JobContext_DefaultMetadata_IsEmptyDictionaryNotNull()
     {
@@ -196,7 +191,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Batch: pipeline runs once, all children get metadata ---
-
     [Fact]
     public async Task BatchPublisher_WithBehavior_AllChildrenGetMetadata()
     {
@@ -222,7 +216,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Metadata inheritance from execution context ---
-
     [Fact]
     public async Task Enqueue_InsideExecutionContext_InheritsParentMetadata()
     {
@@ -254,7 +247,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Batch: ad-hoc metadata via StartNew ---
-
     [Fact]
     public async Task BatchPublisher_WithAdHocMetadata_AllChildrenGetIt()
     {
@@ -279,7 +271,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: behavior modifies metadata AFTER next() ---
-
     [Fact]
     public async Task Enqueue_BehaviorWritesAfterNext_MetadataPersisted()
     {
@@ -297,7 +288,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: behavior short-circuits (never calls next()) ---
-
     [Fact]
     public async Task Enqueue_BehaviorShortCircuits_MetadataFromBehaviorStillPersisted()
     {
@@ -315,7 +305,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: behavior throws → exception propagates, job not created ---
-
     [Fact]
     public async Task Enqueue_BehaviorThrows_ExceptionPropagatesAndJobNotCreated()
     {
@@ -323,10 +312,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         var behavior = new ThrowingBehavior();
         var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, BuildProvider(behavior));
 
-        await Should.ThrowAsync<InvalidOperationException>(async () =>
-        {
-            await publisher.Enqueue(new UnitRequest());
-        });
+        await Should.ThrowAsync<InvalidOperationException>(async () => await publisher.Enqueue(new UnitRequest()));
 
         // Job should not have been created
         await ctx.SaveChangesAsync();
@@ -335,7 +321,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: pipeline execution order (first registered = outermost, runs first) ---
-
     [Fact]
     public async Task Enqueue_BehaviorOrder_FirstRegisteredIsOutermost()
     {
@@ -353,7 +338,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: ad-hoc metadata overrides inherited metadata on key conflict ---
-
     [Fact]
     public async Task Enqueue_AdHocOverridesInherited_OnKeyConflict()
     {
@@ -388,7 +372,6 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Test behaviors (nested private so assembly scanning skips them) ---
-
     private class AppendMetadataBehavior(string key, string value) : IPublishPipelineBehavior<UnitRequest>
     {
         public Task PublishAsync(PublishContext<UnitRequest> context, PublishDelegate next, CancellationToken ct)
@@ -435,6 +418,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         public Task PublishAsync(PublishContext<UnitRequest> context, PublishDelegate next, CancellationToken ct)
         {
             context.Metadata["short-circuit"] = "yes";
+
             // Intentionally not calling next()
             return Task.CompletedTask;
         }
@@ -462,12 +446,18 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class MetadataPublishPipelineTests_PostgreSql : MetadataPublishPipelineTestsBase
 {
-    public MetadataPublishPipelineTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public MetadataPublishPipelineTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class MetadataPublishPipelineTests_SqlServer : MetadataPublishPipelineTestsBase
 {
-    public MetadataPublishPipelineTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public MetadataPublishPipelineTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/MutexTests.cs
+++ b/src/core/Jobly.Tests/Unit/MutexTests.cs
@@ -76,12 +76,12 @@ public abstract class MutexTestsBase : IAsyncLifetime
 
         // Assert: job2 should be cancelled (Deleted)
         var readCtx = _fixture.CreateContext();
-        var job2 = await readCtx.Set<Job>().FindAsync(job2Id);
+        var job2 = await readCtx.Set<Job>().FindAsync([job2Id], CancellationToken.None);
         job2.ShouldNotBeNull();
         job2.CurrentState.ShouldBe(State.Deleted);
 
         var log = await readCtx.Set<JobLog>()
-            .FirstOrDefaultAsync(l => l.JobId == job2Id && l.EventType == "Deleted");
+            .FirstOrDefaultAsync(l => l.JobId == job2Id && l.EventType == "Deleted", CancellationToken.None);
         log.ShouldNotBeNull();
         log.Message.ShouldContain("mutex");
         log.Message.ShouldContain("payment:123");
@@ -232,12 +232,18 @@ public abstract class MutexTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class MutexTests_PostgreSql : MutexTestsBase
 {
-    public MutexTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public MutexTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class MutexTests_SqlServer : MutexTestsBase
 {
-    public MutexTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public MutexTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
+++ b/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
@@ -502,12 +502,18 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class OTelMetricsTests_PostgreSql : OTelMetricsTestsBase
 {
-    public OTelMetricsTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public OTelMetricsTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class OTelMetricsTests_SqlServer : OTelMetricsTestsBase
 {
-    public OTelMetricsTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public OTelMetricsTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
@@ -443,12 +443,18 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class OrchestrationTaskTests_PostgreSql : OrchestrationTaskTestsBase
 {
-    public OrchestrationTaskTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public OrchestrationTaskTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class OrchestrationTaskTests_SqlServer : OrchestrationTaskTestsBase
 {
-    public OrchestrationTaskTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public OrchestrationTaskTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/PauseStateHolderTests.cs
+++ b/src/core/Jobly.Tests/Unit/PauseStateHolderTests.cs
@@ -91,7 +91,7 @@ public class PauseStateHolderTests
     /// Torn:    server=false, group=false → IsPaused=FALSE (bug!)
     /// </summary>
     [Fact]
-    public void Update_IsAtomic_NeverExposesTornState()
+    public async Task Update_IsAtomic_NeverExposesTornState()
     {
         var holder = new PauseStateHolder();
         var groupId = Guid.NewGuid();
@@ -138,7 +138,7 @@ public class PauseStateHolderTests
         }
 
         Volatile.Write(ref readerDone, true);
-        readerTask.Wait();
+        await readerTask;
 
         iterations.ShouldBeGreaterThan(0, "Reader task did not execute");
         tornReadsDetected.ShouldBe(0, $"Detected {tornReadsDetected} torn reads out of {iterations} iterations");

--- a/src/core/Jobly.Tests/Unit/PipelineTests.cs
+++ b/src/core/Jobly.Tests/Unit/PipelineTests.cs
@@ -125,7 +125,7 @@ public abstract class PipelineTestsBase : IAsyncLifetime
             .Where(x => x.JobId == jobId)
             .ToListAsync();
 
-        var handlerLogs = allLogs.Where(x => x.EventType == "Log").ToList();
+        var handlerLogs = allLogs.Where(x => string.Equals(x.EventType, "Log", StringComparison.Ordinal)).ToList();
 
         handlerLogs.ShouldContain(l => l.Message.Contains("Pipeline before handler"));
         handlerLogs.ShouldContain(l => l.Message.Contains("Pipeline after handler"));
@@ -135,12 +135,18 @@ public abstract class PipelineTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class PipelineTests_PostgreSql : PipelineTestsBase
 {
-    public PipelineTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public PipelineTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class PipelineTests_SqlServer : PipelineTestsBase
 {
-    public PipelineTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public PipelineTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/PriorityTests.cs
+++ b/src/core/Jobly.Tests/Unit/PriorityTests.cs
@@ -252,12 +252,18 @@ public abstract class PriorityTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class PriorityTests_PostgreSql : PriorityTestsBase
 {
-    public PriorityTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public PriorityTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class PriorityTests_SqlServer : PriorityTestsBase
 {
-    public PriorityTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public PriorityTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
@@ -279,12 +279,18 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class PublisherOverloadTests_PostgreSql : PublisherOverloadTestsBase
 {
-    public PublisherOverloadTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public PublisherOverloadTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class PublisherOverloadTests_SqlServer : PublisherOverloadTestsBase
 {
-    public PublisherOverloadTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public PublisherOverloadTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/PublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherTests.cs
@@ -169,6 +169,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.ShouldNotBeNull();
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));
     }
+
     [Fact]
     public async Task Enqueue_WithParent_InheritsParentTrace_SameContext()
     {
@@ -236,12 +237,18 @@ public abstract class PublisherTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class PublisherTests_PostgreSql : PublisherTestsBase
 {
-    public PublisherTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public PublisherTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class PublisherTests_SqlServer : PublisherTestsBase
 {
-    public PublisherTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public PublisherTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
@@ -103,12 +103,18 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RecurringJobBugTests_PostgreSql : RecurringJobBugTestsBase
 {
-    public RecurringJobBugTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RecurringJobBugTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RecurringJobBugTests_SqlServer : RecurringJobBugTestsBase
 {
-    public RecurringJobBugTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RecurringJobBugTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
@@ -227,12 +227,18 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RecurringJobEdgeCaseTests_PostgreSql : RecurringJobEdgeCaseTestsBase
 {
-    public RecurringJobEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RecurringJobEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RecurringJobEdgeCaseTests_SqlServer : RecurringJobEdgeCaseTestsBase
 {
-    public RecurringJobEdgeCaseTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RecurringJobEdgeCaseTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCascadeTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCascadeTests.cs
@@ -100,12 +100,18 @@ public abstract class RecurringJobLogCascadeTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RecurringJobLogCascadeTests_PostgreSql : RecurringJobLogCascadeTestsBase
 {
-    public RecurringJobLogCascadeTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RecurringJobLogCascadeTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RecurringJobLogCascadeTests_SqlServer : RecurringJobLogCascadeTestsBase
 {
-    public RecurringJobLogCascadeTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RecurringJobLogCascadeTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
@@ -109,19 +109,27 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
         var cleanCtx = _fixture.CreateContext();
         await ExpirationCleanupTask<TestContext>.CleanupRecurringJobLogs(cleanCtx);
 
-        // No exception = pass
+        var readCtx = _fixture.CreateContext();
+        var count = await readCtx.Set<RecurringJobLog>().CountAsync();
+        count.ShouldBe(0);
     }
 }
 
 [Collection("PostgreSql")]
 public class RecurringJobLogCleanupTests_PostgreSql : RecurringJobLogCleanupTestsBase
 {
-    public RecurringJobLogCleanupTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RecurringJobLogCleanupTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RecurringJobLogCleanupTests_SqlServer : RecurringJobLogCleanupTestsBase
 {
-    public RecurringJobLogCleanupTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RecurringJobLogCleanupTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
@@ -193,12 +193,18 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RecurringJobTests_PostgreSql : RecurringJobTestsBase
 {
-    public RecurringJobTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RecurringJobTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RecurringJobTests_SqlServer : RecurringJobTestsBase
 {
-    public RecurringJobTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RecurringJobTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RequeueEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RequeueEdgeCaseTests.cs
@@ -149,12 +149,18 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RequeueEdgeCaseTests_PostgreSql : RequeueEdgeCaseTestsBase
 {
-    public RequeueEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RequeueEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RequeueEdgeCaseTests_SqlServer : RequeueEdgeCaseTestsBase
 {
-    public RequeueEdgeCaseTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RequeueEdgeCaseTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
@@ -253,12 +253,18 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RetentionEdgeCaseTests_PostgreSql : RetentionEdgeCaseTestsBase
 {
-    public RetentionEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RetentionEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RetentionEdgeCaseTests_SqlServer : RetentionEdgeCaseTestsBase
 {
-    public RetentionEdgeCaseTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RetentionEdgeCaseTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RetentionTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionTests.cs
@@ -335,12 +335,18 @@ public abstract class RetentionTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RetentionTests_PostgreSql : RetentionTestsBase
 {
-    public RetentionTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RetentionTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RetentionTests_SqlServer : RetentionTestsBase
 {
-    public RetentionTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RetentionTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/RetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetryTests.cs
@@ -248,12 +248,18 @@ public abstract class RetryTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class RetryTests_PostgreSql : RetryTestsBase
 {
-    public RetryTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public RetryTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class RetryTests_SqlServer : RetryTestsBase
 {
-    public RetryTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public RetryTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/ServerCommandServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerCommandServiceTests.cs
@@ -198,12 +198,18 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class ServerCommandServiceTests_PostgreSql : ServerCommandServiceTestsBase
 {
-    public ServerCommandServiceTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public ServerCommandServiceTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class ServerCommandServiceTests_SqlServer : ServerCommandServiceTestsBase
 {
-    public ServerCommandServiceTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public ServerCommandServiceTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/ServerMonitoringTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerMonitoringTests.cs
@@ -106,12 +106,18 @@ public abstract class ServerMonitoringTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class ServerMonitoringTests_PostgreSql : ServerMonitoringTestsBase
 {
-    public ServerMonitoringTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public ServerMonitoringTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class ServerMonitoringTests_SqlServer : ServerMonitoringTestsBase
 {
-    public ServerMonitoringTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public ServerMonitoringTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/ServerQueryTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerQueryTests.cs
@@ -192,12 +192,18 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class ServerQueryTests_PostgreSql : ServerQueryTestsBase
 {
-    public ServerQueryTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public ServerQueryTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class ServerQueryTests_SqlServer : ServerQueryTestsBase
 {
-    public ServerQueryTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public ServerQueryTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
+++ b/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
@@ -46,7 +46,6 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- Publisher.Enqueue ---
-
     [Fact]
     public async Task Enqueue_WithActiveActivity_CapturesParentSpanId()
     {
@@ -104,7 +103,6 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- Publisher.Publish (Message) ---
-
     [Fact]
     public async Task Publish_WithActiveActivity_CapturesParentSpanId()
     {
@@ -131,7 +129,6 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- BatchPublisher ---
-
     [Fact]
     public async Task StartBatch_WithActiveActivity_CapturesParentSpanIdOnBatchAndChildren()
     {
@@ -172,7 +169,6 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- MessageRoutingTask propagation ---
-
     [Fact]
     public async Task MessageRouting_PropagatesParentSpanIdToChildJobs()
     {
@@ -257,7 +253,6 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- Publisher inside handler (JobExecutionContext active) ---
-
     [Fact]
     public async Task Enqueue_InsideHandlerWithActivity_CapturesHandlerSpanId()
     {
@@ -304,12 +299,18 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class SpanPropagationTests_PostgreSql : SpanPropagationTestsBase
 {
-    public SpanPropagationTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public SpanPropagationTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class SpanPropagationTests_SqlServer : SpanPropagationTestsBase
 {
-    public SpanPropagationTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public SpanPropagationTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/SqlServerRowLockInterceptorTests.cs
+++ b/src/core/Jobly.Tests/Unit/SqlServerRowLockInterceptorTests.cs
@@ -71,29 +71,41 @@ public class SqlServerRowLockInterceptorTests
         command.CommandText.ShouldContain("FROM [jobly].[Counter] AS [c] WITH (ROWLOCK, UPDLOCK, READPAST)");
     }
 
-    private static DbCommand CreateCommand(string commandText)
+    private static FakeDbCommand CreateCommand(string commandText)
     {
         return new FakeDbCommand { CommandText = commandText };
     }
 
     private sealed class FakeDbCommand : DbCommand
     {
+        [System.Diagnostics.CodeAnalysis.AllowNull]
         public override string CommandText { get; set; } = string.Empty;
+
         public override int CommandTimeout { get; set; }
+
         public override CommandType CommandType { get; set; }
+
         public override bool DesignTimeVisible { get; set; }
+
         public override UpdateRowSource UpdatedRowSource { get; set; }
+
         protected override DbConnection? DbConnection { get; set; }
+
         protected override DbParameterCollection DbParameterCollection => null!;
+
         protected override DbTransaction? DbTransaction { get; set; }
 
-        public override void Cancel() { }
+        public override void Cancel()
+        {
+        }
 
         public override int ExecuteNonQuery() => 0;
 
         public override object? ExecuteScalar() => null;
 
-        public override void Prepare() { }
+        public override void Prepare()
+        {
+        }
 
         protected override DbParameter CreateDbParameter() => null!;
 

--- a/src/core/Jobly.Tests/Unit/StatCounterTests.cs
+++ b/src/core/Jobly.Tests/Unit/StatCounterTests.cs
@@ -224,12 +224,18 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class StatCounterTests_PostgreSql : StatCounterTestsBase
 {
-    public StatCounterTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public StatCounterTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class StatCounterTests_SqlServer : StatCounterTestsBase
 {
-    public StatCounterTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public StatCounterTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/StatsTests.cs
+++ b/src/core/Jobly.Tests/Unit/StatsTests.cs
@@ -136,12 +136,18 @@ public abstract class StatsTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class StatsTests_PostgreSql : StatsTestsBase
 {
-    public StatsTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public StatsTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class StatsTests_SqlServer : StatsTestsBase
 {
-    public StatsTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public StatsTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/WorkerIdLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/WorkerIdLogTests.cs
@@ -80,12 +80,18 @@ public abstract class WorkerIdLogTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class WorkerIdLogTests_PostgreSql : WorkerIdLogTestsBase
 {
-    public WorkerIdLogTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public WorkerIdLogTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class WorkerIdLogTests_SqlServer : WorkerIdLogTestsBase
 {
-    public WorkerIdLogTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public WorkerIdLogTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Tests/Unit/WorkerTests.cs
+++ b/src/core/Jobly.Tests/Unit/WorkerTests.cs
@@ -279,12 +279,18 @@ public abstract class WorkerTestsBase : IAsyncLifetime
 [Collection("PostgreSql")]
 public class WorkerTests_PostgreSql : WorkerTestsBase
 {
-    public WorkerTests_PostgreSql(PostgreSqlFixture fixture) : base(fixture) { }
+    public WorkerTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
 }
 
 [Collection("SqlServer")]
 [Trait("Category", "SqlServer")]
 public class WorkerTests_SqlServer : WorkerTestsBase
 {
-    public WorkerTests_SqlServer(SqlServerFixture fixture) : base(fixture) { }
+    public WorkerTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
 }

--- a/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
@@ -148,8 +148,8 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             jobContext.JobId = job.Id;
             jobContext.TraceId = job.TraceId ?? job.Id;
             jobContext.Metadata = job.Metadata != null
-                ? JsonSerializer.Deserialize<Dictionary<string, string>>(job.Metadata) ?? new Dictionary<string, string>()
-                : new Dictionary<string, string>();
+                ? JsonSerializer.Deserialize<Dictionary<string, string>>(job.Metadata) ?? []
+                : [];
 
             handlerStopwatch = Stopwatch.StartNew();
             await ExecuteJob(job, scope.ServiceProvider, jobCts.Token);
@@ -269,6 +269,7 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             {
                 await SaveJobLogs(context, logCollector);
             }
+
             await context.SaveChangesAsync(default);
             await endTransaction.CommitAsync(default);
         }

--- a/src/core/Jobly.Worker/JoblyWorkerService.cs
+++ b/src/core/Jobly.Worker/JoblyWorkerService.cs
@@ -165,8 +165,8 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
             jobContext.JobId = job.Id;
             jobContext.TraceId = job.TraceId ?? job.Id;
             jobContext.Metadata = job.Metadata != null
-                ? JsonSerializer.Deserialize<Dictionary<string, string>>(job.Metadata) ?? new Dictionary<string, string>()
-                : new Dictionary<string, string>();
+                ? JsonSerializer.Deserialize<Dictionary<string, string>>(job.Metadata) ?? []
+                : [];
 
             handlerStopwatch = Stopwatch.StartNew();
             await ExecuteJob(job, scope.ServiceProvider, jobCts.Token);
@@ -287,6 +287,7 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
             {
                 await SaveJobLogs(context, logCollector);
             }
+
             await context.SaveChangesAsync(default);
             await endTransaction.CommitAsync(default);
         }

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/FailedCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/FailedCommand.cs
@@ -18,13 +18,13 @@ public class FailedCommand : IJobHandler<FailedJobRequest>
         _publisher = publisher;
     }
 
-    public async Task HandleAsync(FailedJobRequest message, CancellationToken ct)
+    public async Task HandleAsync(FailedJobRequest message, CancellationToken cancellationToken)
     {
         if (message.SchedululeTime.HasValue)
         {
             await _publisher.Schedule(new ThrowExceptionRequest(), message.SchedululeTime.Value);
 
-            await _context.SaveChangesAsync(ct);
+            await _context.SaveChangesAsync(cancellationToken);
 
             return;
         }
@@ -34,6 +34,6 @@ public class FailedCommand : IJobHandler<FailedJobRequest>
             await _publisher.Enqueue(new ThrowExceptionRequest());
         }
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/LightFlowCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/LightFlowCommand.cs
@@ -21,7 +21,7 @@ public class LightFlowHandler : IJobHandler<LightFlowRequest>
         _context = context;
     }
 
-    public async Task HandleAsync(LightFlowRequest message, CancellationToken ct)
+    public async Task HandleAsync(LightFlowRequest message, CancellationToken cancellationToken)
     {
         var email = new SendEmailRequest { EmailLogId = 1 };
 
@@ -42,6 +42,6 @@ public class LightFlowHandler : IJobHandler<LightFlowRequest>
         await _publisher.Enqueue(email, parentId);
         await _publisher.Enqueue(new PublishInvoiceRequest { OrderId = "LIGHT-001" }, parentId);
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/NotificationCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/NotificationCommand.cs
@@ -14,7 +14,7 @@ public class OrderEmailHandler : IMessageHandler<OrderNotification>
         _logger = logger;
     }
 
-    public Task HandleAsync(OrderNotification message, CancellationToken ct)
+    public Task HandleAsync(OrderNotification message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Sending order confirmation email");
         return Task.CompletedTask;
@@ -30,7 +30,7 @@ public class OrderSlackHandler : IMessageHandler<OrderNotification>
         _logger = logger;
     }
 
-    public Task HandleAsync(OrderNotification message, CancellationToken ct)
+    public Task HandleAsync(OrderNotification message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Posting order notification to Slack");
         return Task.CompletedTask;

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/OrderProcessingCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/OrderProcessingCommand.cs
@@ -25,7 +25,7 @@ public class ProcessOrderHandler : IJobHandler<ProcessOrderRequest>
         _logger = logger;
     }
 
-    public async Task HandleAsync(ProcessOrderRequest message, CancellationToken ct)
+    public async Task HandleAsync(ProcessOrderRequest message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Processing order {OrderId}", message.OrderId);
 
@@ -63,10 +63,10 @@ public class ShipItemHandler : IJobHandler<ShipItemRequest>
         _logger = logger;
     }
 
-    public async Task HandleAsync(ShipItemRequest message, CancellationToken ct)
+    public async Task HandleAsync(ShipItemRequest message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Shipping item {Index} for order {OrderId}", message.ItemIndex, message.OrderId);
-        await Task.Delay(100, ct); // Simulate work
+        await Task.Delay(100, cancellationToken); // Simulate work
     }
 }
 
@@ -88,11 +88,11 @@ public class PublishInvoiceHandler : IJobHandler<PublishInvoiceRequest>
         _context = context;
     }
 
-    public async Task HandleAsync(PublishInvoiceRequest message, CancellationToken ct)
+    public async Task HandleAsync(PublishInvoiceRequest message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Publishing invoice notification for order {OrderId}", message.OrderId);
         await _publisher.Publish(new InvoiceNotification { OrderId = message.OrderId });
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }
 
@@ -110,7 +110,7 @@ public class InvoiceEmailHandler : IMessageHandler<InvoiceNotification>
         _logger = logger;
     }
 
-    public Task HandleAsync(InvoiceNotification message, CancellationToken ct)
+    public Task HandleAsync(InvoiceNotification message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Sending invoice email for order {OrderId}", message.OrderId);
         return Task.CompletedTask;
@@ -126,7 +126,7 @@ public class InvoiceWebhookHandler : IMessageHandler<InvoiceNotification>
         _logger = logger;
     }
 
-    public Task HandleAsync(InvoiceNotification message, CancellationToken ct)
+    public Task HandleAsync(InvoiceNotification message, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Sending invoice webhook for order {OrderId}", message.OrderId);
         return Task.CompletedTask;

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/RecurringJobCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/RecurringJobCommand.cs
@@ -23,7 +23,7 @@ public class RecurringJobCommand : IJobHandler<RecurringJobRequest>
         _publisher = publisher;
     }
 
-    public async Task HandleAsync(RecurringJobRequest message, CancellationToken ct)
+    public async Task HandleAsync(RecurringJobRequest message, CancellationToken cancellationToken)
     {
         var registration = new Registration
         {
@@ -41,15 +41,15 @@ public class RecurringJobCommand : IJobHandler<RecurringJobRequest>
 
         _context.EmailLogs.Add(emailLog);
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
 
         var sendEmailRequest = new SendEmailRequest
         {
             EmailLogId = emailLog.Id,
         };
 
-        await _publisher.AddOrUpdateRecurringJob(sendEmailRequest, message.Name, message.Cron);
+        await _publisher.AddOrUpdateRecurringJob(sendEmailRequest, message.Name!, message.Cron!);
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/RegisterCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/RegisterCommand.cs
@@ -16,7 +16,7 @@ public class RegisterCommand : IJobHandler<RegisterRequest>
         _batchPublisher = batchPublisher;
     }
 
-    public async Task HandleAsync(RegisterRequest message, CancellationToken ct)
+    public async Task HandleAsync(RegisterRequest message, CancellationToken cancellationToken)
     {
         var registration = new Registration
         {
@@ -34,9 +34,9 @@ public class RegisterCommand : IJobHandler<RegisterRequest>
 
         _context.EmailLogs.Add(emailLog);
 
-        await using var transaction = await _context.Database.BeginTransactionAsync(ct);
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
 
         var sendEmailRequest = new SendEmailRequest
         {
@@ -60,9 +60,9 @@ public class RegisterCommand : IJobHandler<RegisterRequest>
             await _publisher.Enqueue(sendEmailRequest, parentId);
         }
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
 
-        await transaction.CommitAsync(ct);
+        await transaction.CommitAsync(cancellationToken);
     }
 }
 

--- a/src/tests/Jobly.Test.Shared/Handlers/Api/ScheduleRegisterCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/Api/ScheduleRegisterCommand.cs
@@ -23,7 +23,7 @@ public class ScheduleRegisterCommand : IJobHandler<ScheduleRegisterRequest>
         _publisher = publisher;
     }
 
-    public async Task HandleAsync(ScheduleRegisterRequest message, CancellationToken ct)
+    public async Task HandleAsync(ScheduleRegisterRequest message, CancellationToken cancellationToken)
     {
         var registration = new Registration
         {
@@ -41,9 +41,9 @@ public class ScheduleRegisterCommand : IJobHandler<ScheduleRegisterRequest>
 
         _context.EmailLogs.Add(emailLog);
 
-        await using var transaction = await _context.Database.BeginTransactionAsync(ct);
+        await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
 
         var sendEmailRequest = new SendEmailRequest
         {
@@ -64,8 +64,8 @@ public class ScheduleRegisterCommand : IJobHandler<ScheduleRegisterRequest>
             await _publisher.Enqueue(sendEmailRequest, jobParams);
         }
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
 
-        await transaction.CommitAsync(ct);
+        await transaction.CommitAsync(cancellationToken);
     }
 }

--- a/src/tests/Jobly.Test.Shared/Handlers/EmptyCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/EmptyCommand.cs
@@ -4,7 +4,7 @@ namespace Jobly.Core.Handlers;
 
 public class EmptyCommand : IJobHandler<EmptyRequest>
 {
-    public Task HandleAsync(EmptyRequest message, CancellationToken ct) => Task.CompletedTask;
+    public Task HandleAsync(EmptyRequest message, CancellationToken cancellationToken) => Task.CompletedTask;
 }
 
 public class EmptyRequest : IJob;
@@ -13,15 +13,15 @@ public class EmptyMessage : IMessage;
 
 public class EmptyMessageHandler1 : IMessageHandler<EmptyMessage>
 {
-    public Task HandleAsync(EmptyMessage message, CancellationToken ct) => Task.CompletedTask;
+    public Task HandleAsync(EmptyMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
 }
 
 public class EmptyMessageHandler2 : IMessageHandler<EmptyMessage>
 {
-    public Task HandleAsync(EmptyMessage message, CancellationToken ct) => Task.CompletedTask;
+    public Task HandleAsync(EmptyMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
 }
 
 public class EmptyMessageHandler3 : IMessageHandler<EmptyMessage>
 {
-    public Task HandleAsync(EmptyMessage message, CancellationToken ct) => Task.CompletedTask;
+    public Task HandleAsync(EmptyMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/tests/Jobly.Test.Shared/Handlers/SendEmailCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/SendEmailCommand.cs
@@ -12,15 +12,15 @@ public class SendEmailCommand : IJobHandler<SendEmailRequest>
         _context = context;
     }
 
-    public async Task HandleAsync(SendEmailRequest message, CancellationToken ct)
+    public async Task HandleAsync(SendEmailRequest message, CancellationToken cancellationToken)
     {
         var emailLog = await _context.EmailLogs
             .Where(x => x.Id == message.EmailLogId)
-            .FirstAsync(cancellationToken: ct);
+            .FirstAsync(cancellationToken: cancellationToken);
 
         emailLog.ProcessedTime = DateTime.UtcNow;
 
-        await _context.SaveChangesAsync(ct);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }
 

--- a/src/tests/Jobly.Test.Shared/Handlers/SlowCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/SlowCommand.cs
@@ -6,8 +6,8 @@ public class SlowRequest : IJob;
 
 public class SlowCommand : IJobHandler<SlowRequest>
 {
-    public async Task HandleAsync(SlowRequest message, CancellationToken ct)
+    public async Task HandleAsync(SlowRequest message, CancellationToken cancellationToken)
     {
-        await Task.Delay(30000, ct); // 30 seconds
+        await Task.Delay(30000, cancellationToken); // 30 seconds
     }
 }

--- a/src/tests/Jobly.Test.Shared/Handlers/ThrowExceptionCommand.cs
+++ b/src/tests/Jobly.Test.Shared/Handlers/ThrowExceptionCommand.cs
@@ -9,8 +9,8 @@ public class ThrowExceptionRequest : IJob
 
 public class ThrowExceptionCommand : IJobHandler<ThrowExceptionRequest>
 {
-    public Task HandleAsync(ThrowExceptionRequest message, CancellationToken ct)
+    public Task HandleAsync(ThrowExceptionRequest message, CancellationToken cancellationToken)
     {
-        throw new Exception("This is from ThrowExceptionCommand");
+        throw new InvalidOperationException("This is from ThrowExceptionCommand");
     }
 }

--- a/src/tests/Jobly.TestApp/Program.cs
+++ b/src/tests/Jobly.TestApp/Program.cs
@@ -62,10 +62,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseCors();
 app.UseAuthorization();
-app.UseJoblyUI(options =>
-{
-    options.UseBuiltInLogin<DemoCredentialValidator>();
-});
+app.UseJoblyUI(options => options.UseBuiltInLogin<DemoCredentialValidator>());
 app.MapControllers();
 
 // Seed endpoint — creates a realistic demo workload
@@ -156,11 +153,13 @@ app.MapPost("/seed", async (IPublisher publisher, IBatchPublisher batchPublisher
 
     // === Mutex jobs (same key — first holds mutex with slow handler, rest get cancelled) ===
     // Uses a-critical queue so these are picked up before the 300+ other jobs
-    await publisher.Enqueue(new SlowRequest(),
+    await publisher.Enqueue(
+        new SlowRequest(),
         new JobParameters { Queue = "a-critical", Mutex = "payment:customer-42" });
     for (var i = 0; i < 4; i++)
     {
-        await publisher.Enqueue(new SendEmailRequest { EmailLogId = 1 },
+        await publisher.Enqueue(
+            new SendEmailRequest { EmailLogId = 1 },
             new JobParameters { Queue = "a-critical", Mutex = "payment:customer-42" });
     }
 
@@ -185,7 +184,8 @@ app.MapPost("/seed", async (IPublisher publisher, IBatchPublisher batchPublisher
     {
         mixedBatchJobs.Add(new SendEmailRequest { EmailLogId = 1 });
     }
-    var mixedBatchId = await batchPublisher.StartNew(mixedBatchJobs, "mixed-result-batch");
+
+    await batchPublisher.StartNew(mixedBatchJobs, "mixed-result-batch");
 
     // === Named batch (type column won't be null) ===
     var namedBatchJobs = Enumerable.Range(0, 5)
@@ -262,9 +262,11 @@ app.MapPost("/seed-flow", async (IPublisher publisher, IBatchPublisher batchPubl
     var lightFlowId = await publisher.Enqueue(new LightFlowRequest());
 
     // 9. Mutex jobs (same key — first holds mutex, rest cancelled)
-    var mutexId1 = await publisher.Enqueue(new SlowRequest(),
+    var mutexId1 = await publisher.Enqueue(
+        new SlowRequest(),
         new JobParameters { Queue = "a-critical", Mutex = "test-mutex" });
-    var mutexId2 = await publisher.Enqueue(new SendEmailRequest { EmailLogId = 1 },
+    var mutexId2 = await publisher.Enqueue(
+        new SendEmailRequest { EmailLogId = 1 },
         new JobParameters { Queue = "a-critical", Mutex = "test-mutex" });
 
     await publisher.SaveChangesAsync();
@@ -471,7 +473,10 @@ app.MapGet("/perf-continuation-latency", async (TestContext context) =>
             .Where(l => l.EventType == "Completed")
             .MaxAsync(l => (DateTime?)l.Timestamp);
 
-        if (lastChildCompleted == null) continue;
+        if (lastChildCompleted == null)
+        {
+            continue;
+        }
 
         // Find continuation batch
         var contBatchId = await context.Set<Job>()
@@ -479,7 +484,10 @@ app.MapGet("/perf-continuation-latency", async (TestContext context) =>
             .Select(j => j.Id)
             .FirstOrDefaultAsync();
 
-        if (contBatchId == Guid.Empty) continue;
+        if (contBatchId == Guid.Empty)
+        {
+            continue;
+        }
 
         // First processing time of continuation children
         var firstContProcessing = await context.Set<JobLog>()
@@ -487,13 +495,19 @@ app.MapGet("/perf-continuation-latency", async (TestContext context) =>
             .Where(l => l.EventType == "Processing")
             .MinAsync(l => (DateTime?)l.Timestamp);
 
-        if (firstContProcessing == null) continue;
+        if (firstContProcessing == null)
+        {
+            continue;
+        }
 
         var latencyMs = (firstContProcessing.Value - lastChildCompleted.Value).TotalMilliseconds;
         latencies.Add(latencyMs);
     }
 
-    if (latencies.Count == 0) return Results.Ok(new { error = "No continuation chains found" });
+    if (latencies.Count == 0)
+    {
+        return Results.Ok(new { error = "No continuation chains found" });
+    }
 
     latencies.Sort();
     return Results.Ok(new
@@ -540,6 +554,6 @@ internal class DemoCredentialValidator : IJoblyCredentialValidator
 {
     public Task<bool> ValidateAsync(string username, string password)
     {
-        return Task.FromResult(username == "admin" && password == "admin");
+        return Task.FromResult(string.Equals(username, "admin", StringComparison.Ordinal) && string.Equals(password, "admin", StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary
- Resolve all 401 build warnings across the entire solution (0 warnings, 0 errors)
- 98 files changed across Jobly.Core, Jobly.Worker, Jobly.Tests, Jobly.Test.Shared, and Jobly.TestApp
- All suppressions via `.editorconfig` — zero `#pragma` or `[SuppressMessage]` attributes added

## Changes by category
| Count | Rule(s) | Fix |
|-------|---------|-----|
| 280 | SA1502/SA1128 | Reformat test constructor initializers to multi-line |
| 26 | CA1725 | Rename `ct` → `cancellationToken` in handler implementations |
| 20 | SA1512 | Remove blank lines after comments |
| 12 | SA1516 | Add missing blank lines between elements |
| 12 | MA0040 | Pass CancellationToken to async overloads |
| 12 | SA1503/IDE0011 | Add braces to control flow statements |
| 8 | MA0006 | Replace `==` with `string.Equals` |
| 5 | MA0042/S6966 | Replace sync with async calls |
| 5 | IDE0028 | Simplify collection initializers to `[]` |
| 4 | SA1513 | Add blank lines after closing braces |
| 3 | RCS1118 | Mark local variables as `const` |
| 14 | Other | IDE0059, S1481, CA1859, CS8765, xUnit1031, etc. |

## Editorconfig additions
| Rule | Scope | Reason |
|------|-------|--------|
| CA1711 | Global | Delegate types + xUnit collection fixtures |
| S3011 | Global | Intentional reflection in JobDispatcher |
| CA1051 | Tests | Interlocked fields in test counters |
| CA1716 | Test.Shared | Namespace matches project name |

## Test plan
- [x] `dotnet build --no-incremental` → 0 warnings, 0 errors
- [x] `dotnet test --filter "Category!=SqlServer"` → 354 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)