### PR TITLE
Migrate to xUnit v3 + Microsoft Testing Platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ Ships as NuGet packages (Jobly.Core, Jobly.UI, Jobly.Worker). Supports PostgreSQ
 ```bash
 # Backend (from src/)
 dotnet build Jobly.sln
-dotnet test Jobly.sln --filter "Category!=SqlServer"   # PostgreSQL only
-dotnet test Jobly.sln                                    # All databases (632 tests, ~30s)
+dotnet test --project core/Jobly.Tests/Jobly.Tests.csproj --filter-not-trait "Category=SqlServer"  # PostgreSQL only
+dotnet test --project core/Jobly.Tests/Jobly.Tests.csproj                                          # All databases (764 tests, ~2min)
 
 # Run specific test suites
-dotnet test Jobly.sln --filter "FullyQualifiedName~Jobly.Tests.Unit"         # Unit tests only
-dotnet test Jobly.sln --filter "FullyQualifiedName~Jobly.Tests.Integration"  # Integration tests only
+dotnet test --project core/Jobly.Tests/Jobly.Tests.csproj --filter-namespace "Jobly.Tests.Unit"         # Unit tests only
+dotnet test --project core/Jobly.Tests/Jobly.Tests.csproj --filter-namespace "Jobly.Tests.Integration"  # Integration tests only
 
 # Frontend (from src/ui/)
 npm install

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlFixture.cs
@@ -24,7 +24,7 @@ public class PostgreSqlFixture : IAsyncLifetime, IDatabaseFixture
 
     public SaveChangesConcurrencyTokenInterceptor ConcurrencyInterceptor { get; } = new();
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString();
@@ -56,11 +56,11 @@ public class PostgreSqlFixture : IAsyncLifetime, IDatabaseFixture
             .Options);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _container.DisposeAsync();
     }
 }
 
-[CollectionDefinition("PostgreSql")]
+[CollectionDefinition]
 public class PostgreSqlCollection : ICollectionFixture<PostgreSqlFixture>;

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlIntegrationFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlIntegrationFixture.cs
@@ -19,7 +19,7 @@ public class PostgreSqlIntegrationFixture : IAsyncLifetime, IDatabaseFixture
 
     public JoblyTestServer TestServer { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString();
@@ -54,12 +54,12 @@ public class PostgreSqlIntegrationFixture : IAsyncLifetime, IDatabaseFixture
             .Options);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await TestServer.DisposeAsync();
         await _container.DisposeAsync();
     }
 }
 
-[CollectionDefinition("PostgreSql-Integration")]
+[CollectionDefinition]
 public class PostgreSqlIntegrationCollection : ICollectionFixture<PostgreSqlIntegrationFixture>;

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlMultiServerFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlMultiServerFixture.cs
@@ -23,7 +23,7 @@ public class PostgreSqlMultiServerFixture : IAsyncLifetime, IMultiServerDatabase
     // IDatabaseFixture.TestServer — not used, but required by the interface for CreateContext reuse
     JoblyTestServer? IDatabaseFixture.TestServer => Server1;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString();
@@ -59,7 +59,7 @@ public class PostgreSqlMultiServerFixture : IAsyncLifetime, IMultiServerDatabase
             .Options);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await Server2.DisposeAsync();
         await Server1.DisposeAsync();
@@ -67,5 +67,5 @@ public class PostgreSqlMultiServerFixture : IAsyncLifetime, IMultiServerDatabase
     }
 }
 
-[CollectionDefinition("PostgreSql-MultiServer")]
+[CollectionDefinition]
 public class PostgreSqlMultiServerCollection : ICollectionFixture<PostgreSqlMultiServerFixture>;

--- a/src/core/Jobly.Tests/Fixtures/SqlServerFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerFixture.cs
@@ -22,7 +22,7 @@ public class SqlServerFixture : IAsyncLifetime, IDatabaseFixture
 
     public SaveChangesConcurrencyTokenInterceptor ConcurrencyInterceptor { get; } = new();
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString() + ";Encrypt=False;";
@@ -51,11 +51,11 @@ public class SqlServerFixture : IAsyncLifetime, IDatabaseFixture
             .Options);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _container.DisposeAsync();
     }
 }
 
-[CollectionDefinition("SqlServer")]
+[CollectionDefinition]
 public class SqlServerCollection : ICollectionFixture<SqlServerFixture>;

--- a/src/core/Jobly.Tests/Fixtures/SqlServerIntegrationFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerIntegrationFixture.cs
@@ -18,7 +18,7 @@ public class SqlServerIntegrationFixture : IAsyncLifetime, IDatabaseFixture
 
     public JoblyTestServer TestServer { get; private set; } = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString() + ";Encrypt=False;";
@@ -52,12 +52,12 @@ public class SqlServerIntegrationFixture : IAsyncLifetime, IDatabaseFixture
             .Options);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await TestServer.DisposeAsync();
         await _container.DisposeAsync();
     }
 }
 
-[CollectionDefinition("SqlServer-Integration")]
+[CollectionDefinition]
 public class SqlServerIntegrationCollection : ICollectionFixture<SqlServerIntegrationFixture>;

--- a/src/core/Jobly.Tests/Fixtures/SqlServerMultiServerFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerMultiServerFixture.cs
@@ -23,7 +23,7 @@ public class SqlServerMultiServerFixture : IAsyncLifetime, IMultiServerDatabaseF
     // IDatabaseFixture.TestServer — not used, but required by the interface for CreateContext reuse
     JoblyTestServer? IDatabaseFixture.TestServer => Server1;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString() + ";Encrypt=False;";
@@ -58,7 +58,7 @@ public class SqlServerMultiServerFixture : IAsyncLifetime, IMultiServerDatabaseF
             .Options);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await Server2.DisposeAsync();
         await Server1.DisposeAsync();
@@ -66,5 +66,5 @@ public class SqlServerMultiServerFixture : IAsyncLifetime, IMultiServerDatabaseF
     }
 }
 
-[CollectionDefinition("SqlServer-MultiServer")]
+[CollectionDefinition]
 public class SqlServerMultiServerCollection : ICollectionFixture<SqlServerMultiServerFixture>;

--- a/src/core/Jobly.Tests/Integration/BatchIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/BatchIntegrationTests.cs
@@ -209,7 +209,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class BatchIntegrationTests_PostgreSql : BatchIntegrationTestsBase
 {
     public BatchIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -218,7 +218,7 @@ public class BatchIntegrationTests_PostgreSql : BatchIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class BatchIntegrationTests_SqlServer : BatchIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/CancellationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/CancellationIntegrationTests.cs
@@ -107,7 +107,7 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class CancellationIntegrationTests_PostgreSql : CancellationIntegrationTestsBase
 {
     public CancellationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -116,7 +116,7 @@ public class CancellationIntegrationTests_PostgreSql : CancellationIntegrationTe
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class CancellationIntegrationTests_SqlServer : CancellationIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/ConcurrencyEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Integration/ConcurrencyEdgeCaseTests.cs
@@ -108,7 +108,7 @@ public abstract class ConcurrencyEdgeCaseTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class ConcurrencyEdgeCaseTests_PostgreSql : ConcurrencyEdgeCaseTestsBase
 {
     public ConcurrencyEdgeCaseTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -117,7 +117,7 @@ public class ConcurrencyEdgeCaseTests_PostgreSql : ConcurrencyEdgeCaseTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class ConcurrencyEdgeCaseTests_SqlServer : ConcurrencyEdgeCaseTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/ConcurrencyIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ConcurrencyIntegrationTests.cs
@@ -111,7 +111,7 @@ public abstract class ConcurrencyIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class ConcurrencyIntegrationTests_PostgreSql : ConcurrencyIntegrationTestsBase
 {
     public ConcurrencyIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -120,7 +120,7 @@ public class ConcurrencyIntegrationTests_PostgreSql : ConcurrencyIntegrationTest
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class ConcurrencyIntegrationTests_SqlServer : ConcurrencyIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/ContinuationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ContinuationIntegrationTests.cs
@@ -117,7 +117,7 @@ public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class ContinuationIntegrationTests_PostgreSql : ContinuationIntegrationTestsBase
 {
     public ContinuationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -126,7 +126,7 @@ public class ContinuationIntegrationTests_PostgreSql : ContinuationIntegrationTe
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class ContinuationIntegrationTests_SqlServer : ContinuationIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
@@ -138,7 +138,7 @@ public abstract class EndToEndIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class EndToEndIntegrationTests_PostgreSql : EndToEndIntegrationTestsBase
 {
     public EndToEndIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -147,7 +147,7 @@ public class EndToEndIntegrationTests_PostgreSql : EndToEndIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class EndToEndIntegrationTests_SqlServer : EndToEndIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/IntegrationTestBase.cs
+++ b/src/core/Jobly.Tests/Integration/IntegrationTestBase.cs
@@ -13,7 +13,7 @@ public abstract class IntegrationTestBase : IAsyncLifetime
 
     protected JoblyTestServer Server => _fixture.TestServer!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         try
         {
@@ -26,5 +26,5 @@ public abstract class IntegrationTestBase : IAsyncLifetime
         }
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/core/Jobly.Tests/Integration/MessageIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MessageIntegrationTests.cs
@@ -156,7 +156,7 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class MessageIntegrationTests_PostgreSql : MessageIntegrationTestsBase
 {
     public MessageIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -165,7 +165,7 @@ public class MessageIntegrationTests_PostgreSql : MessageIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class MessageIntegrationTests_SqlServer : MessageIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/MetadataIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MetadataIntegrationTests.cs
@@ -88,7 +88,7 @@ public abstract class MetadataIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class MetadataIntegrationTests_PostgreSql : MetadataIntegrationTestsBase
 {
     public MetadataIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -97,7 +97,7 @@ public class MetadataIntegrationTests_PostgreSql : MetadataIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class MetadataIntegrationTests_SqlServer : MetadataIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/MetadataPropagationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MetadataPropagationIntegrationTests.cs
@@ -148,7 +148,7 @@ public abstract class MetadataPropagationIntegrationTestsBase : IntegrationTestB
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class MetadataPropagationIntegrationTests_PostgreSql : MetadataPropagationIntegrationTestsBase
 {
     public MetadataPropagationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -157,7 +157,7 @@ public class MetadataPropagationIntegrationTests_PostgreSql : MetadataPropagatio
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class MetadataPropagationIntegrationTests_SqlServer : MetadataPropagationIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/MultiServerIntegrationTestBase.cs
+++ b/src/core/Jobly.Tests/Integration/MultiServerIntegrationTestBase.cs
@@ -17,7 +17,7 @@ public abstract class MultiServerIntegrationTestBase : IAsyncLifetime
 
     protected TestContext CreateContext() => _fixture.CreateContext();
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         try
         {
@@ -30,5 +30,5 @@ public abstract class MultiServerIntegrationTestBase : IAsyncLifetime
         }
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/src/core/Jobly.Tests/Integration/MultiServerTests.cs
+++ b/src/core/Jobly.Tests/Integration/MultiServerTests.cs
@@ -436,7 +436,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-MultiServer")]
+[Collection<PostgreSqlMultiServerCollection>]
 public class MultiServerTests_PostgreSql : MultiServerTestsBase
 {
     public MultiServerTests_PostgreSql(PostgreSqlMultiServerFixture fixture)
@@ -445,7 +445,7 @@ public class MultiServerTests_PostgreSql : MultiServerTestsBase
     }
 }
 
-[Collection("SqlServer-MultiServer")]
+[Collection<SqlServerMultiServerCollection>]
 [Trait("Category", "SqlServer")]
 public class MultiServerTests_SqlServer : MultiServerTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/MutexIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MutexIntegrationTests.cs
@@ -49,7 +49,7 @@ public abstract class MutexIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class MutexIntegrationTests_PostgreSql : MutexIntegrationTestsBase
 {
     public MutexIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -58,7 +58,7 @@ public class MutexIntegrationTests_PostgreSql : MutexIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class MutexIntegrationTests_SqlServer : MutexIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/PauseIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/PauseIntegrationTests.cs
@@ -140,7 +140,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class PauseIntegrationTests_PostgreSql : PauseIntegrationTestsBase
 {
     public PauseIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -149,7 +149,7 @@ public class PauseIntegrationTests_PostgreSql : PauseIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class PauseIntegrationTests_SqlServer : PauseIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/RealTimeLogIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RealTimeLogIntegrationTests.cs
@@ -102,7 +102,7 @@ public abstract class RealTimeLogIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class RealTimeLogIntegrationTests_PostgreSql : RealTimeLogIntegrationTestsBase
 {
     public RealTimeLogIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -111,7 +111,7 @@ public class RealTimeLogIntegrationTests_PostgreSql : RealTimeLogIntegrationTest
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class RealTimeLogIntegrationTests_SqlServer : RealTimeLogIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
@@ -126,7 +126,7 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class RetryIntegrationTests_PostgreSql : RetryIntegrationTestsBase
 {
     public RetryIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -135,7 +135,7 @@ public class RetryIntegrationTests_PostgreSql : RetryIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class RetryIntegrationTests_SqlServer : RetryIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/ScopeIsolationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ScopeIsolationIntegrationTests.cs
@@ -123,7 +123,7 @@ public abstract class ScopeIsolationIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class ScopeIsolationIntegrationTests_PostgreSql : ScopeIsolationIntegrationTestsBase
 {
     public ScopeIsolationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -132,7 +132,7 @@ public class ScopeIsolationIntegrationTests_PostgreSql : ScopeIsolationIntegrati
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class ScopeIsolationIntegrationTests_SqlServer : ScopeIsolationIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/TraceIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/TraceIntegrationTests.cs
@@ -113,7 +113,7 @@ public abstract class TraceIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class TraceIntegrationTests_PostgreSql : TraceIntegrationTestsBase
 {
     public TraceIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -122,7 +122,7 @@ public class TraceIntegrationTests_PostgreSql : TraceIntegrationTestsBase
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class TraceIntegrationTests_SqlServer : TraceIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Integration/TracePropagationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/TracePropagationIntegrationTests.cs
@@ -87,7 +87,7 @@ public abstract class TracePropagationIntegrationTestsBase : IntegrationTestBase
     }
 }
 
-[Collection("PostgreSql-Integration")]
+[Collection<PostgreSqlIntegrationCollection>]
 public class TracePropagationIntegrationTests_PostgreSql : TracePropagationIntegrationTestsBase
 {
     public TracePropagationIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
@@ -96,7 +96,7 @@ public class TracePropagationIntegrationTests_PostgreSql : TracePropagationInteg
     }
 }
 
-[Collection("SqlServer-Integration")]
+[Collection<SqlServerIntegrationCollection>]
 [Trait("Category", "SqlServer")]
 public class TracePropagationIntegrationTests_SqlServer : TracePropagationIntegrationTestsBase
 {

--- a/src/core/Jobly.Tests/Jobly.Tests.csproj
+++ b/src/core/Jobly.Tests/Jobly.Tests.csproj
@@ -4,8 +4,14 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<OutputType>Exe</OutputType>
 
 		<IsPackable>false</IsPackable>
+
+		<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+		<!-- Suppress xUnit v3 CancellationToken advisory warnings (bulk fix is a separate task) -->
+		<NoWarn>$(NoWarn);xUnit1051;CA1816;MA0040</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -22,7 +28,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
@@ -31,15 +36,7 @@
 		<PackageReference Include="Testcontainers" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
 		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
+		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
@@ -28,7 +28,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
 
     protected ActivityTraceTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -50,7 +50,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private (JoblyWorkerService<TestContext> Worker, ActivityCapture Capture) CreateWorker()
     {
@@ -390,7 +390,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class ActivityTraceTests_PostgreSql : ActivityTraceTestsBase
 {
     public ActivityTraceTests_PostgreSql(PostgreSqlFixture fixture)
@@ -399,7 +399,7 @@ public class ActivityTraceTests_PostgreSql : ActivityTraceTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class ActivityTraceTests_SqlServer : ActivityTraceTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/AuditFixRound2Tests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixRound2Tests.cs
@@ -20,9 +20,9 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
 
     protected AuditFixRound2TestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     /// <summary>
     /// RequeueJob on a Processing job should not set it to Enqueued (would cause double execution).
@@ -180,7 +180,7 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class AuditFixRound2Tests_PostgreSql : AuditFixRound2TestsBase
 {
     public AuditFixRound2Tests_PostgreSql(PostgreSqlFixture fixture)
@@ -189,7 +189,7 @@ public class AuditFixRound2Tests_PostgreSql : AuditFixRound2TestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class AuditFixRound2Tests_SqlServer : AuditFixRound2TestsBase
 {

--- a/src/core/Jobly.Tests/Unit/AuditFixRound3Tests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixRound3Tests.cs
@@ -17,9 +17,9 @@ public abstract class AuditFixRound3TestsBase : IAsyncLifetime
 
     protected AuditFixRound3TestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     /// <summary>
     /// Count-based cleanup must not delete parents whose children haven't expired.
@@ -148,7 +148,7 @@ public abstract class AuditFixRound3TestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class AuditFixRound3Tests_PostgreSql : AuditFixRound3TestsBase
 {
     public AuditFixRound3Tests_PostgreSql(PostgreSqlFixture fixture)
@@ -157,7 +157,7 @@ public class AuditFixRound3Tests_PostgreSql : AuditFixRound3TestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class AuditFixRound3Tests_SqlServer : AuditFixRound3TestsBase
 {

--- a/src/core/Jobly.Tests/Unit/AuditFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixTests.cs
@@ -26,9 +26,9 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
 
     protected AuditFixTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     /// <summary>
     /// CRITICAL #1: Stale recovery must respect CancellationMode.
@@ -171,7 +171,7 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class AuditFixTests_PostgreSql : AuditFixTestsBase
 {
     public AuditFixTests_PostgreSql(PostgreSqlFixture fixture)
@@ -180,7 +180,7 @@ public class AuditFixTests_PostgreSql : AuditFixTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class AuditFixTests_SqlServer : AuditFixTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
@@ -14,9 +14,9 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
 
     protected BackgroundTaskTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     // --- CounterAggregatorTask ---
     [Fact]
@@ -237,7 +237,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class BackgroundTaskTests_PostgreSql : BackgroundTaskTestsBase
 {
     public BackgroundTaskTests_PostgreSql(PostgreSqlFixture fixture)
@@ -246,7 +246,7 @@ public class BackgroundTaskTests_PostgreSql : BackgroundTaskTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class BackgroundTaskTests_SqlServer : BackgroundTaskTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/BatchPublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/BatchPublisherTests.cs
@@ -16,9 +16,9 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
 
     protected BatchPublisherUnitTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static BatchPublisher<TestContext> CreateBatchPublisher(TestContext ctx)
     {
@@ -230,7 +230,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class BatchPublisherUnitTests_PostgreSql : BatchPublisherUnitTestsBase
 {
     public BatchPublisherUnitTests_PostgreSql(PostgreSqlFixture fixture)
@@ -239,7 +239,7 @@ public class BatchPublisherUnitTests_PostgreSql : BatchPublisherUnitTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class BatchPublisherUnitTests_SqlServer : BatchPublisherUnitTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/BugFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/BugFixTests.cs
@@ -18,9 +18,9 @@ public abstract class BugFixTestsBase : IAsyncLifetime
 
     protected BugFixTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     /// <summary>
     /// BUG: Expiration cleanup fails with FK violation when parent job has ExpireAt
@@ -154,7 +154,7 @@ public abstract class BugFixTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class BugFixTests_PostgreSql : BugFixTestsBase
 {
     public BugFixTests_PostgreSql(PostgreSqlFixture fixture)
@@ -163,7 +163,7 @@ public class BugFixTests_PostgreSql : BugFixTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class BugFixTests_SqlServer : BugFixTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/CancellationModeTests.cs
+++ b/src/core/Jobly.Tests/Unit/CancellationModeTests.cs
@@ -16,9 +16,9 @@ public abstract class CancellationModeTestsBase : IAsyncLifetime
 
     protected CancellationModeTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task DeleteJob_WhenProcessing_SetsCancellationModeGraceful()
@@ -114,7 +114,7 @@ public abstract class CancellationModeTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class CancellationModeTests_PostgreSql : CancellationModeTestsBase
 {
     public CancellationModeTests_PostgreSql(PostgreSqlFixture fixture)
@@ -123,7 +123,7 @@ public class CancellationModeTests_PostgreSql : CancellationModeTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class CancellationModeTests_SqlServer : CancellationModeTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
@@ -14,9 +14,9 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
 
     protected CountBasedCleanupTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task RunCountBasedCleanup_WhenOverThreshold_DeletesOldestByExpireAt()
@@ -253,7 +253,7 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class CountBasedCleanupTests_PostgreSql : CountBasedCleanupTestsBase
 {
     public CountBasedCleanupTests_PostgreSql(PostgreSqlFixture fixture)
@@ -262,7 +262,7 @@ public class CountBasedCleanupTests_PostgreSql : CountBasedCleanupTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class CountBasedCleanupTests_SqlServer : CountBasedCleanupTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
@@ -14,9 +14,9 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
 
     protected CrashRecoveryTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task RequeueStaleJobs_MultipleStaleJobs_AllRequeued()
@@ -282,7 +282,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class CrashRecoveryTests_PostgreSql : CrashRecoveryTestsBase
 {
     public CrashRecoveryTests_PostgreSql(PostgreSqlFixture fixture)
@@ -291,7 +291,7 @@ public class CrashRecoveryTests_PostgreSql : CrashRecoveryTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class CrashRecoveryTests_SqlServer : CrashRecoveryTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/DashboardBreakdownTests.cs
+++ b/src/core/Jobly.Tests/Unit/DashboardBreakdownTests.cs
@@ -14,9 +14,9 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
 
     protected DashboardBreakdownTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static Job CreateJob(JobKind kind, State state, string queue = "default")
     {
@@ -178,7 +178,7 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class DashboardBreakdownTests_PostgreSql : DashboardBreakdownTestsBase
 {
     public DashboardBreakdownTests_PostgreSql(PostgreSqlFixture fixture)
@@ -187,7 +187,7 @@ public class DashboardBreakdownTests_PostgreSql : DashboardBreakdownTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class DashboardBreakdownTests_SqlServer : DashboardBreakdownTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
@@ -15,7 +15,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
 
     protected ExpirationEdgeCaseTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -31,7 +31,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     /// <summary>
     /// Inserts an expired job so that RunCleanup has work to do and triggers the stats/log cleanup path.
@@ -204,7 +204,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class ExpirationEdgeCaseTests_PostgreSql : ExpirationEdgeCaseTestsBase
 {
     public ExpirationEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
@@ -213,7 +213,7 @@ public class ExpirationEdgeCaseTests_PostgreSql : ExpirationEdgeCaseTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class ExpirationEdgeCaseTests_SqlServer : ExpirationEdgeCaseTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/FailedJobTypeFilterTests.cs
+++ b/src/core/Jobly.Tests/Unit/FailedJobTypeFilterTests.cs
@@ -17,9 +17,9 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
 
     protected FailedJobTypeFilterTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task GetFailedJobTypeCounts_ReturnsCorrectGroupings()
@@ -271,7 +271,7 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class FailedJobTypeFilterTests_PostgreSql : FailedJobTypeFilterTestsBase
 {
     public FailedJobTypeFilterTests_PostgreSql(PostgreSqlFixture fixture)
@@ -280,7 +280,7 @@ public class FailedJobTypeFilterTests_PostgreSql : FailedJobTypeFilterTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class FailedJobTypeFilterTests_SqlServer : FailedJobTypeFilterTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
@@ -27,7 +27,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
 
     protected HandlerLogTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -49,7 +49,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker(bool enableHandlerLogging = true)
     {
@@ -329,7 +329,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class HandlerLogTests_PostgreSql : HandlerLogTestsBase
 {
     public HandlerLogTests_PostgreSql(PostgreSqlFixture fixture)
@@ -338,7 +338,7 @@ public class HandlerLogTests_PostgreSql : HandlerLogTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class HandlerLogTests_SqlServer : HandlerLogTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/HourlyStatsTests.cs
+++ b/src/core/Jobly.Tests/Unit/HourlyStatsTests.cs
@@ -27,7 +27,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
 
     protected HourlyStatsTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -49,7 +49,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker()
     {
@@ -222,7 +222,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class HourlyStatsTests_PostgreSql : HourlyStatsTestsBase
 {
     public HourlyStatsTests_PostgreSql(PostgreSqlFixture fixture)
@@ -231,7 +231,7 @@ public class HourlyStatsTests_PostgreSql : HourlyStatsTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class HourlyStatsTests_SqlServer : HourlyStatsTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/JobCommandServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobCommandServiceTests.cs
@@ -16,9 +16,9 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
 
     protected JobCommandServiceTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task DeleteJob_SetsStateToDeleted()
@@ -410,7 +410,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class JobCommandServiceTests_PostgreSql : JobCommandServiceTestsBase
 {
     public JobCommandServiceTests_PostgreSql(PostgreSqlFixture fixture)
@@ -419,7 +419,7 @@ public class JobCommandServiceTests_PostgreSql : JobCommandServiceTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class JobCommandServiceTests_SqlServer : JobCommandServiceTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/JobExpirationTimeoutTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobExpirationTimeoutTests.cs
@@ -16,9 +16,9 @@ public abstract class JobExpirationTimeoutTestsBase : IAsyncLifetime
 
     protected JobExpirationTimeoutTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task DeleteJob_UsesConfiguredExpirationTimeout()
@@ -87,7 +87,7 @@ public abstract class JobExpirationTimeoutTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class JobExpirationTimeoutTests_PostgreSql : JobExpirationTimeoutTestsBase
 {
     public JobExpirationTimeoutTests_PostgreSql(PostgreSqlFixture fixture)
@@ -96,7 +96,7 @@ public class JobExpirationTimeoutTests_PostgreSql : JobExpirationTimeoutTestsBas
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class JobExpirationTimeoutTests_SqlServer : JobExpirationTimeoutTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/JobGroupQueryServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobGroupQueryServiceTests.cs
@@ -14,9 +14,9 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
 
     protected JobGroupQueryServiceTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task GetJobGroups_Message_ReturnsMessageKindJobs()
@@ -270,7 +270,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class JobGroupQueryServiceTests_PostgreSql : JobGroupQueryServiceTestsBase
 {
     public JobGroupQueryServiceTests_PostgreSql(PostgreSqlFixture fixture)
@@ -279,7 +279,7 @@ public class JobGroupQueryServiceTests_PostgreSql : JobGroupQueryServiceTestsBas
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class JobGroupQueryServiceTests_SqlServer : JobGroupQueryServiceTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/JobLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobLogTests.cs
@@ -27,7 +27,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
 
     protected JobLogTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -49,7 +49,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker()
     {
@@ -212,7 +212,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class JobLogTests_PostgreSql : JobLogTestsBase
 {
     public JobLogTests_PostgreSql(PostgreSqlFixture fixture)
@@ -221,7 +221,7 @@ public class JobLogTests_PostgreSql : JobLogTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class JobLogTests_SqlServer : JobLogTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/JobQueryServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobQueryServiceTests.cs
@@ -15,9 +15,9 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
 
     protected JobQueryServiceTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task GetJobsList_ReturnsJobsByState()
@@ -267,7 +267,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class JobQueryServiceTests_PostgreSql : JobQueryServiceTestsBase
 {
     public JobQueryServiceTests_PostgreSql(PostgreSqlFixture fixture)
@@ -276,7 +276,7 @@ public class JobQueryServiceTests_PostgreSql : JobQueryServiceTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class JobQueryServiceTests_SqlServer : JobQueryServiceTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/MessageRoutingErrorTests.cs
+++ b/src/core/Jobly.Tests/Unit/MessageRoutingErrorTests.cs
@@ -16,9 +16,9 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
 
     protected MessageRoutingErrorTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static IServiceScopeFactory BuildScopeFactoryWithHandlers()
     {
@@ -173,7 +173,7 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class MessageRoutingErrorTests_PostgreSql : MessageRoutingErrorTestsBase
 {
     public MessageRoutingErrorTests_PostgreSql(PostgreSqlFixture fixture)
@@ -182,7 +182,7 @@ public class MessageRoutingErrorTests_PostgreSql : MessageRoutingErrorTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class MessageRoutingErrorTests_SqlServer : MessageRoutingErrorTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/MessageRoutingTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/MessageRoutingTaskTests.cs
@@ -16,9 +16,9 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
 
     protected MessageRoutingTaskTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static IServiceScopeFactory BuildScopeFactory()
     {
@@ -185,7 +185,7 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class MessageRoutingTaskTests_PostgreSql : MessageRoutingTaskTestsBase
 {
     public MessageRoutingTaskTests_PostgreSql(PostgreSqlFixture fixture)
@@ -194,7 +194,7 @@ public class MessageRoutingTaskTests_PostgreSql : MessageRoutingTaskTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class MessageRoutingTaskTests_SqlServer : MessageRoutingTaskTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/MetadataPublishPipelineTests.cs
+++ b/src/core/Jobly.Tests/Unit/MetadataPublishPipelineTests.cs
@@ -22,9 +22,9 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
 
     protected MetadataPublishPipelineTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static ServiceProvider BuildProvider(params object[] behaviors)
     {
@@ -443,7 +443,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class MetadataPublishPipelineTests_PostgreSql : MetadataPublishPipelineTestsBase
 {
     public MetadataPublishPipelineTests_PostgreSql(PostgreSqlFixture fixture)
@@ -452,7 +452,7 @@ public class MetadataPublishPipelineTests_PostgreSql : MetadataPublishPipelineTe
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class MetadataPublishPipelineTests_SqlServer : MetadataPublishPipelineTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/MutexTests.cs
+++ b/src/core/Jobly.Tests/Unit/MutexTests.cs
@@ -21,9 +21,9 @@ public abstract class MutexTestsBase : IAsyncLifetime
 
     protected MutexTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static readonly Guid WorkerId = Guid.NewGuid();
     private static readonly Guid ServerId = Guid.NewGuid();
@@ -229,7 +229,7 @@ public abstract class MutexTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class MutexTests_PostgreSql : MutexTestsBase
 {
     public MutexTests_PostgreSql(PostgreSqlFixture fixture)
@@ -238,7 +238,7 @@ public class MutexTests_PostgreSql : MutexTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class MutexTests_SqlServer : MutexTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
+++ b/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
@@ -28,7 +28,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
 
     protected OTelMetricsTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -50,7 +50,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker(string queue, BarrierSignal? barrier = null)
     {
@@ -508,7 +508,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class OTelMetricsTests_PostgreSql : OTelMetricsTestsBase
 {
     public OTelMetricsTests_PostgreSql(PostgreSqlFixture fixture)
@@ -517,7 +517,7 @@ public class OTelMetricsTests_PostgreSql : OTelMetricsTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class OTelMetricsTests_SqlServer : OTelMetricsTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
@@ -13,9 +13,9 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
 
     protected OrchestrationTaskTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task RunOrchestration_BatchAllChildrenCompleted_FinalizesBatch()
@@ -440,7 +440,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class OrchestrationTaskTests_PostgreSql : OrchestrationTaskTestsBase
 {
     public OrchestrationTaskTests_PostgreSql(PostgreSqlFixture fixture)
@@ -449,7 +449,7 @@ public class OrchestrationTaskTests_PostgreSql : OrchestrationTaskTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class OrchestrationTaskTests_SqlServer : OrchestrationTaskTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/PipelineTests.cs
+++ b/src/core/Jobly.Tests/Unit/PipelineTests.cs
@@ -27,7 +27,7 @@ public abstract class PipelineTestsBase : IAsyncLifetime
 
     protected PipelineTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -49,7 +49,7 @@ public abstract class PipelineTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker()
     {
@@ -132,7 +132,7 @@ public abstract class PipelineTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class PipelineTests_PostgreSql : PipelineTestsBase
 {
     public PipelineTests_PostgreSql(PostgreSqlFixture fixture)
@@ -141,7 +141,7 @@ public class PipelineTests_PostgreSql : PipelineTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class PipelineTests_SqlServer : PipelineTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/PriorityTests.cs
+++ b/src/core/Jobly.Tests/Unit/PriorityTests.cs
@@ -24,7 +24,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
 
     protected PriorityTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -46,7 +46,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker(string[]? queues = null)
     {
@@ -249,7 +249,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class PriorityTests_PostgreSql : PriorityTestsBase
 {
     public PriorityTests_PostgreSql(PostgreSqlFixture fixture)
@@ -258,7 +258,7 @@ public class PriorityTests_PostgreSql : PriorityTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class PriorityTests_SqlServer : PriorityTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
@@ -17,9 +17,9 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
 
     protected PublisherOverloadTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static Publisher<TestContext> CreatePublisher(TestContext ctx)
     {
@@ -276,7 +276,7 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class PublisherOverloadTests_PostgreSql : PublisherOverloadTestsBase
 {
     public PublisherOverloadTests_PostgreSql(PostgreSqlFixture fixture)
@@ -285,7 +285,7 @@ public class PublisherOverloadTests_PostgreSql : PublisherOverloadTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class PublisherOverloadTests_SqlServer : PublisherOverloadTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/PublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherTests.cs
@@ -18,9 +18,9 @@ public abstract class PublisherTestsBase : IAsyncLifetime
 
     protected PublisherTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static Publisher<TestContext> CreatePublisher(TestContext ctx)
     {
@@ -234,7 +234,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class PublisherTests_PostgreSql : PublisherTestsBase
 {
     public PublisherTests_PostgreSql(PostgreSqlFixture fixture)
@@ -243,7 +243,7 @@ public class PublisherTests_PostgreSql : PublisherTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class PublisherTests_SqlServer : PublisherTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
@@ -19,9 +19,9 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
 
     protected RecurringJobBugTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task AddOrUpdateRecurringJob_DoesNotCreateJob()
@@ -100,7 +100,7 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RecurringJobBugTests_PostgreSql : RecurringJobBugTestsBase
 {
     public RecurringJobBugTests_PostgreSql(PostgreSqlFixture fixture)
@@ -109,7 +109,7 @@ public class RecurringJobBugTests_PostgreSql : RecurringJobBugTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RecurringJobBugTests_SqlServer : RecurringJobBugTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
@@ -16,9 +16,9 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
 
     protected RecurringJobEdgeCaseTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task ScheduleRecurringJobs_JobStillPending_SkipsScheduling()
@@ -406,7 +406,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RecurringJobEdgeCaseTests_PostgreSql : RecurringJobEdgeCaseTestsBase
 {
     public RecurringJobEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
@@ -415,7 +415,7 @@ public class RecurringJobEdgeCaseTests_PostgreSql : RecurringJobEdgeCaseTestsBas
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RecurringJobEdgeCaseTests_SqlServer : RecurringJobEdgeCaseTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCascadeTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCascadeTests.cs
@@ -14,9 +14,9 @@ public abstract class RecurringJobLogCascadeTestsBase : IAsyncLifetime
 
     protected RecurringJobLogCascadeTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task WhenJobIsDeleted_RecurringJobLog_JobIdSetToNull()
@@ -97,7 +97,7 @@ public abstract class RecurringJobLogCascadeTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RecurringJobLogCascadeTests_PostgreSql : RecurringJobLogCascadeTestsBase
 {
     public RecurringJobLogCascadeTests_PostgreSql(PostgreSqlFixture fixture)
@@ -106,7 +106,7 @@ public class RecurringJobLogCascadeTests_PostgreSql : RecurringJobLogCascadeTest
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RecurringJobLogCascadeTests_SqlServer : RecurringJobLogCascadeTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
@@ -12,9 +12,9 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
 
     protected RecurringJobLogCleanupTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task CleanupRecurringJobLogs_KeepsLast100PerRecurringJob()
@@ -115,7 +115,7 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RecurringJobLogCleanupTests_PostgreSql : RecurringJobLogCleanupTestsBase
 {
     public RecurringJobLogCleanupTests_PostgreSql(PostgreSqlFixture fixture)
@@ -124,7 +124,7 @@ public class RecurringJobLogCleanupTests_PostgreSql : RecurringJobLogCleanupTest
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RecurringJobLogCleanupTests_SqlServer : RecurringJobLogCleanupTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
@@ -18,9 +18,9 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
 
     protected RecurringJobTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task AddOrUpdateRecurringJob_CreatesRecurringJobInDb()
@@ -335,7 +335,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RecurringJobTests_PostgreSql : RecurringJobTestsBase
 {
     public RecurringJobTests_PostgreSql(PostgreSqlFixture fixture)
@@ -344,7 +344,7 @@ public class RecurringJobTests_PostgreSql : RecurringJobTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RecurringJobTests_SqlServer : RecurringJobTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RequeueEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RequeueEdgeCaseTests.cs
@@ -16,9 +16,9 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
 
     protected RequeueEdgeCaseTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task RequeueJob_AlreadyEnqueued_NoOpReturnsEarly()
@@ -146,7 +146,7 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RequeueEdgeCaseTests_PostgreSql : RequeueEdgeCaseTestsBase
 {
     public RequeueEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
@@ -155,7 +155,7 @@ public class RequeueEdgeCaseTests_PostgreSql : RequeueEdgeCaseTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RequeueEdgeCaseTests_SqlServer : RequeueEdgeCaseTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
@@ -29,7 +29,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
 
     protected RetentionEdgeCaseTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -51,7 +51,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker()
     {
@@ -259,7 +259,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RetentionEdgeCaseTests_PostgreSql : RetentionEdgeCaseTestsBase
 {
     public RetentionEdgeCaseTests_PostgreSql(PostgreSqlFixture fixture)
@@ -268,7 +268,7 @@ public class RetentionEdgeCaseTests_PostgreSql : RetentionEdgeCaseTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RetentionEdgeCaseTests_SqlServer : RetentionEdgeCaseTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RetentionTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionTests.cs
@@ -27,7 +27,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
 
     protected RetentionTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -49,7 +49,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private JoblyWorkerService<TestContext> CreateWorker()
     {
@@ -332,7 +332,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RetentionTests_PostgreSql : RetentionTestsBase
 {
     public RetentionTests_PostgreSql(PostgreSqlFixture fixture)
@@ -341,7 +341,7 @@ public class RetentionTests_PostgreSql : RetentionTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RetentionTests_SqlServer : RetentionTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/RetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetryTests.cs
@@ -28,7 +28,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
 
     protected RetryTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -50,7 +50,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static int GetRetriedTimes(Job job)
     {
@@ -488,7 +488,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class RetryTests_PostgreSql : RetryTestsBase
 {
     public RetryTests_PostgreSql(PostgreSqlFixture fixture)
@@ -497,7 +497,7 @@ public class RetryTests_PostgreSql : RetryTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class RetryTests_SqlServer : RetryTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/ServerCommandServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerCommandServiceTests.cs
@@ -12,9 +12,9 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
 
     protected ServerCommandServiceTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task PauseServer_SetsPausedAt()
@@ -195,7 +195,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class ServerCommandServiceTests_PostgreSql : ServerCommandServiceTestsBase
 {
     public ServerCommandServiceTests_PostgreSql(PostgreSqlFixture fixture)
@@ -204,7 +204,7 @@ public class ServerCommandServiceTests_PostgreSql : ServerCommandServiceTestsBas
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class ServerCommandServiceTests_SqlServer : ServerCommandServiceTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/ServerMonitoringTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerMonitoringTests.cs
@@ -11,9 +11,9 @@ public abstract class ServerMonitoringTestsBase : IAsyncLifetime
 
     protected ServerMonitoringTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task GetServers_ReturnsServerWithWorkers()
@@ -103,7 +103,7 @@ public abstract class ServerMonitoringTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class ServerMonitoringTests_PostgreSql : ServerMonitoringTestsBase
 {
     public ServerMonitoringTests_PostgreSql(PostgreSqlFixture fixture)
@@ -112,7 +112,7 @@ public class ServerMonitoringTests_PostgreSql : ServerMonitoringTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class ServerMonitoringTests_SqlServer : ServerMonitoringTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/ServerQueryTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerQueryTests.cs
@@ -12,9 +12,9 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
 
     protected ServerQueryTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task GetServerLogs_ReturnsPaginatedLogs()
@@ -189,7 +189,7 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class ServerQueryTests_PostgreSql : ServerQueryTestsBase
 {
     public ServerQueryTests_PostgreSql(PostgreSqlFixture fixture)
@@ -198,7 +198,7 @@ public class ServerQueryTests_PostgreSql : ServerQueryTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class ServerQueryTests_SqlServer : ServerQueryTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
+++ b/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
@@ -21,9 +21,9 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
 
     protected SpanPropagationTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private static Publisher<TestContext> CreatePublisher(TestContext ctx)
     {
@@ -296,7 +296,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class SpanPropagationTests_PostgreSql : SpanPropagationTestsBase
 {
     public SpanPropagationTests_PostgreSql(PostgreSqlFixture fixture)
@@ -305,7 +305,7 @@ public class SpanPropagationTests_PostgreSql : SpanPropagationTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class SpanPropagationTests_SqlServer : SpanPropagationTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/StatCounterTests.cs
+++ b/src/core/Jobly.Tests/Unit/StatCounterTests.cs
@@ -16,9 +16,9 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
 
     protected StatCounterTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task DeleteJob_FromCompletedState_DecrementsSucceededCounter()
@@ -221,7 +221,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class StatCounterTests_PostgreSql : StatCounterTestsBase
 {
     public StatCounterTests_PostgreSql(PostgreSqlFixture fixture)
@@ -230,7 +230,7 @@ public class StatCounterTests_PostgreSql : StatCounterTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class StatCounterTests_SqlServer : StatCounterTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/StatsTests.cs
+++ b/src/core/Jobly.Tests/Unit/StatsTests.cs
@@ -14,9 +14,9 @@ public abstract class StatsTestsBase : IAsyncLifetime
 
     protected StatsTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task GetStatsHistory_ReturnsHourlyData()
@@ -133,7 +133,7 @@ public abstract class StatsTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class StatsTests_PostgreSql : StatsTestsBase
 {
     public StatsTests_PostgreSql(PostgreSqlFixture fixture)
@@ -142,7 +142,7 @@ public class StatsTests_PostgreSql : StatsTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class StatsTests_SqlServer : StatsTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/WorkerIdLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/WorkerIdLogTests.cs
@@ -16,9 +16,9 @@ public abstract class WorkerIdLogTestsBase : IAsyncLifetime
 
     protected WorkerIdLogTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync() => await _fixture.ResetAsync();
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     [Fact]
     public async Task DeleteJob_LogHasNullWorkerId()
@@ -77,7 +77,7 @@ public abstract class WorkerIdLogTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class WorkerIdLogTests_PostgreSql : WorkerIdLogTestsBase
 {
     public WorkerIdLogTests_PostgreSql(PostgreSqlFixture fixture)
@@ -86,7 +86,7 @@ public class WorkerIdLogTests_PostgreSql : WorkerIdLogTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class WorkerIdLogTests_SqlServer : WorkerIdLogTestsBase
 {

--- a/src/core/Jobly.Tests/Unit/WorkerTests.cs
+++ b/src/core/Jobly.Tests/Unit/WorkerTests.cs
@@ -27,7 +27,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
 
     protected WorkerTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _fixture.ResetAsync();
 
@@ -50,7 +50,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    public Task DisposeAsync() => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     private (JoblyWorkerService<TestContext> Worker, IServiceScopeFactory ScopeFactory) CreateWorker(string[]? queues = null)
     {
@@ -276,7 +276,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
     }
 }
 
-[Collection("PostgreSql")]
+[Collection<PostgreSqlCollection>]
 public class WorkerTests_PostgreSql : WorkerTestsBase
 {
     public WorkerTests_PostgreSql(PostgreSqlFixture fixture)
@@ -285,7 +285,7 @@ public class WorkerTests_PostgreSql : WorkerTestsBase
     }
 }
 
-[Collection("SqlServer")]
+[Collection<SqlServerCollection>]
 [Trait("Category", "SqlServer")]
 public class WorkerTests_SqlServer : WorkerTestsBase
 {


### PR DESCRIPTION
## Summary

- Migrate test framework from xUnit v2 (2.9.3) to xUnit v3 (3.2.2) with Microsoft Testing Platform v2
- Replace VSTest runner packages (`xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`, `coverlet.collector`) with `xunit.v3.mtp-v2`
- Update `IAsyncLifetime` signatures from `Task` to `ValueTask` across all test files (xUnit v3 API change)
- Replace magic string `[Collection("name")]` attributes with type-safe `[Collection<T>]` generics (xUnit v3 feature)
- Add `global.json` with MTP runner configuration for `dotnet test` on .NET 10

## Test plan

- [x] All 764 tests pass (unit + PostgreSQL + SQL Server)
- [x] Build succeeds with zero new warnings (advisory xUnit1051/CA1816/MA0040 suppressed in test project)
- [x] `dotnet test` works with MTP runner via `global.json`
- [x] Filter syntax verified: `--filter-not-trait "Category=SqlServer"` for PostgreSQL-only runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)