### PR TITLE
Separate retry into clean per-job configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ await foreach (var user in mediator.CreateStream(new GetUsers { Role = "Admin" }
 
 Single table with `Kind` enum. Key fields:
 - **Shared**: Id, Kind, Type, Message (payload), CreateTime, CurrentState, Queue, ExpireAt, ParentJobId, TraceId, SpawnedByJobId, CancellationMode, ConcurrencyKey
-- **Job-specific**: ScheduleTime, HandlerType, MaxRetries, RetriedTimes, CurrentWorkerId, LastKeepAlive
+- **Job-specific**: ScheduleTime, HandlerType, CurrentWorkerId, LastKeepAlive
 - **Batch-specific**: ContinuationOptions (generalized to all kinds — controls child activation on parent failure)
 - **JobLog** — Unified audit trail. EventType: Created, Processing, Completed, Failed, Requeued, Deleted, Cancelled, CancellationRequested, Log (ILogger output). Includes optional `WorkerId` (set by worker-produced entries, null for command/orchestration entries).
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ public class GenerateReportHandler : IJobHandler<GenerateReport>
 ```csharp
 await publisher.Enqueue(new GenerateReport { Month = 3 });
 await publisher.Schedule(new GenerateReport { Month = 3 }, tomorrow);
-await publisher.Enqueue(new GenerateReport { Month = 3 }, maxRetries: 3);
 await publisher.Enqueue(new GenerateReport { Month = 3 }, queue: "reports");
 await publisher.Enqueue(new FollowUp(), parentJobId: prepareId); // continuation
 ```

--- a/docs/guides/building-addons.md
+++ b/docs/guides/building-addons.md
@@ -8,7 +8,7 @@ Jobly provides three extension points for addons:
 
 1. **`IPublishPipelineBehavior<T>`** — runs at publish time, can modify job metadata
 2. **`IPipelineBehavior<TRequest, TResponse>`** — wraps handler execution, can catch exceptions and influence failure handling
-3. **`IJobContext` / `IJobContext<T>`** — mutable metadata dictionary available during handler execution, with optional typed views via source-generated interfaces
+3. **`IJobContext`** — mutable metadata dictionary available during handler execution, with typed views via `GetMetadata<T>()` and source-generated interfaces
 
 The worker is a generic state machine. On handler failure, it reads `IJobContext.FailureOutcome` and applies whatever state the pipeline decided. If no pipeline set an outcome, the job is marked as `Failed`.
 
@@ -56,12 +56,13 @@ public partial interface IOrderMetadata : IJobMetadata
     int Priority { get; set; }
 }
 
-// Handler injects typed context
-public class ProcessOrderHandler(IJobContext<IOrderMetadata> ctx) : IJobHandler<ProcessOrder>
+// Handler gets typed metadata via GetMetadata<T>()
+public class ProcessOrderHandler(IJobContext ctx) : IJobHandler<ProcessOrder>
 {
     public Task HandleAsync(ProcessOrder msg, CancellationToken ct)
     {
-        ctx.Metadata.CustomerName = "John";   // typed property → writes to dict
+        var meta = ctx.GetMetadata<IOrderMetadata>();
+        meta.CustomerName = "John";            // typed property → writes to dict
         ctx.Metadata["Priority"];              // raw dict access → same value
     }
 }
@@ -69,7 +70,7 @@ public class ProcessOrderHandler(IJobContext<IOrderMetadata> ctx) : IJobHandler<
 
 The typed view IS the dictionary — property writes go directly to the underlying `Dictionary<string, object>`. No sync, no flush, no copy.
 
-**Registration:** `IJobContext<T>` is registered as an open generic in `AddJobly()`. No per-type registration needed. Just inject `IJobContext<IYourMetadata>` and it works.
+**Registration:** `IJobContext` is registered in `AddJobly()`. Call `GetMetadata<T>()` to get a typed view. The typed impl replaces the underlying dictionary, so writes flow through directly.
 
 **Nullable properties:** Use `int?` for properties where "not set" must be distinguishable from `0`:
 
@@ -104,18 +105,19 @@ public class RetryPublishBehavior<T> : IPublishPipelineBehavior<T>
 {
     public Task PublishAsync(PublishContext<T> context, PublishDelegate next, CancellationToken ct)
     {
-        if (!context.Metadata.ContainsKey("MaxRetries"))
-            context.Metadata["MaxRetries"] = _options.Value.MaxRetries;
+        var meta = context.GetMetadata<IRetryMetadata>();
 
-        if (_options.Value.Delays.Length > 0 && !context.Metadata.ContainsKey("RetryDelays"))
-            context.Metadata["RetryDelays"] = _options.Value.Delays;
+        meta.MaxRetries ??= _options.Value.MaxRetries;
+
+        if (_options.Value.Delays.Length > 0 && meta.RetryDelays == null)
+            meta.RetryDelays = _options.Value.Delays;
 
         return next();
     }
 }
 ```
 
-Uses `ContainsKey` so user-registered `IPublishPipelineBehavior<T>` can override per job type.
+Uses null-coalescing so per-enqueue metadata set via `Configure<IRetryMetadata>()` takes precedence.
 
 ### Handler Pipeline: RetryPipelineBehavior
 
@@ -123,7 +125,7 @@ Wraps handler execution. On failure, reads retry config from typed metadata and 
 
 ```csharp
 public class RetryPipelineBehavior<TRequest, TResponse>(
-    IJobContext<IRetryMetadata> jobContext,
+    IJobContext jobContext,
     IOptions<RetryOptions> options,
     TimeProvider timeProvider) : IPipelineBehavior<TRequest, TResponse>
 {
@@ -133,8 +135,9 @@ public class RetryPipelineBehavior<TRequest, TResponse>(
         try { return await next(request, ct); }
         catch (Exception) when (request is IJob)
         {
-            var meta = jobContext.Metadata;
-            var maxRetries = meta.MaxRetries ?? options.Value.MaxRetries;
+            var meta = jobContext.GetMetadata<IRetryMetadata>();
+            var attr = GetRetryAttribute(); // checks [Retry] on handler, then job class
+            var maxRetries = meta.MaxRetries ?? attr?.MaxRetries ?? options.Value.MaxRetries;
 
             if (meta.RetriedTimes < maxRetries)
             {
@@ -201,7 +204,7 @@ public partial interface IDeadLetterMetadata : IJobMetadata
 
 // 2. Handler behavior — on permanent failure, re-enqueue to dead letter queue
 public class DeadLetterBehavior<TRequest, TResponse>(
-    IJobContext<IDeadLetterMetadata> ctx,
+    IJobContext ctx,
     TimeProvider timeProvider) : IPipelineBehavior<TRequest, TResponse>
 {
     public async Task<TResponse> HandleAsync(TRequest request,
@@ -210,10 +213,11 @@ public class DeadLetterBehavior<TRequest, TResponse>(
         try { return await next(request, ct); }
         catch (Exception) when (request is IJob && ctx.FailureOutcome == null)
         {
-            var dlq = ctx.Metadata.DeadLetterQueue;
+            var meta = ctx.GetMetadata<IDeadLetterMetadata>();
+            var dlq = meta.DeadLetterQueue;
             if (dlq != null)
             {
-                ctx.Metadata.OriginalQueue = "default";
+                meta.OriginalQueue = "default";
                 ctx.FailureOutcome = new JobFailureOutcome
                 {
                     State = State.Enqueued,
@@ -229,7 +233,6 @@ public class DeadLetterBehavior<TRequest, TResponse>(
 // 3. Registration
 public static IServiceCollection AddDeadLetterQueue(this IServiceCollection services)
 {
-    services.TryAddScoped(typeof(IJobContext<>), typeof(JobContext<>));
     services.AddTransient(typeof(IPipelineBehavior<,>), typeof(DeadLetterBehavior<,>));
     return services;
 }

--- a/docs/specs/2026-04-14-retry-delay.md
+++ b/docs/specs/2026-04-14-retry-delay.md
@@ -12,7 +12,7 @@
 
 **Retry as pipeline module:** `AddJoblyRetry()` registers `RetryPipelineBehavior` (catches failures, reads typed metadata, sets `FailureOutcome`) and `RetryPublishBehavior` (injects retry config at publish time). Jobly Core has zero retry knowledge.
 
-**Typed metadata:** `IJobMetadata` marker interface + source generator produces `Dictionary<string, object>` subclasses with typed property accessors. `IJobContext<T>` provides typed access via open generic DI. `MetadataSerializer` uses a custom `JsonConverter` for native types.
+**Typed metadata:** `IJobMetadata` marker interface + source generator produces `Dictionary<string, object>` subclasses with typed property accessors. `IJobContext.GetMetadata<T>()` provides typed access. `MetadataSerializer` uses a custom `JsonConverter` for native types.
 
 **Worker scope isolation:** Worker and handler use separate DI scopes. Handler's DbContext changes are committed on success (outbox), discarded on failure.
 
@@ -22,7 +22,7 @@
 Publish: RetryPublishBehavior → metadata["MaxRetries"] = 3
 
 Execute: workerScope creates handlerScope
-  → RetryPipelineBehavior wraps handler (IJobContext<IRetryMetadata>)
+  → RetryPipelineBehavior wraps handler (IJobContext.GetMetadata<IRetryMetadata>())
     → Handler runs
     ← Handler throws
   ← RetryPipelineBehavior: meta.RetriedTimes++, sets FailureOutcome
@@ -45,11 +45,12 @@ public partial interface IOrderMetadata : IJobMetadata
 }
 
 // Handler with typed access
-public class MyHandler(IJobContext<IOrderMetadata> ctx) : IJobHandler<MyJob>
+public class MyHandler(IJobContext ctx) : IJobHandler<MyJob>
 {
     public Task HandleAsync(MyJob msg, CancellationToken ct)
     {
-        ctx.Metadata.CustomerName = "John";  // typed, writes to dict
+        var meta = ctx.GetMetadata<IOrderMetadata>();
+        meta.CustomerName = "John";  // typed, writes to dict
     }
 }
 ```

--- a/src/Jobly.sln
+++ b/src/Jobly.sln
@@ -23,6 +23,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jobly.Benchmarks", "benchmarks\Jobly.Benchmarks\Jobly.Benchmarks.csproj", "{8FA0FE16-D934-4ED5-8295-8554FD99FBF5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "core", "core", "{FBF56CC3-7AE6-AD2D-3F14-7F97FD322CD6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jobly.SourceGenerator", "core\Jobly.SourceGenerator\Jobly.SourceGenerator.csproj", "{39D6E84C-8996-43C5-A542-EEC441CCDC6D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -129,6 +133,18 @@ Global
 		{8FA0FE16-D934-4ED5-8295-8554FD99FBF5}.Release|x64.Build.0 = Release|Any CPU
 		{8FA0FE16-D934-4ED5-8295-8554FD99FBF5}.Release|x86.ActiveCfg = Release|Any CPU
 		{8FA0FE16-D934-4ED5-8295-8554FD99FBF5}.Release|x86.Build.0 = Release|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Debug|x64.Build.0 = Debug|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Debug|x86.Build.0 = Debug|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Release|x64.ActiveCfg = Release|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Release|x64.Build.0 = Release|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Release|x86.ActiveCfg = Release|Any CPU
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -138,6 +154,7 @@ Global
 		{E1F1107D-E6DC-4838-B4CB-8AACBD024D67} = {D8878865-FE56-433C-88BB-95DE65D8A1CB}
 		{70D40039-E8BF-4FA0-ABEB-BF3C64ACE9A8} = {D8878865-FE56-433C-88BB-95DE65D8A1CB}
 		{8FA0FE16-D934-4ED5-8295-8554FD99FBF5} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
+		{39D6E84C-8996-43C5-A542-EEC441CCDC6D} = {FBF56CC3-7AE6-AD2D-3F14-7F97FD322CD6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7E12655-DE26-4176-BCC3-A0DCAABFB10E}

--- a/src/core/Jobly.Core/BatchPublisher.cs
+++ b/src/core/Jobly.Core/BatchPublisher.cs
@@ -79,7 +79,7 @@ public class BatchPublisher<TContext> : IBatchPublisher
         var metadata = await RunPublishPipeline(batchJobMessages[0], adHocMetadata);
         var serializedMetadata = metadata.Count > 0 ? JsonSerializer.Serialize(metadata) : null;
 
-        var batchChildJobs = batchJobMessages.ConvertAll(x => JobHelper.CreateJob(x, 0, null, null, _joblyConfiguration.DefaultQueue, batchJob.Id, batchJobsState, now, metadata: serializedMetadata));
+        var batchChildJobs = batchJobMessages.ConvertAll(x => JobHelper.CreateJob(x, null, _joblyConfiguration.DefaultQueue, batchJob.Id, batchJobsState, now, metadata: serializedMetadata));
 
         // Propagate trace: execution context > parent's trace > self
         var executionContext = JobExecutionContext.Current;

--- a/src/core/Jobly.Core/Configuration.cs
+++ b/src/core/Jobly.Core/Configuration.cs
@@ -2,8 +2,6 @@ namespace Jobly.Core;
 
 public class JoblyConfiguration
 {
-    public int RetryCount { get; set; }
-
     public string DefaultQueue { get; set; } = "default";
 
     public string? Schema { get; set; } = "jobly";

--- a/src/core/Jobly.Core/Data/Interceptors/RowLockInterceptor.cs
+++ b/src/core/Jobly.Core/Data/Interceptors/RowLockInterceptor.cs
@@ -4,14 +4,14 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Jobly.Core.Interceptors;
 
-public static class InterceptorConstants
+internal static class InterceptorConstants
 {
     public static readonly string RowLockTableJob = "LOCK ROW TABLE JOB";
     public static readonly string RowLockTableJobWait = "LOCK ROW TABLE JOB WAIT";
     public static readonly string RowLockTableCounter = "LOCK ROW TABLE COUNTER";
 }
 
-public class PostgresRowLockInterceptor : DbCommandInterceptor
+internal class PostgresRowLockInterceptor : DbCommandInterceptor
 {
     public override InterceptionResult<DbDataReader> ReaderExecuting(
         DbCommand command,
@@ -56,7 +56,7 @@ public class PostgresRowLockInterceptor : DbCommandInterceptor
     }
 }
 
-public partial class SqlServerRowLockInterceptor : DbCommandInterceptor
+internal partial class SqlServerRowLockInterceptor : DbCommandInterceptor
 {
     // Matches the first FROM [table] AS [alias] or FROM [schema].[table] AS [alias] pattern
     [GeneratedRegex(@"(?<from>FROM\s+(?:\[\w+\]\.)*\[\w+\]\s+AS\s+\[\w+\])", RegexOptions.NonBacktracking | RegexOptions.ExplicitCapture)]

--- a/src/core/Jobly.Core/Data/Interceptors/SaveChangesConcurrencyTokenInterceptor.cs
+++ b/src/core/Jobly.Core/Data/Interceptors/SaveChangesConcurrencyTokenInterceptor.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Jobly.Core.Interceptors;
 
-public class SaveChangesConcurrencyTokenInterceptor : SaveChangesInterceptor
+internal class SaveChangesConcurrencyTokenInterceptor : SaveChangesInterceptor
 {
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,

--- a/src/core/Jobly.Core/Handlers/IJobContext.cs
+++ b/src/core/Jobly.Core/Handlers/IJobContext.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace Jobly.Core.Handlers;
 
 public interface IJobContext
@@ -8,16 +6,14 @@ public interface IJobContext
 
     Guid TraceId { get; }
 
+    Type? HandlerType { get; }
+
     JobFailureOutcome? FailureOutcome { get; set; }
 
     Dictionary<string, object> Metadata { get; }
-}
 
-[SuppressMessage("Design", "S3246:Generic type parameters should be co/contravariant when possible", Justification = "T is used as return type but covariance not possible due to FailureOutcome setter on base interface")]
-public interface IJobContext<T> : IJobContext
-    where T : IJobMetadata
-{
-    new T Metadata { get; }
+    T GetMetadata<T>()
+        where T : class, IJobMetadata;
 }
 
 public class JobContext : IJobContext
@@ -26,47 +22,18 @@ public class JobContext : IJobContext
 
     public Guid TraceId { get; set; }
 
+    public Type? HandlerType { get; set; }
+
     public JobFailureOutcome? FailureOutcome { get; set; }
 
     public Dictionary<string, object> Metadata { get; set; } = [];
-}
 
-public class JobContext<T> : IJobContext<T>
-    where T : class, IJobMetadata
-{
-    private readonly JobContext _inner;
-    private T? _typedMetadata;
-
-    public JobContext(JobContext inner)
+    public T GetMetadata<T>()
+        where T : class, IJobMetadata
     {
-        _inner = inner;
-    }
+        var typed = MetadataFactory.Create<T>(Metadata);
+        Metadata = (Dictionary<string, object>)(object)typed;
 
-    public Guid JobId => _inner.JobId;
-
-    public Guid TraceId => _inner.TraceId;
-
-    public JobFailureOutcome? FailureOutcome
-    {
-        get => _inner.FailureOutcome;
-        set => _inner.FailureOutcome = value;
-    }
-
-    Dictionary<string, object> IJobContext.Metadata => _inner.Metadata;
-
-    public T Metadata
-    {
-        get
-        {
-            if (_typedMetadata != null)
-            {
-                return _typedMetadata;
-            }
-
-            _typedMetadata = MetadataFactory.Create<T>(_inner.Metadata);
-            _inner.Metadata = (Dictionary<string, object>)(object)_typedMetadata;
-
-            return _typedMetadata;
-        }
+        return typed;
     }
 }

--- a/src/core/Jobly.Core/Handlers/IPublishPipelineBehavior.cs
+++ b/src/core/Jobly.Core/Handlers/IPublishPipelineBehavior.cs
@@ -8,7 +8,16 @@ public class PublishContext<T>
 {
     public required T Job { get; init; }
 
-    public Dictionary<string, object> Metadata { get; init; } = [];
+    public Dictionary<string, object> Metadata { get; set; } = [];
+
+    public TMeta GetMetadata<TMeta>()
+        where TMeta : class, IJobMetadata
+    {
+        var typed = MetadataFactory.Create<TMeta>(Metadata);
+        Metadata = (Dictionary<string, object>)(object)typed;
+
+        return typed;
+    }
 }
 
 [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Public API")]

--- a/src/core/Jobly.Core/Handlers/JobDispatcher.cs
+++ b/src/core/Jobly.Core/Handlers/JobDispatcher.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Jobly.Core.Handlers;
 
-public static class JobDispatcher
+internal static class JobDispatcher
 {
     private static readonly ConcurrentDictionary<Type, Type> _handlerInterfaceCache = new();
     private static readonly ConcurrentDictionary<(Type HandlerType, Type MessageType), MethodInfo> _handleMethodCache = new();

--- a/src/core/Jobly.Core/Handlers/MetadataSerializer.cs
+++ b/src/core/Jobly.Core/Handlers/MetadataSerializer.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Jobly.Core.Handlers;
 
-public static class MetadataSerializer
+internal static class MetadataSerializer
 {
     private static readonly JsonSerializerOptions Options = new()
     {

--- a/src/core/Jobly.Core/Handlers/RetryAttribute.cs
+++ b/src/core/Jobly.Core/Handlers/RetryAttribute.cs
@@ -1,0 +1,18 @@
+namespace Jobly.Core.Handlers;
+
+/// <summary>
+/// Declares retry policy for a job or handler. Can be applied to IJob or IJobHandler implementations.
+/// Priority: per-enqueue metadata override > handler attribute > job attribute > global RetryOptions.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class RetryAttribute : Attribute
+{
+    public RetryAttribute(int maxRetries)
+    {
+        MaxRetries = maxRetries;
+    }
+
+    public int MaxRetries { get; }
+
+    public int[]? Delays { get; set; }
+}

--- a/src/core/Jobly.Core/Helper/JobHelper.cs
+++ b/src/core/Jobly.Core/Helper/JobHelper.cs
@@ -5,9 +5,9 @@ using Jobly.Core.Handlers;
 
 namespace Jobly.Core.Helper;
 
-public static class JobHelper
+internal static class JobHelper
 {
-    private static Job CreateJobInternal(string message, string type, int retries, DateTime? scheduleTime, int? maxRetries, string? queue, Guid? parentId, State? state, DateTime now, string? concurrencyKey = null, string? metadata = null)
+    private static Job CreateJobInternal(string message, string type, DateTime? scheduleTime, string? queue, Guid? parentId, State? state, DateTime now, string? concurrencyKey = null, string? metadata = null)
     {
         var job = new Job
         {
@@ -16,7 +16,6 @@ public static class JobHelper
             Type = type,
             ScheduleTime = scheduleTime ?? now,
             CurrentState = state ?? (parentId == null ? State.Enqueued : State.Awaiting),
-            MaxRetries = maxRetries ?? retries,
             Queue = queue ?? "default",
             ParentJobId = parentId,
             ConcurrencyKey = concurrencyKey,
@@ -28,9 +27,7 @@ public static class JobHelper
 
     public static Job CreateJob<T>(
         T message,
-        int retries,
         DateTime? scheduleTime,
-        int? maxRetries,
         string? queue,
         Guid? parentId,
         State? state,
@@ -41,11 +38,12 @@ public static class JobHelper
     {
         var serializedMessage = JsonSerializer.Serialize(message);
         var type = message!.GetType().AssemblyQualifiedName!;
-        return CreateJobInternal(serializedMessage, type, retries, scheduleTime, maxRetries, queue, parentId, state, now, concurrencyKey, metadata);
+
+        return CreateJobInternal(serializedMessage, type, scheduleTime, queue, parentId, state, now, concurrencyKey, metadata);
     }
 
-    public static Job CreateJob(string message, string type, int retries, DateTime? scheduleTime, int? maxRetries, string? queue, Guid? parentId, State? state, DateTime now, string? concurrencyKey = null, string? metadata = null)
+    public static Job CreateJob(string message, string type, DateTime? scheduleTime, string? queue, Guid? parentId, State? state, DateTime now, string? concurrencyKey = null, string? metadata = null)
     {
-        return CreateJobInternal(message, type, retries, scheduleTime, maxRetries, queue, parentId, state, now, concurrencyKey, metadata);
+        return CreateJobInternal(message, type, scheduleTime, queue, parentId, state, now, concurrencyKey, metadata);
     }
 }

--- a/src/core/Jobly.Core/Helper/JobParameters.cs
+++ b/src/core/Jobly.Core/Helper/JobParameters.cs
@@ -1,4 +1,5 @@
 using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
 
 namespace Jobly.Core.Helper;
 
@@ -8,11 +9,7 @@ public class JobParameters
 
     internal string? Type { get; set; }
 
-    public int Retries { get; set; }
-
     public DateTime? ScheduleTime { get; set; }
-
-    public int? MaxRetries { get; set; }
 
     public string? Queue { get; set; }
 
@@ -23,4 +20,15 @@ public class JobParameters
     public string? Mutex { get; set; }
 
     public Dictionary<string, object>? Metadata { get; set; }
+
+    public JobParameters Configure<T>(Action<T> configure)
+        where T : class, IJobMetadata
+    {
+        Metadata ??= new Dictionary<string, object>();
+        var typed = MetadataFactory.Create<T>(Metadata);
+        configure(typed);
+        Metadata = (Dictionary<string, object>)(object)typed;
+
+        return this;
+    }
 }

--- a/src/core/Jobly.Core/Jobly.Core.csproj
+++ b/src/core/Jobly.Core/Jobly.Core.csproj
@@ -13,9 +13,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="Jobly.Worker" />
+		<InternalsVisibleTo Include="Jobly.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Cronos" Version="0.11.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Jobly.SourceGenerator\Jobly.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
 </Project>

--- a/src/core/Jobly.Core/Logging/JobExecutionContext.cs
+++ b/src/core/Jobly.Core/Logging/JobExecutionContext.cs
@@ -1,6 +1,6 @@
 namespace Jobly.Core.Logging;
 
-public class JobExecutionInfo
+internal class JobExecutionInfo
 {
     public Guid JobId { get; set; }
 
@@ -9,7 +9,7 @@ public class JobExecutionInfo
     public string? MetadataJson { get; set; }
 }
 
-public static class JobExecutionContext
+internal static class JobExecutionContext
 {
     private static readonly AsyncLocal<JobExecutionInfo?> _current = new();
 

--- a/src/core/Jobly.Core/Logging/JobLogContext.cs
+++ b/src/core/Jobly.Core/Logging/JobLogContext.cs
@@ -3,7 +3,7 @@ using Jobly.Core.Data.Entities;
 
 namespace Jobly.Core.Logging;
 
-public class JobLogCollector
+internal class JobLogCollector
 {
     public Guid JobId { get; set; }
 
@@ -38,7 +38,7 @@ public class JobLogCollector
     }
 }
 
-public static class JobLogContext
+internal static class JobLogContext
 {
     private static readonly AsyncLocal<JobLogCollector?> _current = new();
 

--- a/src/core/Jobly.Core/Models/UnifiedJobDetailModel.cs
+++ b/src/core/Jobly.Core/Models/UnifiedJobDetailModel.cs
@@ -27,10 +27,6 @@ public class UnifiedJobDetailModel
 
     public DateTime? ScheduleTime { get; set; }
 
-    public int RetriedTimes { get; set; }
-
-    public int MaxRetries { get; set; }
-
     public string? ConcurrencyKey { get; set; }
 
     // Batch-specific

--- a/src/core/Jobly.Core/Publisher.cs
+++ b/src/core/Jobly.Core/Publisher.cs
@@ -28,22 +28,10 @@ public interface IPublisher
     Task<Guid> Enqueue<T>(T job, string? queue)
         where T : class, IJob;
 
-    Task<Guid> Enqueue<T>(T job, int maxRetries)
-        where T : class, IJob;
-
-    Task<Guid> Enqueue<T>(T job, int maxRetries, string? queue)
-        where T : class, IJob;
-
     Task<Guid> Enqueue<T>(T job, Guid parentJobId)
         where T : class, IJob;
 
     Task<Guid> Enqueue<T>(T job, Guid parentJobId, string? queue)
-        where T : class, IJob;
-
-    Task<Guid> Enqueue<T>(T job, int maxRetries, Guid parentJobId)
-        where T : class, IJob;
-
-    Task<Guid> Enqueue<T>(T job, int maxRetries, Guid parentJobId, string? queue)
         where T : class, IJob;
 
     Task<Guid> Enqueue<T>(T job, JobParameters jobParameters)
@@ -55,22 +43,10 @@ public interface IPublisher
     Task<Guid> Schedule<T>(T job, DateTime scheduleTime, string? queue)
         where T : class, IJob;
 
-    Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries)
-        where T : class, IJob;
-
-    Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries, string? queue)
-        where T : class, IJob;
-
     Task<Guid> Schedule<T>(T job, DateTime scheduleTime, Guid parentJobId)
         where T : class, IJob;
 
     Task<Guid> Schedule<T>(T job, DateTime scheduleTime, Guid parentJobId, string? queue)
-        where T : class, IJob;
-
-    Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries, Guid parentJobId)
-        where T : class, IJob;
-
-    Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries, Guid parentJobId, string? queue)
         where T : class, IJob;
 
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
@@ -156,76 +132,43 @@ public class Publisher<TContext> : IPublisher
     // --- IJob: create Job rows directly ---
     public async Task<Guid> Enqueue<T>(T job)
         where T : class, IJob
-        => await CreateJob(job, null, null, null, null);
+        => await CreateJob(job, null, null, null);
 
     public async Task<Guid> Enqueue<T>(T job, string? queue)
         where T : class, IJob
-        => await CreateJob(job, null, null, queue, null);
-
-    public async Task<Guid> Enqueue<T>(T job, int maxRetries)
-        where T : class, IJob
-        => await CreateJob(job, null, maxRetries, null, null);
-
-    public async Task<Guid> Enqueue<T>(T job, int maxRetries, string? queue)
-        where T : class, IJob
-        => await CreateJob(job, null, maxRetries, queue, null);
+        => await CreateJob(job, null, queue, null);
 
     public async Task<Guid> Enqueue<T>(T job, Guid parentJobId)
         where T : class, IJob
-        => await CreateJob(job, null, null, null, parentJobId);
+        => await CreateJob(job, null, null, parentJobId);
 
     public async Task<Guid> Enqueue<T>(T job, Guid parentJobId, string? queue)
         where T : class, IJob
-        => await CreateJob(job, null, null, queue, parentJobId);
-
-    public async Task<Guid> Enqueue<T>(T job, int maxRetries, Guid parentJobId)
-        where T : class, IJob
-        => await CreateJob(job, null, maxRetries, null, parentJobId);
-
-    public async Task<Guid> Enqueue<T>(T job, int maxRetries, Guid parentJobId, string? queue)
-        where T : class, IJob
-        => await CreateJob(job, null, maxRetries, queue, parentJobId);
+        => await CreateJob(job, null, queue, parentJobId);
 
     public async Task<Guid> Enqueue<T>(T job, JobParameters jobParameters)
         where T : class, IJob
-        => await CreateJob(job, jobParameters.ScheduleTime, jobParameters.MaxRetries, jobParameters.Queue, jobParameters.ParentId, jobParameters.Mutex, jobParameters.Metadata);
+        => await CreateJob(job, jobParameters.ScheduleTime, jobParameters.Queue, jobParameters.ParentId, jobParameters.Mutex, jobParameters.Metadata);
 
     public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime)
         where T : class, IJob
-        => await CreateJob(job, scheduleTime, null, null, null);
+        => await CreateJob(job, scheduleTime, null, null);
 
     public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, string? queue)
         where T : class, IJob
-        => await CreateJob(job, scheduleTime, null, queue, null);
-
-    public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries)
-        where T : class, IJob
-        => await CreateJob(job, scheduleTime, maxRetries, null, null);
-
-    public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries, string? queue)
-        where T : class, IJob
-        => await CreateJob(job, scheduleTime, maxRetries, queue, null);
+        => await CreateJob(job, scheduleTime, queue, null);
 
     public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, Guid parentJobId)
         where T : class, IJob
-        => await CreateJob(job, scheduleTime, null, null, parentJobId);
+        => await CreateJob(job, scheduleTime, null, parentJobId);
 
     public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, Guid parentJobId, string? queue)
         where T : class, IJob
-        => await CreateJob(job, scheduleTime, null, queue, parentJobId);
-
-    public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries, Guid parentJobId)
-        where T : class, IJob
-        => await CreateJob(job, scheduleTime, maxRetries, null, parentJobId);
-
-    public async Task<Guid> Schedule<T>(T job, DateTime scheduleTime, int maxRetries, Guid parentJobId, string? queue)
-        where T : class, IJob
-        => await CreateJob(job, scheduleTime, maxRetries, queue, parentJobId);
+        => await CreateJob(job, scheduleTime, queue, parentJobId);
 
     private async Task<Guid> CreateJob<T>(
         T job,
         DateTime? scheduleTime,
-        int? maxRetries,
         string? queue,
         Guid? parentId,
         string? mutex = null,
@@ -238,9 +181,7 @@ public class Publisher<TContext> : IPublisher
 
         var newJob = JobHelper.CreateJob(
             job,
-            _configuration.RetryCount,
             scheduleTime,
-            maxRetries,
             queue,
             parentId,
             null,

--- a/src/core/Jobly.Core/Retry/IRetryMetadata.cs
+++ b/src/core/Jobly.Core/Retry/IRetryMetadata.cs
@@ -1,6 +1,6 @@
 using Jobly.Core.Handlers;
 
-namespace Jobly.Worker.Retry;
+namespace Jobly.Core.Retry;
 
 public partial interface IRetryMetadata : IJobMetadata
 {

--- a/src/core/Jobly.Core/Retry/RetryOptions.cs
+++ b/src/core/Jobly.Core/Retry/RetryOptions.cs
@@ -1,4 +1,4 @@
-namespace Jobly.Worker.Retry;
+namespace Jobly.Core.Retry;
 
 public class RetryOptions
 {

--- a/src/core/Jobly.Core/Retry/RetryPipelineBehavior.cs
+++ b/src/core/Jobly.Core/Retry/RetryPipelineBehavior.cs
@@ -1,17 +1,21 @@
+using System.Collections.Concurrent;
+using System.Reflection;
 using Jobly.Core.Enums;
 using Jobly.Core.Handlers;
 using Microsoft.Extensions.Options;
 
-namespace Jobly.Worker.Retry;
+namespace Jobly.Core.Retry;
 
 public class RetryPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
     where TRequest : IRequest<TResponse>
 {
-    private readonly IJobContext<IRetryMetadata> _jobContext;
+    private static readonly ConcurrentDictionary<Type, RetryAttribute?> AttributeCache = new();
+
+    private readonly IJobContext _jobContext;
     private readonly IOptions<RetryOptions> _options;
     private readonly TimeProvider _timeProvider;
 
-    public RetryPipelineBehavior(IJobContext<IRetryMetadata> jobContext, IOptions<RetryOptions> options, TimeProvider timeProvider)
+    public RetryPipelineBehavior(IJobContext jobContext, IOptions<RetryOptions> options, TimeProvider timeProvider)
     {
         _jobContext = jobContext;
         _options = options;
@@ -26,13 +30,14 @@ public class RetryPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
         }
         catch (Exception) when (request is IJob)
         {
-            var meta = _jobContext.Metadata;
-            var maxRetries = meta.MaxRetries ?? _options.Value.MaxRetries;
+            var meta = _jobContext.GetMetadata<IRetryMetadata>();
+            var attr = GetRetryAttribute();
+            var maxRetries = meta.MaxRetries ?? attr?.MaxRetries ?? _options.Value.MaxRetries;
             var retriedTimes = meta.RetriedTimes;
 
             if (retriedTimes < maxRetries)
             {
-                var delays = meta.RetryDelays ?? _options.Value.Delays;
+                var delays = meta.RetryDelays ?? attr?.Delays ?? _options.Value.Delays;
                 var now = _timeProvider.GetUtcNow().UtcDateTime;
                 DateTime? scheduleTime = null;
 
@@ -54,5 +59,20 @@ public class RetryPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
 
             throw;
         }
+    }
+
+    private RetryAttribute? GetRetryAttribute()
+    {
+        var handlerType = _jobContext.HandlerType;
+        if (handlerType != null)
+        {
+            var handlerAttr = AttributeCache.GetOrAdd(handlerType, static t => t.GetCustomAttribute<RetryAttribute>());
+            if (handlerAttr != null)
+            {
+                return handlerAttr;
+            }
+        }
+
+        return AttributeCache.GetOrAdd(typeof(TRequest), static t => t.GetCustomAttribute<RetryAttribute>());
     }
 }

--- a/src/core/Jobly.Core/Retry/RetryPublishBehavior.cs
+++ b/src/core/Jobly.Core/Retry/RetryPublishBehavior.cs
@@ -1,7 +1,7 @@
 using Jobly.Core.Handlers;
 using Microsoft.Extensions.Options;
 
-namespace Jobly.Worker.Retry;
+namespace Jobly.Core.Retry;
 
 public class RetryPublishBehavior<T> : IPublishPipelineBehavior<T>
 {
@@ -14,14 +14,13 @@ public class RetryPublishBehavior<T> : IPublishPipelineBehavior<T>
 
     public Task PublishAsync(PublishContext<T> context, PublishDelegate next, CancellationToken ct)
     {
-        if (!context.Metadata.ContainsKey("MaxRetries"))
-        {
-            context.Metadata["MaxRetries"] = _options.Value.MaxRetries;
-        }
+        var meta = context.GetMetadata<IRetryMetadata>();
 
-        if (_options.Value.Delays.Length > 0 && !context.Metadata.ContainsKey("RetryDelays"))
+        meta.MaxRetries ??= _options.Value.MaxRetries;
+
+        if (_options.Value.Delays.Length > 0 && meta.RetryDelays == null)
         {
-            context.Metadata["RetryDelays"] = _options.Value.Delays;
+            meta.RetryDelays = _options.Value.Delays;
         }
 
         return next();

--- a/src/core/Jobly.Core/Retry/RetryServiceConfiguration.cs
+++ b/src/core/Jobly.Core/Retry/RetryServiceConfiguration.cs
@@ -1,8 +1,7 @@
 using Jobly.Core.Handlers;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
-namespace Jobly.Worker.Retry;
+namespace Jobly.Core.Retry;
 
 public static class RetryServiceConfiguration
 {
@@ -17,7 +16,6 @@ public static class RetryServiceConfiguration
             services.AddOptions<RetryOptions>();
         }
 
-        services.TryAddScoped(typeof(IJobContext<>), typeof(JobContext<>));
         services.AddTransient(typeof(IPublishPipelineBehavior<>), typeof(RetryPublishBehavior<>));
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(RetryPipelineBehavior<,>));
 

--- a/src/core/Jobly.Core/ServiceConfiguration.cs
+++ b/src/core/Jobly.Core/ServiceConfiguration.cs
@@ -81,7 +81,6 @@ public static class ServiceConfiguration
 
         services.AddScoped<JobContext>();
         services.AddScoped<IJobContext>(x => x.GetRequiredService<JobContext>());
-        services.AddScoped(typeof(IJobContext<>), typeof(JobContext<>));
 
         return services;
     }

--- a/src/core/Jobly.Core/Services/JobQueryService.cs
+++ b/src/core/Jobly.Core/Services/JobQueryService.cs
@@ -202,8 +202,6 @@ public class JobQueryService<TContext> : IJobQueryService
                 Message = x.Message,
                 HandlerType = x.HandlerType,
                 ScheduleTime = x.ScheduleTime == DateTime.MinValue ? null : x.ScheduleTime,
-                RetriedTimes = x.RetriedTimes,
-                MaxRetries = x.MaxRetries,
                 ConcurrencyKey = x.ConcurrencyKey,
                 ContinuationOptions = x.ContinuationOptions,
                 Queue = x.Queue,

--- a/src/core/Jobly.Core/Services/RecurringJobService.cs
+++ b/src/core/Jobly.Core/Services/RecurringJobService.cs
@@ -103,7 +103,6 @@ public class RecurringJobService<TContext> : IRecurringJobService
             CreateTime = now,
             ScheduleTime = now,
             CurrentState = State.Enqueued,
-            MaxRetries = 0,
             Queue = recurringJob.Queue,
         };
 

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlFixture.cs
@@ -20,9 +20,9 @@ public class PostgreSqlFixture : IAsyncLifetime, IDatabaseFixture
 
     public JoblyTestServer? TestServer => null;
 
-    public PostgresRowLockInterceptor Interceptor { get; } = new();
+    internal PostgresRowLockInterceptor Interceptor { get; } = new();
 
-    public SaveChangesConcurrencyTokenInterceptor ConcurrencyInterceptor { get; } = new();
+    internal SaveChangesConcurrencyTokenInterceptor ConcurrencyInterceptor { get; } = new();
 
     public async ValueTask InitializeAsync()
     {

--- a/src/core/Jobly.Tests/Fixtures/SqlServerFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerFixture.cs
@@ -18,9 +18,9 @@ public class SqlServerFixture : IAsyncLifetime, IDatabaseFixture
 
     public JoblyTestServer? TestServer => null;
 
-    public SqlServerRowLockInterceptor Interceptor { get; } = new();
+    internal SqlServerRowLockInterceptor Interceptor { get; } = new();
 
-    public SaveChangesConcurrencyTokenInterceptor ConcurrencyInterceptor { get; } = new();
+    internal SaveChangesConcurrencyTokenInterceptor ConcurrencyInterceptor { get; } = new();
 
     public async ValueTask InitializeAsync()
     {

--- a/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
@@ -1,6 +1,8 @@
 using Jobly.Core.Data.Entities;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
+using Jobly.Core.Helper;
+using Jobly.Core.Retry;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Jobly.Worker.Services;
@@ -61,7 +63,7 @@ public abstract class EndToEndIntegrationTestsBase : IntegrationTestBase
         // 7. Failing jobs with retries (5, maxRetries=2)
         for (var i = 0; i < 5; i++)
         {
-            await publisher.Enqueue(new ThrowExceptionRequest(), maxRetries: 2);
+            await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 2));
         }
 
         // 8. Batch of 10 → continuation of 3

--- a/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
+++ b/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
@@ -6,7 +6,7 @@ using Jobly.Core.Handlers;
 using Jobly.Core.Services;
 using Jobly.Tests.Fixtures;
 using Jobly.Worker;
-using Jobly.Worker.Retry;
+using Jobly.Core.Retry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/core/Jobly.Tests/Integration/MultiServerTests.cs
+++ b/src/core/Jobly.Tests/Integration/MultiServerTests.cs
@@ -2,6 +2,7 @@ using Jobly.Core.Data.Entities;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
 using Jobly.Core.Helper;
+using Jobly.Core.Retry;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Jobly.Worker.Services;
@@ -288,7 +289,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         // 5. Failing jobs with retries (3, maxRetries=2)
         for (var i = 0; i < 3; i++)
         {
-            await publisher.Enqueue(new ThrowExceptionRequest(), maxRetries: 2);
+            await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 2));
         }
 
         // 6. Batch of 10 → continuation of 3

--- a/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
@@ -3,6 +3,7 @@ using Jobly.Core.Handlers;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
 using Jobly.Core.Helper;
+using Jobly.Core.Retry;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Microsoft.EntityFrameworkCore;
@@ -37,7 +38,7 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
     public async Task GivenFailingJobWithThreeRetries_WhenProcessed_ThenRetriesThreeTimesThenFails()
     {
         var publisher = Server.CreatePublisher();
-        var jobId = await publisher.Enqueue(new ThrowExceptionRequest(), maxRetries: 3);
+        var jobId = await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 3));
         await publisher.SaveChangesAsync();
 
         await Server.WaitForJobState(jobId, State.Failed, timeout: TimeSpan.FromSeconds(30));
@@ -46,7 +47,6 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
 
         var job = await ctx.Set<Job>().FirstAsync(j => j.Id == jobId);
         job.CurrentState.ShouldBe(State.Failed);
-        job.MaxRetries.ShouldBe(3);
         GetRetriedTimes(job).ShouldBe(3);
 
         // Should have 1 initial attempt + 3 retries = 4 "Processing" log entries
@@ -71,7 +71,6 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
         var publisher = Server.CreatePublisher();
         var jobId = await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters
         {
-            MaxRetries = 0,
             Metadata = new Dictionary<string, object> { ["MaxRetries"] = 0 },
         });
         await publisher.SaveChangesAsync();
@@ -82,7 +81,6 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
 
         var job = await ctx.Set<Job>().FirstAsync(j => j.Id == jobId);
         job.CurrentState.ShouldBe(State.Failed);
-        job.MaxRetries.ShouldBe(0);
         GetRetriedTimes(job).ShouldBe(0);
 
         // Should have exactly 1 "Processing" log entry (the single attempt)
@@ -107,9 +105,8 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
         var publisher = Server.CreatePublisher();
         var jobId = await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters
         {
-            MaxRetries = 1,
             Metadata = new Dictionary<string, object> { ["MaxRetries"] = 1 },
-        });
+        }.Configure<IRetryMetadata>(m => m.MaxRetries = 1));
         await publisher.SaveChangesAsync();
 
         await Server.WaitForJobState(jobId, State.Failed, timeout: TimeSpan.FromSeconds(30));

--- a/src/core/Jobly.Tests/TestData/Handlers/RetryAttributeCommands.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/RetryAttributeCommands.cs
@@ -1,0 +1,52 @@
+using Jobly.Core.Handlers;
+
+namespace Jobly.Tests.TestData.Handlers;
+
+// Handler with [Retry] attribute
+[Retry(5)]
+public class RetryAttributeHandlerCommand : IJobHandler<RetryAttributeHandlerRequest>
+{
+    public Task HandleAsync(RetryAttributeHandlerRequest message, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Always fails");
+    }
+}
+
+public class RetryAttributeHandlerRequest : IJob;
+
+// Job class with [Retry] attribute, handler without attribute
+public class RetryAttributeJobCommand : IJobHandler<RetryAttributeJobRequest>
+{
+    public Task HandleAsync(RetryAttributeJobRequest message, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Always fails");
+    }
+}
+
+[Retry(4)]
+public class RetryAttributeJobRequest : IJob;
+
+// Both handler and job have [Retry] — handler should win
+[Retry(7)]
+public class RetryAttributeBothCommand : IJobHandler<RetryAttributeBothRequest>
+{
+    public Task HandleAsync(RetryAttributeBothRequest message, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Always fails");
+    }
+}
+
+[Retry(2)]
+public class RetryAttributeBothRequest : IJob;
+
+// Handler with [Retry] that includes custom delays
+[Retry(3, Delays = [100, 200, 300])]
+public class RetryAttributeWithDelaysCommand : IJobHandler<RetryAttributeWithDelaysRequest>
+{
+    public Task HandleAsync(RetryAttributeWithDelaysRequest message, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Always fails");
+    }
+}
+
+public class RetryAttributeWithDelaysRequest : IJob;

--- a/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
+++ b/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
@@ -9,7 +9,7 @@ using Jobly.Core.Logging;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Jobly.Worker;
-using Jobly.Worker.Retry;
+using Jobly.Core.Retry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
@@ -27,106 +27,6 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Enqueue_WithMaxRetries_SetsMaxRetriesOnJob()
-    {
-        // Arrange
-        var ctx = _fixture.CreateContext();
-        var publisher = CreatePublisher(ctx);
-
-        // Act
-        var id = await publisher.Enqueue(new UnitRequest(), 5);
-        await ctx.SaveChangesAsync();
-
-        // Assert
-        var readCtx = _fixture.CreateContext();
-        var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
-        job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(5);
-    }
-
-    [Fact]
-    public async Task Enqueue_WithMaxRetriesAndQueue_SetsBothFields()
-    {
-        // Arrange
-        var ctx = _fixture.CreateContext();
-        var publisher = CreatePublisher(ctx);
-
-        // Act
-        var id = await publisher.Enqueue(new UnitRequest(), 3, "critical");
-        await ctx.SaveChangesAsync();
-
-        // Assert
-        var readCtx = _fixture.CreateContext();
-        var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
-        job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(3);
-        job.Queue.ShouldBe("critical");
-    }
-
-    [Fact]
-    public async Task Enqueue_WithMaxRetriesAndParent_SetsBothFields()
-    {
-        // Arrange
-        var ctx = _fixture.CreateContext();
-        var publisher = CreatePublisher(ctx);
-        var parentId = Guid.NewGuid();
-
-        ctx.Set<Job>().Add(new Job
-        {
-            Id = parentId,
-            Kind = JobKind.Batch,
-            CurrentState = State.Awaiting,
-            CreateTime = DateTime.UtcNow,
-            ScheduleTime = DateTime.UtcNow,
-            Queue = "default",
-        });
-        await ctx.SaveChangesAsync();
-
-        // Act
-        var id = await publisher.Enqueue(new UnitRequest(), 3, parentId);
-        await ctx.SaveChangesAsync();
-
-        // Assert
-        var readCtx = _fixture.CreateContext();
-        var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
-        job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(3);
-        job.ParentJobId.ShouldBe(parentId);
-    }
-
-    [Fact]
-    public async Task Enqueue_WithAllParameters_SetsAllFields()
-    {
-        // Arrange
-        var ctx = _fixture.CreateContext();
-        var publisher = CreatePublisher(ctx);
-        var parentId = Guid.NewGuid();
-
-        ctx.Set<Job>().Add(new Job
-        {
-            Id = parentId,
-            Kind = JobKind.Batch,
-            CurrentState = State.Awaiting,
-            CreateTime = DateTime.UtcNow,
-            ScheduleTime = DateTime.UtcNow,
-            Queue = "default",
-        });
-        await ctx.SaveChangesAsync();
-
-        // Act
-        var id = await publisher.Enqueue(new UnitRequest(), 3, parentId, "critical");
-        await ctx.SaveChangesAsync();
-
-        // Assert
-        var readCtx = _fixture.CreateContext();
-        var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
-        job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(3);
-        job.ParentJobId.ShouldBe(parentId);
-        job.Queue.ShouldBe("critical");
-    }
-
-    [Fact]
     public async Task Enqueue_WithJobParameters_SetsAllFields()
     {
         // Arrange
@@ -148,7 +48,6 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
 
         var jobParams = new JobParameters
         {
-            MaxRetries = 7,
             Queue = "high-priority",
             ParentId = parentId,
             ScheduleTime = futureTime,
@@ -162,29 +61,8 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
         var readCtx = _fixture.CreateContext();
         var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
         job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(7);
         job.Queue.ShouldBe("high-priority");
         job.ParentJobId.ShouldBe(parentId);
-        job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));
-    }
-
-    [Fact]
-    public async Task Schedule_WithMaxRetries_SetsScheduleTimeAndRetries()
-    {
-        // Arrange
-        var ctx = _fixture.CreateContext();
-        var publisher = CreatePublisher(ctx);
-        var futureTime = DateTime.UtcNow.AddHours(2);
-
-        // Act
-        var id = await publisher.Schedule(new UnitRequest(), futureTime, 3);
-        await ctx.SaveChangesAsync();
-
-        // Assert
-        var readCtx = _fixture.CreateContext();
-        var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
-        job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(3);
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));
     }
 
@@ -242,7 +120,7 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Schedule_WithAllParameters_SetsAllFields()
+    public async Task Schedule_WithParentAndQueue_SetsAllFields()
     {
         // Arrange
         var ctx = _fixture.CreateContext();
@@ -262,14 +140,13 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
 
         // Act
-        var id = await publisher.Schedule(new UnitRequest(), futureTime, 3, parentId, "critical");
+        var id = await publisher.Schedule(new UnitRequest(), futureTime, parentId, "critical");
         await ctx.SaveChangesAsync();
 
         // Assert
         var readCtx = _fixture.CreateContext();
         var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
         job.ShouldNotBeNull();
-        job.MaxRetries.ShouldBe(3);
         job.ParentJobId.ShouldBe(parentId);
         job.Queue.ShouldBe("critical");
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));

--- a/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
@@ -8,7 +8,7 @@ using Jobly.Core.Services;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Jobly.Worker;
-using Jobly.Worker.Retry;
+using Jobly.Core.Retry;
 using Jobly.Worker.Services;
 using Medallion.Threading;
 using Microsoft.EntityFrameworkCore;

--- a/src/core/Jobly.Tests/Unit/RetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetryTests.cs
@@ -7,7 +7,7 @@ using Jobly.Core.Handlers;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Jobly.Worker;
-using Jobly.Worker.Retry;
+using Jobly.Core.Retry;
 using Jobly.Worker.Services;
 using Medallion.Threading;
 using Microsoft.EntityFrameworkCore;
@@ -130,7 +130,6 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 3,
         });
         await ctx.SaveChangesAsync();
 
@@ -147,7 +146,6 @@ public abstract class RetryTestsBase : IAsyncLifetime
         var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
         job.CurrentState.ShouldBe(State.Failed);
         GetRetriedTimes(job).ShouldBe(3);
-        job.MaxRetries.ShouldBe(3);
     }
 
     [Fact]
@@ -166,7 +164,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 0,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -198,7 +196,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 2,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -240,7 +238,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 3,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -285,7 +283,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = now,
             ScheduleTime = now,
             Queue = "default",
-            MaxRetries = 1,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -317,7 +315,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 3,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -360,7 +358,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = originalScheduleTime,
             ScheduleTime = originalScheduleTime,
             Queue = "default",
-            MaxRetries = 1,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -392,7 +390,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 1,
+
         });
         await ctx.SaveChangesAsync();
 
@@ -429,7 +427,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = now,
             ScheduleTime = now,
             Queue = "default",
-            MaxRetries = 1,
+
             Metadata = metadata,
         });
         await ctx.SaveChangesAsync();
@@ -466,7 +464,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            MaxRetries = 0,
+
             Metadata = metadata,
         });
         await ctx.SaveChangesAsync();
@@ -485,6 +483,180 @@ public abstract class RetryTestsBase : IAsyncLifetime
         var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
         job.CurrentState.ShouldBe(State.Failed);
         GetRetriedTimes(job).ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_WithRetryAttributeOnHandler_UsesAttributeMaxRetries()
+    {
+        // Arrange — handler has [Retry(5)], global has 0
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(RetryAttributeHandlerRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new RetryAttributeHandlerRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 0);
+
+        // Act — process once, should be requeued (attribute says 5 retries)
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.CurrentState.ShouldBe(State.Enqueued);
+        GetRetriedTimes(job).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_WithRetryAttributeOnJob_UsesAttributeMaxRetries()
+    {
+        // Arrange — job class has [Retry(4)], global has 0
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(RetryAttributeJobRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new RetryAttributeJobRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 0);
+
+        // Act — process once, should be requeued (attribute says 4 retries)
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.CurrentState.ShouldBe(State.Enqueued);
+        GetRetriedTimes(job).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_WithRetryAttributeOnBothHandlerAndJob_HandlerWins()
+    {
+        // Arrange — handler has [Retry(7)], job has [Retry(2)], global has 0
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(RetryAttributeBothRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new RetryAttributeBothRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 0);
+
+        // Act — exhaust all retries from handler attribute (7)
+        for (var i = 0; i < 8; i++)
+        {
+            var resetCtx = _fixture.CreateContext();
+            await resetCtx.Set<Job>()
+                .Where(x => x.Id == jobId)
+                .Where(x => x.CurrentState == State.Enqueued)
+                .ExecuteUpdateAsync(x => x.SetProperty(p => p.ScheduleTime, DateTime.UtcNow));
+
+            await worker.GetAndProcessJob(CancellationToken.None);
+        }
+
+        // Assert — should have used handler's 7 retries (not job's 2)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.CurrentState.ShouldBe(State.Failed);
+        GetRetriedTimes(job).ShouldBe(7);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_MetadataOverridesRetryAttribute()
+    {
+        // Arrange — handler has [Retry(5)], but metadata overrides to 1
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var metadata = JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["MaxRetries"] = 1,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(RetryAttributeHandlerRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new RetryAttributeHandlerRequest()),
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            Metadata = metadata,
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 0);
+
+        // Act — process twice (1 initial + 1 retry from metadata)
+        for (var i = 0; i < 2; i++)
+        {
+            await worker.GetAndProcessJob(CancellationToken.None);
+        }
+
+        // Assert — should have used metadata's 1 retry (not handler attribute's 5)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.CurrentState.ShouldBe(State.Failed);
+        GetRetriedTimes(job).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetAndProcessJob_WithRetryAttributeDelays_UsesAttributeDelays()
+    {
+        // Arrange — handler has [Retry(3, Delays = [100, 200, 300])]
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(RetryAttributeWithDelaysRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new RetryAttributeWithDelaysRequest()),
+            CreateTime = now,
+            ScheduleTime = now,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        // Global has 10s delay, attribute has 100s
+        var worker = CreateWorker(maxRetries: 0, delays: [10]);
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert — should use attribute's 100s delay (not global 10s)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.CurrentState.ShouldBe(State.Enqueued);
+        job.ScheduleTime.ShouldBeGreaterThan(now.AddSeconds(90));
     }
 }
 

--- a/src/core/Jobly.Tests/Unit/TypedMetadataTests.cs
+++ b/src/core/Jobly.Tests/Unit/TypedMetadataTests.cs
@@ -1,7 +1,8 @@
 using System.Text.Json;
 using Jobly.Core.Handlers;
+using Jobly.Core.Helper;
 using Jobly.Tests.TestData.Handlers;
-using Jobly.Worker.Retry;
+using Jobly.Core.Retry;
 using Shouldly;
 
 namespace Jobly.Tests.Unit;
@@ -100,7 +101,7 @@ public class TypedMetadataTests
     }
 
     [Fact]
-    public void TypedView_ReplacesDictOnJobContext_SameObject()
+    public void JobContext_GetMetadata_WritesFlowToUnderlyingDictionary()
     {
         var jobContext = new JobContext
         {
@@ -108,14 +109,12 @@ public class TypedMetadataTests
             Metadata = new Dictionary<string, object> { ["MaxRetries"] = 5 },
         };
 
-        // Simulate what JobContext<T> does
-        var typed = MetadataFactory.Create<IRetryMetadata>(jobContext.Metadata);
-        jobContext.Metadata = (Dictionary<string, object>)(object)typed;
+        var typed = jobContext.GetMetadata<IRetryMetadata>();
 
-        // Typed and raw are the same object
+        // Typed view IS the underlying dictionary
         ReferenceEquals(jobContext.Metadata, typed).ShouldBeTrue();
 
-        // Read via typed
+        // Read existing value
         typed.MaxRetries.ShouldBe(5);
 
         // Write via typed, read via raw
@@ -125,6 +124,28 @@ public class TypedMetadataTests
         // Write via raw, read via typed
         jobContext.Metadata["MaxRetries"] = 10;
         typed.MaxRetries.ShouldBe(10);
+    }
+
+    [Fact]
+    public void PublishContext_GetMetadata_WritesFlowToUnderlyingDictionary()
+    {
+        var context = new PublishContext<object>
+        {
+            Job = new object(),
+            Metadata = new Dictionary<string, object> { ["TestKey"] = "existing" },
+        };
+
+        var typed = context.GetMetadata<ITestMetadata>();
+
+        // Typed view IS the underlying dictionary
+        ReferenceEquals(context.Metadata, typed).ShouldBeTrue();
+
+        // Existing value preserved
+        typed.TestKey.ShouldBe("existing");
+
+        // Write via typed, read via raw
+        typed.TestCount = 42;
+        context.Metadata["TestCount"].ShouldBe(42);
     }
 
     [Fact]
@@ -141,5 +162,37 @@ public class TypedMetadataTests
         json.ShouldContain("\"MaxRetries\":3");
         json.ShouldContain("\"RetriedTimes\":1");
         json.ShouldContain("\"RetryDelays\":[15,60]");
+    }
+
+    [Fact]
+    public void JobParameters_Configure_ChainedCalls_PreservesAllMetadata()
+    {
+        var parameters = new JobParameters()
+            .Configure<IRetryMetadata>(m => m.MaxRetries = 10)
+            .Configure<ITestMetadata>(m =>
+            {
+                m.TestKey = "hello";
+                m.TestCount = 42;
+            });
+
+        parameters.Metadata.ShouldNotBeNull();
+        parameters.Metadata["MaxRetries"].ShouldBe(10);
+        parameters.Metadata["TestKey"].ShouldBe("hello");
+        parameters.Metadata["TestCount"].ShouldBe(42);
+    }
+
+    [Fact]
+    public void JobParameters_Configure_SingleCall_SetsMetadata()
+    {
+        var parameters = new JobParameters()
+            .Configure<IRetryMetadata>(m =>
+            {
+                m.MaxRetries = 5;
+                m.RetryDelays = [15, 60];
+            });
+
+        parameters.Metadata.ShouldNotBeNull();
+        parameters.Metadata["MaxRetries"].ShouldBe(5);
+        parameters.Metadata["RetryDelays"].ShouldBe(new int[] { 15, 60 });
     }
 }

--- a/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
@@ -335,15 +335,20 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
         var messageType = Type.GetType(job.Type!) ?? throw new JoblyException($"Unknown type {job.Type}");
         var payload = JsonSerializer.Deserialize(job.Message!, messageType) ?? throw new JoblyException($"Unable to deserialize message {job.Message} to type {job.Type}");
 
+        var jobContext = provider.GetRequiredService<JobContext>();
+
         if (job.HandlerType != null)
         {
             var handlerType = Type.GetType(job.HandlerType) ?? throw new JoblyException($"Unknown handler type {job.HandlerType}");
+            jobContext.HandlerType = handlerType;
             await JobDispatcher.ExecuteHandler(payload, messageType, handlerType, provider, cancellationToken);
+
             return;
         }
 
         var jobHandlerType = JobDispatcher.DiscoverJobHandler(messageType, provider) ?? throw new JoblyException($"No handler registered for {messageType.Name}");
         job.HandlerType = jobHandlerType.AssemblyQualifiedName;
+        jobContext.HandlerType = jobHandlerType;
         await JobDispatcher.ExecuteJobHandler(payload, messageType, jobHandlerType, provider, cancellationToken);
     }
 

--- a/src/core/Jobly.Worker/JoblyWorkerService.cs
+++ b/src/core/Jobly.Worker/JoblyWorkerService.cs
@@ -357,15 +357,20 @@ public class JoblyWorkerService<TContext> : IJoblyWorkerService
         var messageType = Type.GetType(job.Type!) ?? throw new JoblyException($"Unknown type {job.Type}");
         var payload = JsonSerializer.Deserialize(job.Message!, messageType) ?? throw new JoblyException($"Unable to deserialize message {job.Message} to type {job.Type}");
 
+        var jobContext = provider.GetRequiredService<JobContext>();
+
         if (job.HandlerType != null)
         {
             var handlerType = Type.GetType(job.HandlerType) ?? throw new JoblyException($"Unknown handler type {job.HandlerType}");
+            jobContext.HandlerType = handlerType;
             await JobDispatcher.ExecuteHandler(payload, messageType, handlerType, provider, cancellationToken);
+
             return;
         }
 
         var jobHandlerType = JobDispatcher.DiscoverJobHandler(messageType, provider) ?? throw new JoblyException($"No handler registered for {messageType.Name}");
         job.HandlerType = jobHandlerType.AssemblyQualifiedName;
+        jobContext.HandlerType = jobHandlerType;
         await JobDispatcher.ExecuteJobHandler(payload, messageType, jobHandlerType, provider, cancellationToken);
     }
 

--- a/src/core/Jobly.Worker/Services/MessageRoutingTask.cs
+++ b/src/core/Jobly.Worker/Services/MessageRoutingTask.cs
@@ -101,9 +101,7 @@ public class MessageRoutingTask<TContext> : ServerTaskBase<TContext>
                 var job = JobHelper.CreateJob(
                     message: message.Message!,
                     type: message.Type!,
-                    retries: 0,
                     scheduleTime: null,
-                    maxRetries: 0,
                     queue: message.Queue,
                     parentId: message.Id,
                     state: State.Enqueued,

--- a/src/core/Jobly.Worker/Services/RecurringJobSchedulerTask.cs
+++ b/src/core/Jobly.Worker/Services/RecurringJobSchedulerTask.cs
@@ -87,9 +87,7 @@ public class RecurringJobSchedulerTask<TContext> : ServerTaskBase<TContext>
             var newJob = JobHelper.CreateJob(
                 message: recurringJob.Message!,
                 type: recurringJob.Type!,
-                retries: 0,
                 scheduleTime: now,
-                maxRetries: 0,
                 queue: recurringJob.Queue,
                 parentId: null,
                 state: State.Enqueued,

--- a/src/tests/Jobly.TestApp/Program.cs
+++ b/src/tests/Jobly.TestApp/Program.cs
@@ -4,6 +4,7 @@ using Jobly.Core.Entities;
 using Jobly.Core.Enums;
 using Jobly.Core.Handlers;
 using Jobly.Core.Helper;
+using Jobly.Core.Retry;
 using Jobly.Test.Shared;
 using Jobly.UI;
 using Jobly.UI.UIMiddleware;
@@ -28,9 +29,9 @@ builder.Services.AddCors(options =>
         policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
 });
 
+builder.Services.AddJoblyRetry(o => o.MaxRetries = 3);
 builder.Services.AddJoblyWorker<TestContext>(options =>
 {
-    options.RetryCount = 3;
     options.WorkerCount = 10;
     options.ServerName = "jobly-demo-server";
     options.DefaultQueue = "default";
@@ -105,7 +106,7 @@ app.MapPost("/seed", async (IPublisher publisher, IBatchPublisher batchPublisher
     // === Failing jobs with retries (shows retry lifecycle) ===
     for (var i = 0; i < 10; i++)
     {
-        await publisher.Enqueue(new ThrowExceptionRequest(), maxRetries: 3, queue: queues[random.Next(queues.Length)]);
+        await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters { Queue = queues[random.Next(queues.Length)] }.Configure<IRetryMetadata>(m => m.MaxRetries = 3));
     }
 
     // === Continuations (parent → child chains) ===
@@ -231,7 +232,7 @@ app.MapPost("/seed-flow", async (IPublisher publisher, IBatchPublisher batchPubl
     var simpleJobId = await publisher.Enqueue(new SendEmailRequest { EmailLogId = 1 });
 
     // 2. Simple failing job (shows retries + failed state)
-    var failingJobId = await publisher.Enqueue(new ThrowExceptionRequest(), maxRetries: 2);
+    var failingJobId = await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 2));
 
     // 3. Job → 3 continuation jobs (fan-out, creates trace via handler spawning)
     var fanOutId = await publisher.Enqueue(new RegisterRequest { Email = "flow-parent@test.com" });
@@ -308,7 +309,7 @@ app.MapPost("/seed/simple-job", async (IPublisher publisher) =>
 
 app.MapPost("/seed/failing-job", async (IPublisher publisher) =>
 {
-    var id = await publisher.Enqueue(new ThrowExceptionRequest(), maxRetries: 2);
+    var id = await publisher.Enqueue(new ThrowExceptionRequest(), new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 2));
     await publisher.SaveChangesAsync();
     return Results.Ok(new { detail = $"/jobly/detail/{id}" });
 });

--- a/src/tests/Jobly.TestWorker/Program.cs
+++ b/src/tests/Jobly.TestWorker/Program.cs
@@ -1,4 +1,5 @@
 using Jobly.Core;
+using Jobly.Core.Retry;
 using Jobly.Test.Shared;
 using Jobly.Worker;
 
@@ -6,10 +7,10 @@ var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices((context, services) =>
     {
         services.AddServices(context.Configuration);
+        services.AddJoblyRetry(o => o.MaxRetries = 3);
         services.AddJoblyWorker<TestContext>(options =>
         {
             options.WorkerCount = 10;
-            options.RetryCount = 3;
             options.PollingInterval = TimeSpan.FromSeconds(5);
         });
     })

--- a/website/docs/features/metadata.md
+++ b/website/docs/features/metadata.md
@@ -44,13 +44,14 @@ public class ProcessOrderHandler : IJobHandler<ProcessOrder>
 }
 ```
 
-`IJobContext` extends `IJobMetadata` and provides:
+`IJobContext` provides:
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `JobId` | `Guid` | The current job's ID |
 | `TraceId` | `Guid` | The trace ID (shared across related jobs) |
-| `Metadata` | `IReadOnlyDictionary<string, string>` | Key-value metadata attached to the job |
+| `Metadata` | `Dictionary<string, object>` | Key-value metadata attached to the job |
+| `GetMetadata<T>()` | `T` | Returns a typed metadata view (T must implement IJobMetadata) |
 
 ## Publish Pipeline Behaviors
 
@@ -84,7 +85,8 @@ The `PublishContext<T>` passed to publish pipeline behaviors contains:
 | Property | Type | Description |
 |----------|------|-------------|
 | `Job` | `T` | The job/message being published |
-| `Metadata` | `Dictionary<string, string>` | Mutable metadata dictionary — add or modify entries here |
+| `Metadata` | `Dictionary<string, object>` | Mutable metadata dictionary — add or modify entries here |
+| `GetMetadata<TMeta>()` | `TMeta` | Returns a typed metadata view for strongly-typed writes |
 
 ## Metadata Inheritance
 

--- a/website/docs/operations/configuration.md
+++ b/website/docs/operations/configuration.md
@@ -12,7 +12,6 @@ Used by the publisher side (`AddJobly<TContext>`):
 builder.Services.AddJobly<AppDbContext>(options =>
 {
     options.Schema = "jobly";      // Database schema for all Jobly tables (default: "jobly", null for default schema)
-    options.RetryCount = 3;        // Default max retries for new jobs (default: 0)
     options.DefaultQueue = "default"; // Queue name when none specified (default: "default")
     options.JobExpirationTimeout = TimeSpan.FromDays(1); // How long completed/deleted jobs kept (default: 1 day)
 });
@@ -21,7 +20,6 @@ builder.Services.AddJobly<AppDbContext>(options =>
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `Schema` | `string?` | `"jobly"` | Database schema for all Jobly tables. Set to `null` for the database's default schema. |
-| `RetryCount` | `int` | `0` | Default max retries for jobs that don't specify their own |
 | `DefaultQueue` | `string` | `"default"` | Queue used when no queue is specified at publish time |
 | `JobExpirationTimeout` | `TimeSpan` | `1 day` | How long completed/deleted jobs are kept before cleanup. Failed jobs never expire. |
 
@@ -36,6 +34,25 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 ```
 
 This produces tables like `jobly.job`, `jobly.job_log`, `jobly.server`, etc.
+
+## Retry Configuration
+
+Configure retry behavior with `AddJoblyRetry()`:
+
+```csharp
+services.AddJoblyRetry(options =>
+{
+    options.MaxRetries = 3;               // Default max retries (default: 0)
+    options.Delays = [15, 60, 300];       // Retry delays in seconds (default: [15, 60, 300])
+});
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `MaxRetries` | `int` | `0` | Default max retries when no `[Retry]` attribute is present |
+| `Delays` | `int[]` | `[15, 60, 300]` | Delay in seconds between retries. Last value is reused if fewer delays than retries |
+
+Per-job override via `[Retry]` attribute on handler or job class, or per-enqueue via metadata. See [Jobs](/docs/patterns/jobs#retries).
 
 ## Worker Configuration (`JoblyWorkerConfiguration`)
 
@@ -78,7 +95,6 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
     options.ExpirationCleanupInterval = TimeSpan.FromSeconds(60);
 
     // Inherited from JoblyConfiguration
-    options.RetryCount = 3;
     options.DefaultQueue = "default";
 });
 ```

--- a/website/docs/patterns/jobs.md
+++ b/website/docs/patterns/jobs.md
@@ -37,9 +37,44 @@ await publisher.Schedule(new GenerateReport { ReportId = 1 }, DateTime.UtcNow.Ad
 
 ## Retries
 
+Declare retry policy on the handler:
+
 ```csharp
-await publisher.Enqueue(new GenerateReport { ReportId = 1 }, maxRetries: 3);
+[Retry(3)]
+public class GenerateReportHandler : IJobHandler<GenerateReport>
+{
+    // ...
+}
 ```
+
+Or on the job class:
+
+```csharp
+[Retry(3, Delays = [15, 60, 300])]
+public class GenerateReport : IJob
+{
+    public int ReportId { get; set; }
+}
+```
+
+Override per-enqueue via metadata:
+
+```csharp
+await publisher.Enqueue(new GenerateReport { ReportId = 1 },
+    new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 5));
+```
+
+Configure global defaults:
+
+```csharp
+services.AddJoblyRetry(o =>
+{
+    o.MaxRetries = 3;
+    o.Delays = [15, 60, 300]; // seconds
+});
+```
+
+Priority: per-enqueue metadata > handler attribute > job attribute > global `RetryOptions`.
 
 Failed jobs are retried automatically. Crash requeues (server died mid-execution) do **not** count against the retry limit.
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -218,11 +218,20 @@ await publisher.SaveChangesAsync();
 
 ### Retries
 
+Declare retry policy on the handler or job class:
+
 ```csharp
-await publisher.Enqueue(new GenerateReport { ReportId = 1 }, maxRetries: 3);
+[Retry(3, Delays = [15, 60, 300])]
+public class GenerateReportHandler : IJobHandler<GenerateReport> { ... }
 ```
 
-Failed jobs are retried automatically. Crash requeues (server died mid-execution) do NOT count against the retry limit.
+Or configure global defaults:
+
+```csharp
+services.AddJoblyRetry(o => { o.MaxRetries = 3; o.Delays = [15, 60, 300]; });
+```
+
+Priority: per-enqueue metadata > handler attribute > job attribute > global RetryOptions. Failed jobs are retried automatically. Crash requeues do NOT count against the retry limit.
 
 ### Named queues
 
@@ -688,7 +697,6 @@ The `RunJobMonitor` task runs alongside each handler execution, periodically dra
 builder.Services.AddJobly<AppDbContext>(options =>
 {
     options.Schema = "jobly";                                  // Database schema (default: "jobly", null for default)
-    options.RetryCount = 3;                                    // Default max retries (default: 0)
     options.DefaultQueue = "default";                          // Default queue name (default: "default")
     options.JobExpirationTimeout = TimeSpan.FromDays(1);       // Completed/deleted job retention (default: 1 day)
 });
@@ -736,7 +744,6 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
     options.ExpirationCleanupInterval = TimeSpan.FromSeconds(60);
 
     // Inherited from JoblyConfiguration
-    options.RetryCount = 3;
     options.DefaultQueue = "default";
 });
 ```


### PR DESCRIPTION
## Summary

- Move retry from a publisher concern to a handler/execution concern with `[Retry(N)]` attribute and typed metadata overrides
- Remove all retry knowledge from Core's publisher API (`maxRetries` overloads, `JoblyConfiguration.RetryCount`, `JobParameters.MaxRetries`)
- Unify metadata access with `GetMetadata<T>()` on both `IJobContext` and `PublishContext<T>` (removes `IJobContext<T>` / `JobContext<T>`)
- Move retry code to `Jobly.Core.Retry` namespace — ships with Core, uses only public APIs
- Make internal: `JobHelper`, `JobDispatcher`, `MetadataSerializer`, interceptors, execution context plumbing
- Update all documentation, tests, and test apps

**Priority chain:** per-enqueue metadata > `[Retry]` on handler > `[Retry]` on job class > `RetryOptions` global

## Test plan

- [x] 430 PostgreSQL tests pass (verified locally)
- [x] Verify `[Retry]` attribute on handler works (5 dedicated tests)
- [x] Verify `GetMetadata<T>()` on `JobContext` and `PublishContext` (2 dedicated tests)
- [x] Verify `JobParameters.Configure<T>()` chaining (2 dedicated tests)
- [x] Verify full priority chain: metadata > handler attr > job attr > global (6 tests)
- [x] Grep for stale `RetryCount`, `maxRetries:`, `IJobContext<`, `Jobly.Worker.Retry` — zero hits
- [x] Run SQL Server tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)