### PR TITLE
Add global 10-second test timeout

### DIFF
--- a/docs/TUnit.md
+++ b/docs/TUnit.md
@@ -1,0 +1,55 @@
+# TUnit Evaluation (2026-04-15)
+
+We evaluated migrating from xUnit v3 to TUnit v1.33.0. After a full side-by-side comparison with all 767 tests ported and passing, we decided **not to switch**. This document captures the findings for future reference.
+
+## Why We Stayed on xUnit
+
+- **No performance benefit** — test execution times were identical (~1m 33s for 767 tests). Both frameworks are dominated by Testcontainers startup and database I/O, not framework overhead.
+- **Slower builds** — TUnit's source generator adds ~5s to clean builds (16s vs 11s).
+- **Larger binaries** — test assembly 2.9 MB vs 1.1 MB; output directory 96 MB vs 51 MB.
+- **More verbose syntax** — `[ClassDataSource<T>(Shared = SharedType.Keyed, Key = "...")]` + `[NotInParallel("...")]` vs xUnit's `[Collection<T>]`.
+- **Required `[InheritsTests]`** on all 128 concrete subclasses — TUnit's source generator doesn't auto-discover inherited `[Test]` methods.
+- **`[Retry]` name collision** — TUnit has its own `[Retry]` attribute that conflicts with Jobly's `[Retry]`.
+- **Activity.Current interference** — TUnit creates an `Activity` per test for tracing, which broke 10 tests that assert on ambient `Activity.Current` state. Fixable with save/restore, but adds boilerplate.
+- **TUnit's unique features (Native AOT, `[DependsOn]`, `[Retry]`, `[ParallelLimiter]`)** are not needed by this project.
+
+## What We Did Instead
+
+Added `TimedFactAttribute` / `TimedTheoryAttribute` with a default 10-second timeout — the one TUnit feature we wanted. See `src/core/Jobly.Tests/TestData/TimedFactAttribute.cs`.
+
+## Benchmark Results
+
+| Metric | xUnit v3 (3.2.2) | TUnit (1.33.0) |
+|--------|:-:|:-:|
+| Tests discovered | 767 | 767 |
+| Tests passed | 767/767 | 767/767 |
+| Build time (clean) | **11.3s** | 16.0s |
+| Test execution (767 tests) | **~1m 34s** | ~1m 36s |
+| Test discovery | **17.5s** | 31.5s |
+| Test assembly size | **1.1 MB** | 2.9 MB |
+| Output directory | **51 MB** | 96 MB |
+
+## Migration Mapping Reference
+
+If we revisit this in the future, here's the attribute mapping:
+
+| xUnit | TUnit |
+|-------|-------|
+| `[Fact]` | `[Test]` |
+| `[Theory]` | `[Test]` |
+| `[InlineData(...)]` | `[Arguments(...)]` |
+| `[Trait("k", "v")]` | `[Property("k", "v")]` |
+| `[Collection<T>]` | `[ClassDataSource<T>(Shared = SharedType.Keyed, Key = "...")]` + `[NotInParallel("...")]` |
+| `[CollectionDefinition]` + `ICollectionFixture<T>` | Not needed (delete) |
+| `IAsyncLifetime` (fixtures) | `IAsyncInitializer` + `IAsyncDisposable` |
+| `IAsyncLifetime` (test classes) | `[Before(HookType.Test)]` + `[After(HookType.Test)]` |
+| Inherited tests from abstract base | Add `[InheritsTests]` to concrete class |
+| `--filter-not-trait "Category=SqlServer"` | `-- --treenode-filter "/*/*/*/*[Category!=SqlServer]"` |
+
+### Key Gotchas
+
+1. **`IAsyncInitializer.InitializeAsync()`** returns `Task`, not `ValueTask` like xUnit's `IAsyncLifetime`.
+2. **TUnit runs everything in parallel by default**, including tests sharing a fixture. Must add `[NotInParallel("key")]` to prevent Respawn corruption.
+3. **TUnit creates an `Activity` per test** — tests asserting `Activity.Current == null` need `Activity.Current = null` save/restore.
+4. **TUnitMigrator CLI tool** requires Central Package Management — didn't work for us.
+5. **TUnit produces HTML test reports automatically** — one nice feature we'd lose by staying on xUnit.

--- a/src/core/Jobly.Tests/Integration/BatchIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/BatchIntegrationTests.cs
@@ -15,7 +15,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenBatchOfFive_WhenAllComplete_ThenBatchFinalizes()
     {
         var batchPublisher = Server.CreateBatchPublisher();
@@ -41,7 +41,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
         childJobs.ShouldAllBe(j => j.CurrentState == State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenBatchWithContinuation_WhenFirstBatchCompletes_ThenContinuationActivatesAndCompletes()
     {
         var batchPublisher = Server.CreateBatchPublisher();
@@ -75,7 +75,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
         continuationChildren.ShouldAllBe(j => j.CurrentState == State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenThreeChainedBatches_WhenProcessed_ThenAllComplete()
     {
         var batchPublisher = Server.CreateBatchPublisher();
@@ -107,7 +107,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
         batch3.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenBatchWithOnAnyFinishedState_WhenSomeJobsFail_ThenContinuationStillFires()
     {
         var batchPublisher = Server.CreateBatchPublisher();
@@ -144,7 +144,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
         continuationChildren.ShouldAllBe(j => j.CurrentState == State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenBatchWithOnlyOnSucceeded_WhenJobFails_ThenContinuationStaysAwaiting()
     {
         var batchPublisher = Server.CreateBatchPublisher();
@@ -185,7 +185,7 @@ public abstract class BatchIntegrationTestsBase : IntegrationTestBase
         continuationChildren.ShouldAllBe(j => j.CurrentState == State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenBatchWithRetryJobs_WhenRetriesExhausted_ThenBatchReflectsOutcome()
     {
         var batchPublisher = Server.CreateBatchPublisher();

--- a/src/core/Jobly.Tests/Integration/CancellationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/CancellationIntegrationTests.cs
@@ -14,7 +14,7 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenDeleted_ThenHandlerIsCancelledAndLoggedAsCancelled()
     {
         var publisher = Server.CreatePublisher();
@@ -36,7 +36,7 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
         job.CurrentState.ShouldBe(State.Deleted);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenDeleted_ThenCancellationModeIsSetToGraceful()
     {
         var publisher = Server.CreatePublisher();
@@ -60,7 +60,7 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
         cancellationLog.WorkerId.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenDeleted_ThenWorkerLogsHaveWorkerId()
     {
         var publisher = Server.CreatePublisher();
@@ -85,7 +85,7 @@ public abstract class CancellationIntegrationTestsBase : IntegrationTestBase
         cancelledLog.WorkerId.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenDeleted_ThenCompletesQuicklyNotAfterFullDuration()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/ConcurrencyEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Integration/ConcurrencyEdgeCaseTests.cs
@@ -15,7 +15,7 @@ public abstract class ConcurrencyEdgeCaseTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenConcurrentDeleteOnSameJob_ThenOnlyOneDeleteRecorded()
     {
         // Arrange — enqueue a job and wait for it to complete
@@ -63,7 +63,7 @@ public abstract class ConcurrencyEdgeCaseTestsBase : IntegrationTestBase
         // Either way, there should be exactly 1 successful delete
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenConcurrentRequeueOnSameJob_ThenStateConsistent()
     {
         // Arrange — enqueue a job and wait for it to complete

--- a/src/core/Jobly.Tests/Integration/ConcurrencyIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ConcurrencyIntegrationTests.cs
@@ -15,7 +15,7 @@ public abstract class ConcurrencyIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenFiftyCounterJobs_WithFiveWorkers_ThenAllProcessedExactlyOnce()
     {
         // The test server runs with 5 workers. Enqueue 50 counter jobs.
@@ -55,7 +55,7 @@ public abstract class ConcurrencyIntegrationTestsBase : IntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenSingleJob_WithFiveWorkers_ThenOnlyOneProcessesIt()
     {
         var publisher = Server.CreatePublisher();
@@ -79,7 +79,7 @@ public abstract class ConcurrencyIntegrationTestsBase : IntegrationTestBase
         completedLogs.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenFiveMessages_WithFiveWorkers_ThenAllRoutedExactlyOnce()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/ContinuationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ContinuationIntegrationTests.cs
@@ -15,7 +15,7 @@ public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenParentJob_WhenCompletes_ThenChildActivatesAndCompletes()
     {
         var publisher = Server.CreatePublisher();
@@ -35,7 +35,7 @@ public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
         child.ParentJobId.ShouldBe(parentId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenParentJobThatFails_WhenDefaultOnlyOnSucceeded_ThenChildStaysAwaiting()
     {
         var publisher = Server.CreatePublisher();
@@ -59,7 +59,7 @@ public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
         child.CurrentState.ShouldBe(State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenParentJobThatFails_WithOnAnyFinishedState_ThenChildStillActivates()
     {
         // Use batch publisher to create a batch with OnAnyFinishedState continuation,
@@ -93,7 +93,7 @@ public abstract class ContinuationIntegrationTestsBase : IntegrationTestBase
         continuationChildren.ShouldAllBe(j => j.CurrentState == State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenThreeLevelContinuationChain_WhenProcessed_ThenAllComplete()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/EndToEndIntegrationTests.cs
@@ -18,7 +18,7 @@ public abstract class EndToEndIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenComplexWorkload_WhenProcessedByRealWorkers_ThenAllJobsReachTerminalState()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/MessageIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MessageIntegrationTests.cs
@@ -15,7 +15,7 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenSingleHandlerMessage_WhenPublished_ThenMessageCompletesAndHandlerExecutes()
     {
         var publisher = Server.CreatePublisher();
@@ -39,7 +39,7 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
         handlerJobs[0].CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMultiHandlerMessage_WhenPublished_ThenBothHandlersExecuteAndMessageCompletes()
     {
         var publisher = Server.CreatePublisher();
@@ -62,7 +62,7 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
         handlerJobs.ShouldAllBe(j => j.CurrentState == State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMessageWithQueue_WhenPublished_ThenChildrenInheritQueue()
     {
         var publisher = Server.CreatePublisher();
@@ -83,7 +83,7 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
         handlerJobs[0].Queue.ShouldBe("a-critical");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMultipleMessages_WhenPublished_ThenAllRouteAndComplete()
     {
         var publisher = Server.CreatePublisher();
@@ -112,7 +112,7 @@ public abstract class MessageIntegrationTestsBase : IntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMessageWithFailingHandler_WhenProcessed_ThenMessageStillCompletesWithFailedJobs()
     {
         // MultiRequest has 2 handlers. We can't make only one fail easily,

--- a/src/core/Jobly.Tests/Integration/MetadataIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MetadataIntegrationTests.cs
@@ -16,7 +16,7 @@ public abstract class MetadataIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PublishJob_WithPublishPipeline_MetadataPersistedAndAvailableInHandler()
     {
         var publisher = Server.CreatePublisher();
@@ -39,7 +39,7 @@ public abstract class MetadataIntegrationTestsBase : IntegrationTestBase
         capture.CapturedMetadata["source"].ShouldBe("publish-pipeline");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PublishMessage_MetadataInheritedByRoutedChildJobs()
     {
         var publisher = Server.CreatePublisher();
@@ -63,7 +63,7 @@ public abstract class MetadataIntegrationTestsBase : IntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BatchPublish_AllChildrenGetSameMetadata()
     {
         var batchPublisher = Server.CreateBatchPublisher();

--- a/src/core/Jobly.Tests/Integration/MetadataPropagationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MetadataPropagationIntegrationTests.cs
@@ -17,7 +17,7 @@ public abstract class MetadataPropagationIntegrationTestsBase : IntegrationTestB
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenHandlerThatWritesMetadata_WhenCompleted_ThenHandlerMetadataPersisted()
     {
         var publisher = Server.CreatePublisher();
@@ -36,7 +36,7 @@ public abstract class MetadataPropagationIntegrationTestsBase : IntegrationTestB
         metadata["HandlerWrote"].ShouldBe("from-handler");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenPublishPipelineAndHandler_WhenCompleted_ThenBothMetadataKeysPersisted()
     {
         // RetryPublishBehavior sets MaxRetries at publish time
@@ -62,7 +62,7 @@ public abstract class MetadataPropagationIntegrationTestsBase : IntegrationTestB
         metadata["HandlerWrote"].ShouldBe("from-handler");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenUserMetadataAtPublishTime_WhenCompleted_ThenUserMetadataPreserved()
     {
         var publisher = Server.CreatePublisher();
@@ -92,7 +92,7 @@ public abstract class MetadataPropagationIntegrationTestsBase : IntegrationTestB
         metadata.ShouldContainKey("HandlerWrote");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenFailingJobWithRetry_WhenFailed_ThenRetryMetadataPersisted()
     {
         var publisher = Server.CreatePublisher();
@@ -119,7 +119,7 @@ public abstract class MetadataPropagationIntegrationTestsBase : IntegrationTestB
         Convert.ToInt32(metadata["RetriedTimes"]).ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenChildJobSpawnedByHandler_WhenCompleted_ThenChildInheritsParentMetadata()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/MultiServerTests.cs
+++ b/src/core/Jobly.Tests/Integration/MultiServerTests.cs
@@ -18,7 +18,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenManyJobs_WithTwoServers_ThenEachJobProcessedExactlyOnce()
     {
         var publisher = Server1.CreatePublisher();
@@ -67,7 +67,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMessages_WithTwoServers_ThenEachRoutedExactlyOnce()
     {
         var publisher = Server1.CreatePublisher();
@@ -102,7 +102,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMultiHandlerMessage_WithTwoServers_ThenCorrectChildCount()
     {
         var publisher = Server1.CreatePublisher();
@@ -135,7 +135,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenBatch_WithTwoServers_ThenBatchCompletesCorrectly()
     {
         var batchPublisher = Server1.CreateBatchPublisher();
@@ -186,7 +186,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         continuationChildren.ShouldAllBe(x => x.CurrentState == State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenContinuations_WithTwoServers_ThenContinuationsActivateAndExecute()
     {
         var publisher = Server1.CreatePublisher();
@@ -223,7 +223,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMutexJobs_WithTwoServers_ThenMutexEnforcedAcrossServers()
     {
         // Enqueue a slow job that holds the mutex — published via Server1
@@ -256,7 +256,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         await Server1.WaitForJobState(job1Id, State.Deleted, timeout: TimeSpan.FromSeconds(15));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenComplexWorkload_WithTwoServers_ThenAllReachTerminalState()
     {
         var publisher = Server1.CreatePublisher();
@@ -377,7 +377,7 @@ public abstract class MultiServerTestsBase : MultiServerIntegrationTestBase
         statsFailed.ShouldBe(failedJobs, "stats:failed should match failed job count");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenPausedServer_WithTwoServers_ThenOtherServerProcessesJobs()
     {
         // Get Server1's worker group and pause it

--- a/src/core/Jobly.Tests/Integration/MutexIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/MutexIntegrationTests.cs
@@ -15,7 +15,7 @@ public abstract class MutexIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenTwoJobsWithSameMutex_WhenProcessed_ThenSecondIsCancelled()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/PauseIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/PauseIntegrationTests.cs
@@ -23,7 +23,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         return group.Id;
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseServer_PauseStateHolder_UpdatedByHeartbeat()
     {
         var groupId = await GetFirstGroupId();
@@ -38,7 +38,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         await Server.WaitForPauseState(groupId, expectedPaused: false);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseServer_JobsStayEnqueued()
     {
         var groupId = await GetFirstGroupId();
@@ -67,7 +67,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         await Server.WaitForCompletion();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseServer_Resume_JobsGetProcessed()
     {
         var groupId = await GetFirstGroupId();
@@ -89,7 +89,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         job.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseWorkerGroup_JobsStayEnqueued()
     {
         var groupId = await GetFirstGroupId();
@@ -118,7 +118,7 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         await Server.WaitForCompletion();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseWorkerGroup_Resume_JobsGetProcessed()
     {
         var groupId = await GetFirstGroupId();

--- a/src/core/Jobly.Tests/Integration/RealTimeLogIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RealTimeLogIntegrationTests.cs
@@ -14,7 +14,7 @@ public abstract class RealTimeLogIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenHandlerLogs_ThenLogsAppearInDbBeforeCompletion()
     {
         var publisher = Server.CreatePublisher();
@@ -47,7 +47,7 @@ public abstract class RealTimeLogIntegrationTestsBase : IntegrationTestBase
         await Server.WaitForJobLog(jobId, "Cancelled", timeout: TimeSpan.FromSeconds(15));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenHandlerLogs_ThenLogLevelsArePreserved()
     {
         var publisher = Server.CreatePublisher();
@@ -71,7 +71,7 @@ public abstract class RealTimeLogIntegrationTestsBase : IntegrationTestBase
         await Server.WaitForJobLog(jobId, "Cancelled", timeout: TimeSpan.FromSeconds(15));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenProcessingJob_WhenCancelledBeforeFlush_ThenHandlerLogsArePreserved()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/RetryIntegrationTests.cs
@@ -34,7 +34,7 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
         return 0;
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenFailingJobWithThreeRetries_WhenProcessed_ThenRetriesThreeTimesThenFails()
     {
         var publisher = Server.CreatePublisher();
@@ -65,7 +65,7 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
         failedLogs.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenFailingJobWithZeroRetries_WhenProcessed_ThenFailsImmediately()
     {
         var publisher = Server.CreatePublisher();
@@ -99,7 +99,7 @@ public abstract class RetryIntegrationTestsBase : IntegrationTestBase
         failedLogs.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenFailingJobWithRetries_WhenProcessed_ThenScheduleTimeUpdatedOnRetry()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/ScopeIsolationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/ScopeIsolationIntegrationTests.cs
@@ -17,7 +17,7 @@ public abstract class ScopeIsolationIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenHandlerThatAddsEntityAndThrows_WhenProcessed_ThenEntityNotPersisted()
     {
         var publisher = Server.CreatePublisher();
@@ -36,7 +36,7 @@ public abstract class ScopeIsolationIntegrationTestsBase : IntegrationTestBase
         leaked.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenHandlerThatAddsEntitySavesAndThrows_WhenProcessed_ThenEntityPersisted()
     {
         var publisher = Server.CreatePublisher();
@@ -55,7 +55,7 @@ public abstract class ScopeIsolationIntegrationTestsBase : IntegrationTestBase
         committed.ShouldBeTrue();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenHandlerThatAddsEntityAndThrows_WithRetry_ThenEntityNotPersisted()
     {
         var publisher = Server.CreatePublisher();
@@ -83,7 +83,7 @@ public abstract class ScopeIsolationIntegrationTestsBase : IntegrationTestBase
         job.CurrentState.ShouldBe(State.Failed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenSuccessfulHandler_WhenChildJobPublished_ThenChildJobPersisted()
     {
         var publisher = Server.CreatePublisher();
@@ -100,7 +100,7 @@ public abstract class ScopeIsolationIntegrationTestsBase : IntegrationTestBase
         childJobs.Count.ShouldBeGreaterThan(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenSuccessfulHandler_WhenMetadataModifiedByPipeline_ThenMetadataPersisted()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/TraceIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/TraceIntegrationTests.cs
@@ -15,7 +15,7 @@ public abstract class TraceIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenSpawnChildJobRequest_WhenProcessed_ThenChildInheritsParentTraceId()
     {
         var publisher = Server.CreatePublisher();
@@ -37,7 +37,7 @@ public abstract class TraceIntegrationTestsBase : IntegrationTestBase
         child.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenSpawnGrandchildJobRequest_WhenProcessed_ThenThreeLevelChainSharesTraceId()
     {
         var publisher = Server.CreatePublisher();
@@ -68,7 +68,7 @@ public abstract class TraceIntegrationTestsBase : IntegrationTestBase
         leaf.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenMultiHandlerMessage_WhenRouted_ThenAllHandlerJobsShareSameTraceId()
     {
         var publisher = Server.CreatePublisher();
@@ -90,7 +90,7 @@ public abstract class TraceIntegrationTestsBase : IntegrationTestBase
         handlerJobs.ShouldAllBe(j => j.TraceId == message.TraceId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenTwoSeparateJobs_WhenPublished_ThenEachHasDifferentTraceId()
     {
         var publisher = Server.CreatePublisher();

--- a/src/core/Jobly.Tests/Integration/TracePropagationIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/TracePropagationIntegrationTests.cs
@@ -14,7 +14,7 @@ public abstract class TracePropagationIntegrationTestsBase : IntegrationTestBase
     {
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenJobThatSpawnsChild_ThenChildHasSpawnedByJobId()
     {
         // Arrange
@@ -36,7 +36,7 @@ public abstract class TracePropagationIntegrationTestsBase : IntegrationTestBase
         child.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenJobThatSpawnsBatch_ThenBatchJobsHaveTraceId()
     {
         // Arrange
@@ -66,7 +66,7 @@ public abstract class TracePropagationIntegrationTestsBase : IntegrationTestBase
         batchChildren.ShouldAllBe(j => j.TraceId == traceId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GivenJobThatSpawnsBatch_ThenBatchJobsHaveSpawnedByJobId()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Jobly.Tests.csproj
+++ b/src/core/Jobly.Tests/Jobly.Tests.csproj
@@ -41,6 +41,7 @@
 
 	<ItemGroup>
 		<Using Include="Xunit" />
+		<Using Include="Jobly.Tests.TestData" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/core/Jobly.Tests/TestData/TimedFactAttribute.cs
+++ b/src/core/Jobly.Tests/TestData/TimedFactAttribute.cs
@@ -1,0 +1,17 @@
+namespace Jobly.Tests.TestData;
+
+public class TimedFactAttribute : FactAttribute
+{
+    public TimedFactAttribute(int timeout = 10_000)
+    {
+        Timeout = timeout;
+    }
+}
+
+public class TimedTheoryAttribute : TheoryAttribute
+{
+    public TimedTheoryAttribute(int timeout = 10_000)
+    {
+        Timeout = timeout;
+    }
+}

--- a/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ActivityTraceTests.cs
@@ -97,7 +97,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         return (worker, capture);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_JobWithTraceId_ActivityHasMatchingTraceId()
     {
         // Arrange
@@ -127,7 +127,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         capture.TraceId.ShouldBe(traceId.ToString("N"));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_JobWithTraceId_ActivityHasNonEmptySpanId()
     {
         // Arrange
@@ -157,7 +157,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         capture.SpanId.ShouldNotBe("0000000000000000");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_JobWithoutTraceId_ActivityUsesJobIdAsTraceId()
     {
         // Arrange
@@ -186,7 +186,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         capture.TraceId.ShouldBe(jobId.ToString("N"));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_JobWithParentSpanId_ActivityHasMatchingParentId()
     {
         // Arrange
@@ -217,7 +217,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         capture.ParentSpanId.ShouldBe(parentSpanId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_JobWithoutParentSpanId_ActivityHasEmptyParentId()
     {
         // Arrange
@@ -247,7 +247,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         capture.ParentSpanId.ShouldBe("0000000000000000");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_AfterExecution_ActivityIsCleared()
     {
         // Arrange
@@ -276,7 +276,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         Activity.Current.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_HandlerThrows_ActivityIsCleared()
     {
         // Arrange
@@ -305,7 +305,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         Activity.Current.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_TwoJobs_EachGetsUniqueSpanId()
     {
         // Arrange
@@ -355,7 +355,7 @@ public abstract class ActivityTraceTestsBase : IAsyncLifetime
         firstSpanId.ShouldNotBe(secondSpanId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_Completed_ActivityHasMessagingAttributes()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/AuditFixRound2Tests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixRound2Tests.cs
@@ -28,7 +28,7 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
     /// RequeueJob on a Processing job should not set it to Enqueued (would cause double execution).
     /// It should either refuse or treat it as cancellation.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_WhenProcessing_DoesNotSetEnqueued()
     {
         var ctx = _fixture.CreateContext();
@@ -60,7 +60,7 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
     /// When a parent is Deleted, its Awaiting children should be cleaned up (Deleted).
     /// Otherwise they can never run.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task Orchestration_WhenParentDeleted_AwaitingChildrenAreFailed()
     {
         var ctx = _fixture.CreateContext();
@@ -103,7 +103,7 @@ public abstract class AuditFixRound2TestsBase : IAsyncLifetime
     /// When a parent fails with OnlyOnSucceeded, Awaiting continuations stay Awaiting.
     /// The parent could be requeued and succeed later.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task Orchestration_WhenParentFailedOnlyOnSucceeded_AwaitingContinuationsAreDeleted()
     {
         var ctx = _fixture.CreateContext();

--- a/src/core/Jobly.Tests/Unit/AuditFixRound3Tests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixRound3Tests.cs
@@ -24,7 +24,7 @@ public abstract class AuditFixRound3TestsBase : IAsyncLifetime
     /// <summary>
     /// Count-based cleanup must not delete parents whose children haven't expired.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task CountBasedCleanup_SkipsParentsWithNonExpiredChildren()
     {
         // Arrange: 5 standalone expired jobs + 1 parent with non-expired child
@@ -87,7 +87,7 @@ public abstract class AuditFixRound3TestsBase : IAsyncLifetime
     /// RequeueJob on a child should lock the parent row to prevent concurrent OrchestrationTask race.
     /// Verify that parent state is correctly set after requeue.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_LocksParentRow_ParentStateCorrect()
     {
         // Arrange: batch with 2 failed children, parent finalized as Failed

--- a/src/core/Jobly.Tests/Unit/AuditFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixTests.cs
@@ -35,7 +35,7 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
     /// If a job has CancellationMode=Graceful (user called DeleteJob), stale recovery
     /// should set it to Deleted, NOT requeue it.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task StaleRecovery_WithCancellationModeGraceful_SetsDeletedNotEnqueued()
     {
         // Arrange: a processing job with CancellationMode=Graceful and stale keep-alive
@@ -72,7 +72,7 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
     /// The real race is hard to reproduce in a unit test, but we can verify the parent's
     /// state is correctly set after requeue of a child whose parent was already finalized.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_WhenParentIsCompleted_SetsParentBackToAwaitingOrProcessing()
     {
         // Arrange: a batch with one completed child and a finalized parent
@@ -124,7 +124,7 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
     /// HIGH: No JobLog when message routing finds 0 handlers.
     /// Messages marked Failed should have a log explaining why.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task MessageRouting_NoHandlers_CreatesFailedLogEntry()
     {
         // Arrange: a message with a type that has no registered handlers

--- a/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
@@ -19,7 +19,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     // --- CounterAggregatorTask ---
-    [Fact]
+    [TimedFact]
     public async Task AggregateCounters_SumsCountersIntoStatistics()
     {
         // Arrange
@@ -44,7 +44,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
         failed.Value.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task AggregateCounters_DeletesProcessedCounters()
     {
         // Arrange
@@ -64,7 +64,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
     }
 
     // --- ExpirationCleanupTask ---
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_DeletesExpiredJobs()
     {
         // Arrange
@@ -92,7 +92,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
         job.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_KeepsNonExpiredJobs()
     {
         // Arrange
@@ -120,7 +120,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
         job.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_KeepsFailedJobsWithoutExpireAt()
     {
         // Arrange
@@ -149,7 +149,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
     }
 
     // --- StaleJobRecoveryTask ---
-    [Fact]
+    [TimedFact]
     public async Task StaleJobRecovery_RequeuesStaleJobs()
     {
         // Arrange
@@ -179,7 +179,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StaleJobRecovery_KeepsFreshJobs()
     {
         // Arrange
@@ -210,7 +210,7 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
     }
 
     // --- ServerCleanupTask ---
-    [Fact]
+    [TimedFact]
     public async Task ServerCleanup_RemovesDeadServers()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/BatchPublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/BatchPublisherTests.cs
@@ -25,7 +25,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         return new BatchPublisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StartNew_CreatesBatchKindJobWithProcessingState()
     {
         // Arrange
@@ -45,7 +45,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         batch.CurrentState.ShouldBe(State.Processing);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StartNew_CreatesChildJobsWithEnqueuedState()
     {
         // Arrange
@@ -66,7 +66,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         children.ShouldAllBe(c => c.CurrentState == State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StartNew_SetsJobCountOnBatch()
     {
         // Arrange
@@ -85,7 +85,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         batch.JobCount.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ContinueBatchWith_CreatesBatchWithParentId()
     {
         // Arrange
@@ -110,7 +110,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         continuation.Kind.ShouldBe(JobKind.Batch);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ContinueBatchWith_ChildrenAreAwaiting()
     {
         // Arrange
@@ -135,7 +135,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         children.ShouldAllBe(c => c.CurrentState == State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StartNew_WithName_SetsTypeField()
     {
         // Arrange
@@ -154,7 +154,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         batch.Type.ShouldBe("MyBatchName");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ContinueBatchWith_InheritsParentTrace_SameContext()
     {
         // Arrange: parent and continuation batch in same context (not committed yet)
@@ -179,7 +179,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         children.ShouldAllBe(c => c.TraceId == parent.TraceId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ContinueBatchWith_InheritsParentTrace_SeparateContext()
     {
         // Arrange: parent already committed
@@ -207,7 +207,7 @@ public abstract class BatchPublisherUnitTestsBase : IAsyncLifetime
         children.ShouldAllBe(c => c.TraceId == parent.TraceId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StartNew_GetsOwnTrace()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/BugFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/BugFixTests.cs
@@ -26,7 +26,7 @@ public abstract class BugFixTestsBase : IAsyncLifetime
     /// BUG: Expiration cleanup fails with FK violation when parent job has ExpireAt
     /// but child jobs still reference it via ParentJobId.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_ParentWithChildren_DoesNotThrowFkViolation()
     {
         // Arrange: parent with ExpireAt in the past, child referencing it
@@ -74,7 +74,7 @@ public abstract class BugFixTestsBase : IAsyncLifetime
     /// BUG: Expiration cleanup fails when parent is expired but child is not yet expired.
     /// Parent can't be deleted because child still references it.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_ParentExpiredChildNot_DoesNotThrowFkViolation()
     {
         // Arrange: parent expired, child NOT expired (still has future ExpireAt)
@@ -125,7 +125,7 @@ public abstract class BugFixTestsBase : IAsyncLifetime
     /// <summary>
     /// BUG: JobModel doesn't include HandlerType. Job lists should show handler info.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task GetJobsList_IncludesHandlerType()
     {
         // Arrange: create a job with a handler type

--- a/src/core/Jobly.Tests/Unit/CancellationModeTests.cs
+++ b/src/core/Jobly.Tests/Unit/CancellationModeTests.cs
@@ -20,7 +20,7 @@ public abstract class CancellationModeTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_WhenProcessing_SetsCancellationModeGraceful()
     {
         // Arrange
@@ -53,7 +53,7 @@ public abstract class CancellationModeTestsBase : IAsyncLifetime
         logs.ShouldContain(l => l.EventType == "CancellationRequested");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_WhenNotProcessing_SetsStateToDeleted()
     {
         // Arrange
@@ -83,7 +83,7 @@ public abstract class CancellationModeTestsBase : IAsyncLifetime
         job.ExpireAt.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_WhenFailed_SetsStateToDeleted()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
@@ -18,7 +18,7 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task RunCountBasedCleanup_WhenOverThreshold_DeletesOldestByExpireAt()
     {
         // Arrange
@@ -51,7 +51,7 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
         remaining.ShouldBe(20);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCountBasedCleanup_WhenUnderThreshold_DeletesNothing()
     {
         // Arrange
@@ -84,7 +84,7 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
         remaining.ShouldBe(15);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCountBasedCleanup_BatchesCorrectly()
     {
         // Arrange
@@ -122,7 +122,7 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
         earliestRemaining.Value.ShouldBeGreaterThanOrEqualTo(DateTime.UtcNow.AddHours(9));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCountBasedCleanup_ExcludesJobsWithNullExpireAt()
     {
         // Arrange
@@ -183,7 +183,7 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
         totalRemaining.ShouldBe(30);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCountBasedCleanup_DeletesAssociatedJobLogs()
     {
         // Arrange — insert 25 jobs (5 over threshold of 20), with logs on the 5 oldest

--- a/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
@@ -18,7 +18,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueStaleJobs_MultipleStaleJobs_AllRequeued()
     {
         // Arrange — insert 5 stale Processing jobs
@@ -56,7 +56,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueStaleJobs_NonProcessingJobs_NotAffected()
     {
         // Arrange — insert jobs in Completed, Failed, and Enqueued states with old keepalive
@@ -113,7 +113,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         (await readCtx.Set<Job>().FirstAsync(j => j.Id == enqueuedId)).CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueStaleJobs_StaleJob_RetriedTimesNotIncremented()
     {
         // Arrange
@@ -144,7 +144,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         job.RetriedTimes.ShouldBe(2); // Unchanged
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueStaleJobs_ConcurrentCalls_OnlyOnceRequeued()
     {
         // Arrange
@@ -179,7 +179,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         logs.Count.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CleanUpServers_DeadServerWithProcessingJob_JobStateUnchanged()
     {
         // Arrange
@@ -226,7 +226,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Processing); // Unchanged — StaleJobRecovery handles this
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CleanUpServers_CombinedRecovery_JobsRequeuedAndServerCleaned()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/DashboardAuthTests.cs
+++ b/src/core/Jobly.Tests/Unit/DashboardAuthTests.cs
@@ -38,7 +38,7 @@ public class DashboardAuthTests
         return (app, app.GetTestClient());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task NoAuth_ApiReturnsOk()
     {
         var (app, client) = await CreateApp();
@@ -54,7 +54,7 @@ public class DashboardAuthTests
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BuiltInLogin_ApiReturns401WithoutCookie()
     {
         var (app, client) = await CreateApp(o => o.UseBuiltInLogin<TestCredentialValidator>());
@@ -70,7 +70,7 @@ public class DashboardAuthTests
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BuiltInLogin_ValidCredentials_Returns200AndSetsCookie()
     {
         var (app, client) = await CreateApp(o => o.UseBuiltInLogin<TestCredentialValidator>());
@@ -93,7 +93,7 @@ public class DashboardAuthTests
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BuiltInLogin_InvalidCredentials_Returns401()
     {
         var (app, client) = await CreateApp(o => o.UseBuiltInLogin<TestCredentialValidator>());
@@ -114,7 +114,7 @@ public class DashboardAuthTests
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BuiltInLogin_WithCookie_ApiReturnsOk()
     {
         var (app, client) = await CreateApp(o => o.UseBuiltInLogin<TestCredentialValidator>());
@@ -143,7 +143,7 @@ public class DashboardAuthTests
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CustomAuthFilter_Unauthorized_Returns401ForApi()
     {
         var (app, client) = await CreateApp(o => o.Authorization = new DenyAllFilter());
@@ -159,7 +159,7 @@ public class DashboardAuthTests
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CustomAuthFilter_WithRedirectUrl_RedirectsForSpa()
     {
         var (app, client) = await CreateApp(o =>

--- a/src/core/Jobly.Tests/Unit/DashboardBreakdownTests.cs
+++ b/src/core/Jobly.Tests/Unit/DashboardBreakdownTests.cs
@@ -31,7 +31,7 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
         };
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_CountsMessagesByState()
     {
         // Arrange
@@ -63,7 +63,7 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
         status.MessagesFailed.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_CountsBatchesByState()
     {
         // Arrange
@@ -99,7 +99,7 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
         status.Batches.ShouldBe(4); // excludes deleted
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_CountsJobStates()
     {
         // Arrange
@@ -129,7 +129,7 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
         status.Deleted.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_ExcludesNonJobKindFromJobCounts()
     {
         // Arrange — only insert Message + Batch kinds, no Job kind
@@ -154,7 +154,7 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
         status.Failed.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_CombinesStatisticAndCounterValues()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/DistributedLockRegistrationTests.cs
+++ b/src/core/Jobly.Tests/Unit/DistributedLockRegistrationTests.cs
@@ -11,7 +11,7 @@ namespace Jobly.Tests.Unit;
 
 public class DistributedLockRegistrationTests
 {
-    [Fact]
+    [TimedFact]
     public void AddJoblyWorker_PostgreSql_ResolvesPostgresLockProvider()
     {
         var services = new ServiceCollection();
@@ -24,7 +24,7 @@ public class DistributedLockRegistrationTests
         provider.ShouldBeOfType<PostgresDistributedSynchronizationProvider>();
     }
 
-    [Fact]
+    [TimedFact]
     public void AddJoblyWorker_SqlServer_ResolvesSqlServerLockProvider()
     {
         var services = new ServiceCollection();
@@ -46,7 +46,7 @@ public class DistributedLockRegistrationTests
     /// Poison the TestContext registration so any attempt to resolve it throws.
     /// The fix must succeed without ever resolving a DbContext.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public void AddJoblyWorker_PostgreSql_ResolvesFromOptionsExtension_NotFromContext()
     {
         var services = new ServiceCollection();
@@ -65,7 +65,7 @@ public class DistributedLockRegistrationTests
     /// <summary>
     /// Same as above but for SQL Server.
     /// </summary>
-    [Fact]
+    [TimedFact]
     public void AddJoblyWorker_SqlServer_ResolvesFromOptionsExtension_NotFromContext()
     {
         var services = new ServiceCollection();
@@ -81,7 +81,7 @@ public class DistributedLockRegistrationTests
         provider.ShouldBeOfType<SqlDistributedSynchronizationProvider>();
     }
 
-    [Fact]
+    [TimedFact]
     public void AddJoblyWorker_OptionsExtensionPreservesPassword_AfterJoblyWrapsOptions()
     {
         const string connectionString = "Host=localhost;Database=test;Username=user;Password=secret123";
@@ -98,7 +98,7 @@ public class DistributedLockRegistrationTests
         extension.ConnectionString.ShouldBe(connectionString);
     }
 
-    [Fact]
+    [TimedFact]
     public void AddJoblyWorker_PostgreSql_LockProviderCreatesLock()
     {
         var services = new ServiceCollection();

--- a/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
@@ -51,7 +51,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCleanup_OldHourlyStats_Deleted()
     {
         // Arrange — use stats:failed: prefix because the cleanup uses a lexicographic comparison
@@ -73,7 +73,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         stat.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCleanup_RecentHourlyStats_Kept()
     {
         // Arrange
@@ -95,7 +95,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         stat.Value.ShouldBe(7);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCleanup_OldServerLogs_DeletedBasedOnTaskInterval()
     {
         // Arrange — insert a ServerTask with 60s interval, retention = 60 * 300 = 18000 seconds
@@ -134,7 +134,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         log.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCleanup_RecentServerLogs_Kept()
     {
         // Arrange
@@ -173,7 +173,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         log.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunCleanup_OrphanedServerLogs_DeletedAfterOneDay()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/FailedJobTypeFilterTests.cs
+++ b/src/core/Jobly.Tests/Unit/FailedJobTypeFilterTests.cs
@@ -21,7 +21,7 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task GetFailedJobTypeCounts_ReturnsCorrectGroupings()
     {
         // Arrange
@@ -80,7 +80,7 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
         result[2].Count.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetFailedJobTypeCounts_ExcludesNonFailedJobs()
     {
         // Arrange
@@ -131,7 +131,7 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
         result[0].Count.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetFailedJobsByType_ReturnsOnlyMatchingType()
     {
         // Arrange
@@ -176,7 +176,7 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
         result.Items.ShouldAllBe(j => j.Type == "TypeA");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteFailedJobsByType_DeletesAllMatchingJobs()
     {
         // Arrange
@@ -230,7 +230,7 @@ public abstract class FailedJobTypeFilterTestsBase : IAsyncLifetime
         remainingTypeB.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueFailedJobsByType_RequeuesAllMatchingJobs()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/HandlerLogTests.cs
@@ -92,7 +92,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_HandlerWithLogging_LogsAreCaptured()
     {
         // Arrange
@@ -127,7 +127,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         logs.ShouldContain(l => l.Message.Contains("This is a warning", StringComparison.Ordinal));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_HandlerWithLogging_LogsHaveCorrectLevel()
     {
         // Arrange
@@ -164,7 +164,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         warningLog.Level.ShouldBe("Warning");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_HandlerThatThrows_LogsBeforeErrorAreCaptured()
     {
         // Arrange
@@ -200,7 +200,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         handlerLogs.ShouldContain(l => l.Message.Contains("About to fail", StringComparison.Ordinal));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_TwoJobs_LogsDoNotLeak()
     {
         // Arrange — create two logging jobs
@@ -260,7 +260,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         logs2.ShouldContain(l => l.Message.Contains("About to fail", StringComparison.Ordinal));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_HandlerLoggingDisabled_HandlerLogsNotWritten()
     {
         // Arrange
@@ -294,7 +294,7 @@ public abstract class HandlerLogTestsBase : IAsyncLifetime
         handlerLogs.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_HandlerLoggingDisabled_StateLogsStillWritten()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/HourlyStatsTests.cs
+++ b/src/core/Jobly.Tests/Unit/HourlyStatsTests.cs
@@ -91,7 +91,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_CompletedJob_IncrementsHourlySucceededStat()
     {
         // Arrange
@@ -126,7 +126,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
         stat.Value.ShouldBeGreaterThanOrEqualTo(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailedJob_IncrementsHourlyFailedStat()
     {
         // Arrange
@@ -161,7 +161,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
         stat.Value.ShouldBeGreaterThanOrEqualTo(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_MultipleJobs_HourlyStatsAccumulate()
     {
         // Arrange — create 3 jobs
@@ -201,7 +201,7 @@ public abstract class HourlyStatsTestsBase : IAsyncLifetime
         stat.Value.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_IncludesHistoricalTotals()
     {
         // Arrange — insert stats

--- a/src/core/Jobly.Tests/Unit/JobCommandServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobCommandServiceTests.cs
@@ -20,7 +20,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_SetsStateToDeleted()
     {
         // Arrange
@@ -48,7 +48,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Deleted);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_SetsExpireAt()
     {
         // Arrange
@@ -76,7 +76,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.ExpireAt.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_CreatesDeletedLog()
     {
         // Arrange
@@ -103,7 +103,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         logs.ShouldContain(l => l.EventType == "Deleted");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_AlreadyDeleted_NoOp()
     {
         // Arrange
@@ -131,7 +131,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Deleted);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_SetsStateToEnqueued()
     {
         // Arrange
@@ -159,7 +159,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_ClearsExpireAt()
     {
         // Arrange
@@ -188,7 +188,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.ExpireAt.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_WithMessageParent_ResetsParentToProcessing()
     {
         // Arrange
@@ -230,7 +230,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         parent.CurrentState.ShouldBe(State.Processing);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_WithBatchParent_ResetsParentToAwaiting()
     {
         // Arrange
@@ -273,7 +273,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         parent.CurrentState.ShouldBe(State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_MessageSpawnedJob_KeepsHandlerType()
     {
         // Arrange
@@ -315,7 +315,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.HandlerType.ShouldBe(handlerType);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_DirectJob_ClearsHandlerType()
     {
         // Arrange
@@ -345,7 +345,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         job.HandlerType.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BulkDeleteJobs_DeletesMultiple()
     {
         // Arrange
@@ -377,7 +377,7 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         jobs.ShouldAllBe(j => j.CurrentState == State.Deleted);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task BulkRequeueJobs_RequeuesMultiple()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/JobExpirationTimeoutTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobExpirationTimeoutTests.cs
@@ -20,7 +20,7 @@ public abstract class JobExpirationTimeoutTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_UsesConfiguredExpirationTimeout()
     {
         // Arrange
@@ -54,7 +54,7 @@ public abstract class JobExpirationTimeoutTestsBase : IAsyncLifetime
         job.ExpireAt.Value.ShouldBeLessThanOrEqualTo(after.AddHours(2).AddSeconds(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_DefaultTimeout_ExpiresInOneDay()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/JobGroupQueryServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobGroupQueryServiceTests.cs
@@ -18,7 +18,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroups_Message_ReturnsMessageKindJobs()
     {
         // Arrange
@@ -55,7 +55,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroups_Batch_ReturnsBatchKindJobs()
     {
         // Arrange
@@ -93,7 +93,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroups_WithStateFilter_FiltersCorrectly()
     {
         // Arrange
@@ -126,7 +126,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroupById_ReturnsDetailWithSpawnedJobsCount()
     {
         // Arrange
@@ -167,7 +167,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
         result.SpawnedJobsCount.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroupById_NonExistent_ReturnsNull()
     {
         // Act
@@ -178,7 +178,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
         result.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroupJobs_ReturnsChildJobs()
     {
         // Arrange
@@ -218,7 +218,7 @@ public abstract class JobGroupQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobGroupJobCounts_ReturnsStateBreakdown()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/JobLogCollectorTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobLogCollectorTests.cs
@@ -5,7 +5,7 @@ namespace Jobly.Tests.Unit;
 
 public class JobLogCollectorTests
 {
-    [Fact]
+    [TimedFact]
     public void Drain_ReturnsAllEntries_AndClearsQueue()
     {
         var collector = new JobLogCollector { JobId = Guid.NewGuid() };
@@ -22,7 +22,7 @@ public class JobLogCollectorTests
         collector.Drain().Count.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public void Drain_ReturnsEmptyList_WhenQueueIsEmpty()
     {
         var collector = new JobLogCollector { JobId = Guid.NewGuid() };
@@ -32,7 +32,7 @@ public class JobLogCollectorTests
         entries.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Drain_DoesNotLoseEntries_WhenAddAndDrainConcurrently()
     {
         var collector = new JobLogCollector { JobId = Guid.NewGuid() };

--- a/src/core/Jobly.Tests/Unit/JobLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobLogTests.cs
@@ -91,7 +91,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_CreatedJob_HasCreatedLog()
     {
         // Arrange
@@ -114,7 +114,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
         logs.ShouldContain(l => l.EventType == "Created");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_CompletedJob_HasFullLifecycleLogs()
     {
         // Arrange
@@ -146,7 +146,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
         completed.Timestamp.ShouldBeGreaterThanOrEqualTo(processing.Timestamp);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailedJob_HasFailedLogWithErrorLevel()
     {
         // Arrange
@@ -181,7 +181,7 @@ public abstract class JobLogTestsBase : IAsyncLifetime
         logs.ShouldNotContain(l => l.EventType == "Completed");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_CreatesRequeuedLog()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/JobQueryServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/JobQueryServiceTests.cs
@@ -19,7 +19,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task GetJobsList_ReturnsJobsByState()
     {
         // Arrange
@@ -60,7 +60,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetScheduledJobs_ReturnsFutureScheduledOnly()
     {
         // Arrange
@@ -98,7 +98,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAwaitingJobs_ReturnsOnlyAwaiting()
     {
         // Arrange
@@ -131,7 +131,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetSiblingJobs_ReturnsOtherChildrenOfSameParent()
     {
         // Arrange
@@ -183,7 +183,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetChildJobs_ReturnsDirectChildren()
     {
         // Arrange
@@ -223,7 +223,7 @@ public abstract class JobQueryServiceTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetTraceJobs_ReturnsJobsWithSameTraceId()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/JoblyTelemetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/JoblyTelemetryTests.cs
@@ -9,7 +9,7 @@ namespace Jobly.Tests.Unit;
 /// </summary>
 public class JoblyTelemetryTests
 {
-    [Fact]
+    [TimedFact]
     public void GetShortTypeName_AssemblyQualifiedName_ReturnsNameWithoutAssembly()
     {
         var result = JoblyTelemetry.GetShortTypeName("MyApp.Handlers.SendReport, MyApp, Version=1.0.0.0");
@@ -17,7 +17,7 @@ public class JoblyTelemetryTests
         result.ShouldBe("MyApp.Handlers.SendReport");
     }
 
-    [Fact]
+    [TimedFact]
     public void GetShortTypeName_PlainTypeName_ReturnsAsIs()
     {
         var result = JoblyTelemetry.GetShortTypeName("MyApp.Handlers.SendReport");
@@ -25,7 +25,7 @@ public class JoblyTelemetryTests
         result.ShouldBe("MyApp.Handlers.SendReport");
     }
 
-    [Fact]
+    [TimedFact]
     public void GetShortTypeName_Null_ReturnsUnknown()
     {
         var result = JoblyTelemetry.GetShortTypeName(null);
@@ -33,7 +33,7 @@ public class JoblyTelemetryTests
         result.ShouldBe("unknown");
     }
 
-    [Fact]
+    [TimedFact]
     public void GetShortTypeName_EmptyString_ReturnsEmpty()
     {
         var result = JoblyTelemetry.GetShortTypeName(string.Empty);
@@ -41,7 +41,7 @@ public class JoblyTelemetryTests
         result.ShouldBe(string.Empty);
     }
 
-    [Fact]
+    [TimedFact]
     public void StartJobActivity_ValidParentSpanId_SetsParentId()
     {
         var traceId = Guid.NewGuid();
@@ -54,7 +54,7 @@ public class JoblyTelemetryTests
         activity.Dispose();
     }
 
-    [Fact]
+    [TimedFact]
     public void StartJobActivity_MalformedParentSpanId_DoesNotThrow()
     {
         var traceId = Guid.NewGuid();
@@ -67,7 +67,7 @@ public class JoblyTelemetryTests
         activity.Dispose();
     }
 
-    [Fact]
+    [TimedFact]
     public void StartJobActivity_TooShortParentSpanId_DoesNotThrow()
     {
         var traceId = Guid.NewGuid();
@@ -80,7 +80,7 @@ public class JoblyTelemetryTests
         activity.Dispose();
     }
 
-    [Fact]
+    [TimedFact]
     public void StartJobActivity_NullParentSpanId_SetsDefaultParentId()
     {
         var traceId = Guid.NewGuid();

--- a/src/core/Jobly.Tests/Unit/MediatorTests.cs
+++ b/src/core/Jobly.Tests/Unit/MediatorTests.cs
@@ -7,7 +7,7 @@ namespace Jobly.Tests.Unit;
 
 public class MediatorTests
 {
-    [Fact]
+    [TimedFact]
     public async Task Send_WithRequestHandler_ReturnsResponse()
     {
         var services = new ServiceCollection();
@@ -21,7 +21,7 @@ public class MediatorTests
         result.ShouldBe("Hello, Jobly!");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Send_WithNoHandler_ThrowsInvalidOperationException()
     {
         var services = new ServiceCollection();
@@ -34,7 +34,7 @@ public class MediatorTests
             () => mediator.Send(new GetGreetingRequest { Name = "Jobly" }));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Send_WithPipelineBehavior_ExecutesPipeline()
     {
         var log = new List<string>();
@@ -53,7 +53,7 @@ public class MediatorTests
         log.ShouldBe(["before", "after"]);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithStreamHandler_ReturnsItems()
     {
         var services = new ServiceCollection();
@@ -71,7 +71,7 @@ public class MediatorTests
         items.ShouldBe([0, 1, 2, 3, 4]);
     }
 
-    [Fact]
+    [TimedFact]
     public void CreateStream_WithNoHandler_ThrowsInvalidOperationException()
     {
         var services = new ServiceCollection();
@@ -84,7 +84,7 @@ public class MediatorTests
             () => mediator.CreateStream(new GetNumbersStreamRequest { Count = 1 }));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithPipelineBehavior_ExecutesPipeline()
     {
         var log = new List<string>();
@@ -107,7 +107,7 @@ public class MediatorTests
         log.ShouldBe(["before", "after"]);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithCancellation_StopsEnumeration()
     {
         var services = new ServiceCollection();
@@ -134,7 +134,7 @@ public class MediatorTests
         items.Count.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithEmptyStream_ReturnsNoItems()
     {
         var services = new ServiceCollection();
@@ -152,7 +152,7 @@ public class MediatorTests
         items.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithMultipleBehaviors_ExecutesInOrder()
     {
         var log = new List<string>();
@@ -177,7 +177,7 @@ public class MediatorTests
         log.ShouldBe(["outer:before", "inner:before", "inner:after", "outer:after"]);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithHandlerException_PropagatesException()
     {
         var services = new ServiceCollection();
@@ -199,7 +199,7 @@ public class MediatorTests
         items.ShouldBe([0, 1]);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CreateStream_WithRequestPipelineBehavior_ExecutesBehavior()
     {
         var log = new List<string>();

--- a/src/core/Jobly.Tests/Unit/MessageRoutingErrorTests.cs
+++ b/src/core/Jobly.Tests/Unit/MessageRoutingErrorTests.cs
@@ -36,7 +36,7 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
         return provider.GetRequiredService<IServiceScopeFactory>();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_UnknownMessageType_SetsMessageToFailed()
     {
         // Arrange
@@ -68,7 +68,7 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
         message.CurrentState.ShouldBe(State.Failed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_NoHandlersRegistered_SetsMessageToFailed()
     {
         // Arrange — use a valid type that exists but has no handler registered
@@ -101,7 +101,7 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
         message.CurrentState.ShouldBe(State.Failed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_MultipleHandlers_CreatesOneJobPerHandler()
     {
         // Arrange
@@ -134,7 +134,7 @@ public abstract class MessageRoutingErrorTestsBase : IAsyncLifetime
         children.Count.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_SetsHandlerTypeOnChildJobs()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/MessageRoutingTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/MessageRoutingTaskTests.cs
@@ -29,7 +29,7 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
         return provider.GetRequiredService<IServiceScopeFactory>();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_WithEnqueuedMessage_CreatesChildJobs()
     {
         // Arrange
@@ -63,7 +63,7 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
         children.Count.ShouldBeGreaterThan(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_SetsMessageToProcessing()
     {
         // Arrange
@@ -95,7 +95,7 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
         message.CurrentState.ShouldBe(State.Processing);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_ChildJobsInheritQueue()
     {
         // Arrange
@@ -128,7 +128,7 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
         children.ShouldAllBe(c => c.Queue == "critical");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_NoMessages_ReturnsZero()
     {
         // Arrange — empty DB
@@ -142,7 +142,7 @@ public abstract class MessageRoutingTaskTestsBase : IAsyncLifetime
         routed.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunMessageRouting_MultipleMessages_RoutesAll()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/MetadataPublishPipelineTests.cs
+++ b/src/core/Jobly.Tests/Unit/MetadataPublishPipelineTests.cs
@@ -40,7 +40,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #1: Multiple behaviors per type all run ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_MultipleBehaviors_AllBehaviorsRun()
     {
         var ctx = _fixture.CreateContext();
@@ -58,7 +58,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         metadata["key-b"].ShouldBe("value-b");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Publish_MultipleBehaviors_AllBehaviorsRunForMessage()
     {
         var ctx = _fixture.CreateContext();
@@ -77,7 +77,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #2: CancellationToken flows to behaviors ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_CancellationToken_FlowsToBehavior()
     {
         var ctx = _fixture.CreateContext();
@@ -94,7 +94,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #3: No behaviors → null metadata (not empty JSON) ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_NoBehaviors_MetadataIsNull()
     {
         var ctx = _fixture.CreateContext();
@@ -108,7 +108,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Ad-hoc metadata via JobParameters ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithJobParametersMetadata_MetadataPersisted()
     {
         var ctx = _fixture.CreateContext();
@@ -126,7 +126,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         metadata["ad-hoc"].ShouldBe("value");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_BehaviorAndAdHocMetadata_BothPresent()
     {
         var ctx = _fixture.CreateContext();
@@ -147,7 +147,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Fix #5: Model metadata caching ---
-    [Fact]
+    [TimedFact]
     public void UnifiedJobDetailModel_Metadata_CachedAcrossAccesses_1()
     {
         var model = new UnifiedJobDetailModel { MetadataJson = """{"key":"value"}""" };
@@ -160,7 +160,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         ReferenceEquals(first, second).ShouldBeTrue("Metadata should be the same instance on repeated access");
     }
 
-    [Fact]
+    [TimedFact]
     public void UnifiedJobDetailModel_Metadata_CachedAcrossAccesses_WithMultipleKeys()
     {
         var model = new UnifiedJobDetailModel { MetadataJson = """{"key1":"value1","key2":"value2"}""" };
@@ -174,7 +174,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
         ReferenceEquals(first, second).ShouldBeTrue("Metadata should be the same instance on repeated access");
     }
 
-    [Fact]
+    [TimedFact]
     public void UnifiedJobDetailModel_NullMetadataJson_ReturnsNull()
     {
         var model = new UnifiedJobDetailModel { MetadataJson = null };
@@ -182,7 +182,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: JobContext with null metadata → Metadata is empty dict, not null ---
-    [Fact]
+    [TimedFact]
     public void JobContext_DefaultMetadata_IsEmptyDictionaryNotNull()
     {
         var ctx = new JobContext();
@@ -191,7 +191,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Batch: pipeline runs once, all children get metadata ---
-    [Fact]
+    [TimedFact]
     public async Task BatchPublisher_WithBehavior_AllChildrenGetMetadata()
     {
         var ctx = _fixture.CreateContext();
@@ -216,7 +216,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Metadata inheritance from execution context ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_InsideExecutionContext_InheritsParentMetadata()
     {
         // Simulate a handler publishing a child job
@@ -247,7 +247,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Batch: ad-hoc metadata via StartNew ---
-    [Fact]
+    [TimedFact]
     public async Task BatchPublisher_WithAdHocMetadata_AllChildrenGetIt()
     {
         var ctx = _fixture.CreateContext();
@@ -271,7 +271,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: behavior modifies metadata AFTER next() ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_BehaviorWritesAfterNext_MetadataPersisted()
     {
         var ctx = _fixture.CreateContext();
@@ -288,7 +288,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: behavior short-circuits (never calls next()) ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_BehaviorShortCircuits_MetadataFromBehaviorStillPersisted()
     {
         var ctx = _fixture.CreateContext();
@@ -305,7 +305,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: behavior throws → exception propagates, job not created ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_BehaviorThrows_ExceptionPropagatesAndJobNotCreated()
     {
         var ctx = _fixture.CreateContext();
@@ -321,7 +321,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: pipeline execution order (first registered = outermost, runs first) ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_BehaviorOrder_FirstRegisteredIsOutermost()
     {
         var ctx = _fixture.CreateContext();
@@ -338,7 +338,7 @@ public abstract class MetadataPublishPipelineTestsBase : IAsyncLifetime
     }
 
     // --- Edge case: ad-hoc metadata overrides inherited metadata on key conflict ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_AdHocOverridesInherited_OnKeyConflict()
     {
         JobExecutionContext.Current = new JobExecutionInfo

--- a/src/core/Jobly.Tests/Unit/MetadataSerializerTests.cs
+++ b/src/core/Jobly.Tests/Unit/MetadataSerializerTests.cs
@@ -5,7 +5,7 @@ namespace Jobly.Tests.Unit;
 
 public class MetadataSerializerTests
 {
-    [Theory]
+    [TimedTheory]
     [InlineData("""{"Name":"Alice"}""", "Name", "Alice")]
     [InlineData("""{"Key":""}""", "Key", "")]
     [InlineData("""{"Key":"hello world"}""", "Key", "hello world")]
@@ -17,7 +17,7 @@ public class MetadataSerializerTests
         dict[key].ShouldBe(expected);
     }
 
-    [Theory]
+    [TimedTheory]
     [InlineData("""{"Count":0}""", "Count", 0L)]
     [InlineData("""{"Count":42}""", "Count", 42L)]
     [InlineData("""{"Count":-1}""", "Count", -1L)]
@@ -30,7 +30,7 @@ public class MetadataSerializerTests
         dict[key].ShouldBe(expected);
     }
 
-    [Theory]
+    [TimedTheory]
     [InlineData("""{"Value":3.14}""", "Value", 3.14)]
     [InlineData("""{"Value":0.5}""", "Value", 0.5)]
     public void Deserialize_FloatValues_ReturnsDouble(string json, string key, double expected)
@@ -41,7 +41,7 @@ public class MetadataSerializerTests
         dict[key].ShouldBe(expected);
     }
 
-    [Theory]
+    [TimedTheory]
     [InlineData("""{"Active":true}""", "Active", true)]
     [InlineData("""{"Active":false}""", "Active", false)]
     public void Deserialize_BooleanValues_ReturnsBool(string json, string key, bool expected)
@@ -52,7 +52,7 @@ public class MetadataSerializerTests
         dict[key].ShouldBe(expected);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_NullValue_ReturnsNull()
     {
         var dict = MetadataSerializer.Deserialize("""{"Key":null}""");
@@ -61,7 +61,7 @@ public class MetadataSerializerTests
         dict["Key"].ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_IntArray_ReturnsList()
     {
         var dict = MetadataSerializer.Deserialize("""{"Delays":[15,60,300]}""");
@@ -73,7 +73,7 @@ public class MetadataSerializerTests
         list[2].ShouldBe(300L);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_StringArray_ReturnsList()
     {
         var dict = MetadataSerializer.Deserialize("""{"Tags":["a","b","c"]}""");
@@ -85,7 +85,7 @@ public class MetadataSerializerTests
         list[2].ShouldBe("c");
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_EmptyArray_ReturnsList()
     {
         var dict = MetadataSerializer.Deserialize("""{"Items":[]}""");
@@ -94,7 +94,7 @@ public class MetadataSerializerTests
         list.Count.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_MixedArray_ReturnsList()
     {
         var dict = MetadataSerializer.Deserialize("""{"Mixed":[1,"two",true]}""");
@@ -106,7 +106,7 @@ public class MetadataSerializerTests
         list[2].ShouldBe(true);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_NestedObject_ReturnsDictionary()
     {
         var dict = MetadataSerializer.Deserialize("""{"Outer":{"Inner":"value","Count":5}}""");
@@ -116,7 +116,7 @@ public class MetadataSerializerTests
         nested["Count"].ShouldBe(5L);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_MultipleKeys_AllConvertedCorrectly()
     {
         var dict = MetadataSerializer.Deserialize("""{"Name":"John","Age":30,"Active":true,"Score":9.5}""");
@@ -127,7 +127,7 @@ public class MetadataSerializerTests
         dict["Score"].ShouldBe(9.5);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_NullJson_ReturnsEmptyDictionary()
     {
         var dict = MetadataSerializer.Deserialize(null);
@@ -136,7 +136,7 @@ public class MetadataSerializerTests
         dict.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_EmptyString_ReturnsEmptyDictionary()
     {
         var dict = MetadataSerializer.Deserialize("");
@@ -145,7 +145,7 @@ public class MetadataSerializerTests
         dict.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_EmptyObject_ReturnsEmptyDictionary()
     {
         var dict = MetadataSerializer.Deserialize("{}");
@@ -154,7 +154,7 @@ public class MetadataSerializerTests
         dict.ShouldBeEmpty();
     }
 
-    [Fact]
+    [TimedFact]
     public void Serialize_DictionaryWithNativeTypes_ProducesCorrectJson()
     {
         var dict = new Dictionary<string, object>
@@ -172,19 +172,19 @@ public class MetadataSerializerTests
         json.ShouldContain("\"Active\":true");
     }
 
-    [Fact]
+    [TimedFact]
     public void Serialize_EmptyDictionary_ReturnsNull()
     {
         MetadataSerializer.Serialize(new Dictionary<string, object>()).ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public void Serialize_NullDictionary_ReturnsNull()
     {
         MetadataSerializer.Serialize(null).ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public void RoundTrip_NativeTypes_PreservedAfterSerializeDeserialize()
     {
         var original = new Dictionary<string, object>
@@ -204,7 +204,7 @@ public class MetadataSerializerTests
         restored["Score"].ShouldBe(9.5);
     }
 
-    [Fact]
+    [TimedFact]
     public void RoundTrip_ArrayValues_PreservedAfterSerializeDeserialize()
     {
         var original = new Dictionary<string, object>
@@ -222,7 +222,7 @@ public class MetadataSerializerTests
         list[2].ShouldBe(300L);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_DeeplyNested_AllLevelsConverted()
     {
         var json = """{"L1":{"L2":{"L3":"deep","Num":99}}}""";
@@ -234,7 +234,7 @@ public class MetadataSerializerTests
         l2["Num"].ShouldBe(99L);
     }
 
-    [Fact]
+    [TimedFact]
     public void Deserialize_ArrayOfObjects_ReturnsListOfDictionaries()
     {
         var json = """{"Items":[{"Name":"A"},{"Name":"B"}]}""";

--- a/src/core/Jobly.Tests/Unit/MutexTests.cs
+++ b/src/core/Jobly.Tests/Unit/MutexTests.cs
@@ -29,7 +29,7 @@ public abstract class MutexTestsBase : IAsyncLifetime
     private static readonly Guid ServerId = Guid.NewGuid();
     private static readonly string[] DefaultQueues = ["default"];
 
-    [Fact]
+    [TimedFact]
     public async Task MutexHeld_SecondJobCancelled()
     {
         // Arrange: two jobs with same concurrency key, first already processing
@@ -87,7 +87,7 @@ public abstract class MutexTestsBase : IAsyncLifetime
         log.Message.ShouldContain("payment:123");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DifferentMutexKeys_BothProcess()
     {
         // Arrange: two jobs with different concurrency keys
@@ -129,7 +129,7 @@ public abstract class MutexTestsBase : IAsyncLifetime
         job2.CurrentState.ShouldNotBe(State.Deleted);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task NoConcurrencyKey_NoMutexCheck()
     {
         // Arrange: job without concurrency key
@@ -159,7 +159,7 @@ public abstract class MutexTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task MutexFree_JobProcessesNormally()
     {
         // Arrange: job with concurrency key but no other job holds it

--- a/src/core/Jobly.Tests/Unit/NamingConventionTests.cs
+++ b/src/core/Jobly.Tests/Unit/NamingConventionTests.cs
@@ -8,7 +8,7 @@ namespace Jobly.Tests.Unit;
 
 public class NamingConventionTests
 {
-    [Fact]
+    [TimedFact]
     public void JoblyEntities_UsePascalCaseTableNames_WhenNoConventionApplied()
     {
         var options = new DbContextOptionsBuilder<TestContext>()
@@ -30,7 +30,7 @@ public class NamingConventionTests
         model.FindEntityType(typeof(ServerLog))!.GetTableName().ShouldBe("ServerLog");
     }
 
-    [Fact]
+    [TimedFact]
     public void JoblyEntities_UseSnakeCaseTableNames_WhenSnakeCaseConventionApplied()
     {
         var options = new DbContextOptionsBuilder<TestContext>()
@@ -54,7 +54,7 @@ public class NamingConventionTests
         model.FindEntityType(typeof(ServerLog))!.GetTableName().ShouldBe("server_log");
     }
 
-    [Fact]
+    [TimedFact]
     public void JoblyEntities_UseSnakeCaseColumnNames_WhenSnakeCaseConventionApplied()
     {
         var options = new DbContextOptionsBuilder<TestContext>()
@@ -74,7 +74,7 @@ public class NamingConventionTests
         jobEntity.FindProperty(nameof(Job.CancellationMode))!.GetColumnName().ShouldBe("cancellation_mode");
     }
 
-    [Fact]
+    [TimedFact]
     public void JoblyEntities_UseDefaultJoblySchema()
     {
         var options = new DbContextOptionsBuilder<TestContext>()
@@ -92,7 +92,7 @@ public class NamingConventionTests
         model.FindEntityType(typeof(Counter))!.GetSchema().ShouldBe("jobly");
     }
 
-    [Fact]
+    [TimedFact]
     public void JoblyEntities_UseCustomSchema_WhenOverridden()
     {
         var options = new DbContextOptionsBuilder<SchemaTestContext>()
@@ -105,7 +105,7 @@ public class NamingConventionTests
         model.FindEntityType(typeof(Job))!.GetSchema().ShouldBe("custom");
     }
 
-    [Fact]
+    [TimedFact]
     public void JoblyEntities_UseNullSchema_WhenSetToNull()
     {
         var options = new DbContextOptionsBuilder<NullSchemaTestContext>()

--- a/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
+++ b/src/core/Jobly.Tests/Unit/OTelMetricsTests.cs
@@ -116,7 +116,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         return false;
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_Completed_RecordsDurationMetric()
     {
         // Arrange — unique queue isolates from parallel tests
@@ -163,7 +163,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         recordedDuration.ShouldBeGreaterThanOrEqualTo(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_Completed_RecordsCompletedMetricWithSucceededStatus()
     {
         // Arrange
@@ -210,7 +210,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         completedCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_Failed_RecordsCompletedMetricWithFailedStatus()
     {
         // Arrange
@@ -258,7 +258,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         failedCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_RecordsEnqueuedMetric()
     {
         // Arrange — publisher uses unique queue, no worker needed
@@ -292,7 +292,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         enqueuedCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_IncrementsAndDecrementsActiveMetric()
     {
         // Arrange
@@ -339,7 +339,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         activeNet.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_TwoWorkersConcurrently_ActiveMetricReachesTwo()
     {
         // Arrange — two barrier jobs on same queue
@@ -417,7 +417,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         Interlocked.Read(ref currentActive).ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailedWithRetries_RecordsRetriedStatus()
     {
         // Arrange
@@ -466,7 +466,7 @@ public abstract class OTelMetricsTestsBase : IAsyncLifetime
         retriedCount.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task StartBatch_RecordsEnqueuedMetricForBatchAndChildren()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
@@ -17,7 +17,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_BatchAllChildrenCompleted_FinalizesBatch()
     {
         // Arrange
@@ -61,7 +61,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         batch.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_BatchSomeChildrenEnqueued_DoesNotFinalize()
     {
         // Arrange
@@ -111,7 +111,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         batch.CurrentState.ShouldBe(State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_BatchWithFailedChild_OnlyOnSucceeded_BatchFails()
     {
         // Arrange
@@ -162,7 +162,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         batch.CurrentState.ShouldBe(State.Failed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_BatchWithFailedChild_OnAnyFinished_BatchCompletes()
     {
         // Arrange
@@ -213,7 +213,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         batch.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_MessageAllChildrenCompleted_FinalizesMessage()
     {
         // Arrange
@@ -257,7 +257,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         message.ExpireAt.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_ActivatesContinuationChildren()
     {
         // Arrange: completed batch parent -> awaiting continuation batch child -> awaiting grandchildren
@@ -338,7 +338,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_FailedParentOnlyOnSucceeded_ContinuationStaysAwaiting()
     {
         // Arrange: failed batch parent (OnlyOnSucceeded) -> awaiting continuation child
@@ -397,7 +397,7 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         continuation.CurrentState.ShouldBe(State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RunOrchestration_AlreadyFinalized_ReturnsNoWork()
     {
         // Arrange: completed batch + completed children

--- a/src/core/Jobly.Tests/Unit/PauseStateHolderTests.cs
+++ b/src/core/Jobly.Tests/Unit/PauseStateHolderTests.cs
@@ -5,7 +5,7 @@ namespace Jobly.Tests.Unit;
 
 public class PauseStateHolderTests
 {
-    [Fact]
+    [TimedFact]
     public void IsPaused_ReturnsFalse_WhenNothingPaused()
     {
         var holder = new PauseStateHolder();
@@ -15,7 +15,7 @@ public class PauseStateHolderTests
         holder.IsPaused(null).ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public void IsPaused_ReturnsTrue_WhenServerPaused()
     {
         var holder = new PauseStateHolder();
@@ -27,7 +27,7 @@ public class PauseStateHolderTests
         holder.IsPaused(null).ShouldBeTrue();
     }
 
-    [Fact]
+    [TimedFact]
     public void IsPaused_ReturnsTrue_WhenGroupPaused()
     {
         var holder = new PauseStateHolder();
@@ -45,7 +45,7 @@ public class PauseStateHolderTests
         holder.IsPaused(null).ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public void IsPaused_ReturnsTrue_WhenBothPaused()
     {
         var holder = new PauseStateHolder();
@@ -56,7 +56,7 @@ public class PauseStateHolderTests
         holder.IsPaused(groupId).ShouldBeTrue();
     }
 
-    [Fact]
+    [TimedFact]
     public void Update_ReplacesState()
     {
         var holder = new PauseStateHolder();
@@ -69,7 +69,7 @@ public class PauseStateHolderTests
         holder.IsPaused(groupId).ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public void IsPaused_ReturnsFalse_OnFreshInstance()
     {
         // A fresh PauseStateHolder should default to "not paused".
@@ -90,7 +90,7 @@ public class PauseStateHolderTests
     /// State B: server=false, group=true  → IsPaused=true  (group is paused)
     /// Torn:    server=false, group=false → IsPaused=FALSE (bug!)
     /// </summary>
-    [Fact]
+    [TimedFact]
     public async Task Update_IsAtomic_NeverExposesTornState()
     {
         var holder = new PauseStateHolder();

--- a/src/core/Jobly.Tests/Unit/PipelineTests.cs
+++ b/src/core/Jobly.Tests/Unit/PipelineTests.cs
@@ -91,7 +91,7 @@ public abstract class PipelineTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithPipelineBehavior_PipelineLogsAppearInJobLogs()
     {
         // Arrange — UnitRequest has LoggingPipelineBehavior registered

--- a/src/core/Jobly.Tests/Unit/PriorityTests.cs
+++ b/src/core/Jobly.Tests/Unit/PriorityTests.cs
@@ -90,7 +90,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_MultipleQueues_ProcessesAlphabeticalFirst()
     {
         // Arrange — insert jobs in "b-default" and "a-critical"
@@ -139,7 +139,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
         defaultJob.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_SameQueue_ProcessesEarlierScheduledFirst()
     {
         // Arrange — insert 2 jobs same queue, different ScheduleTime
@@ -186,7 +186,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
         laterJob.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_DefaultQueue_Processed()
     {
         // Arrange
@@ -217,7 +217,7 @@ public abstract class PriorityTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Completed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_PastScheduledJob_Processed()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherOverloadTests.cs
@@ -26,7 +26,7 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
         return new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithJobParameters_SetsAllFields()
     {
         // Arrange
@@ -66,7 +66,7 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Schedule_WithQueue_SetsScheduleTimeAndQueue()
     {
         // Arrange
@@ -86,7 +86,7 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Schedule_WithParent_SetsScheduleTimeAndParent()
     {
         // Arrange
@@ -119,7 +119,7 @@ public abstract class PublisherOverloadTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Schedule_WithParentAndQueue_SetsAllFields()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/PublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherTests.cs
@@ -27,7 +27,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         return new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, new ServiceCollection().BuildServiceProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Publish_CreatesMessageKindJobWithEnqueuedState()
     {
         // Arrange
@@ -46,7 +46,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Publish_WithQueue_SetsQueueOnJob()
     {
         // Arrange
@@ -64,7 +64,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.Queue.ShouldBe("critical");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Publish_SetsTraceIdToJobId()
     {
         // Arrange
@@ -82,7 +82,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.TraceId.ShouldBe(job.Id);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_CreatesJobKindJobWithEnqueuedState()
     {
         // Arrange
@@ -101,7 +101,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithParentId_SetsParentAndAwaitingState()
     {
         // Arrange
@@ -133,7 +133,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Awaiting);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_CreatesJobLog()
     {
         // Arrange
@@ -151,7 +151,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         logs[0].EventType.ShouldBe("Created");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Schedule_SetsScheduleTime()
     {
         // Arrange
@@ -170,7 +170,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddHours(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithParent_InheritsParentTrace_SameContext()
     {
         // Arrange: parent and child created in same context before SaveChanges
@@ -191,7 +191,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         child.TraceId.ShouldBe(parent.TraceId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithParent_InheritsParentTrace_SeparateContext()
     {
         // Arrange: parent already committed to DB
@@ -215,7 +215,7 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         child.TraceId.ShouldBe(parent.TraceId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithoutParent_GetsOwnTrace()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
@@ -23,7 +23,7 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task AddOrUpdateRecurringJob_DoesNotCreateJob()
     {
         var ctx = _fixture.CreateContext();
@@ -40,7 +40,7 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
         recurring.NextExecution.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_CreatesJobWithScheduleTimeNow()
     {
         // Arrange: register a recurring job with NextExecution in the past (so scheduler triggers)
@@ -70,7 +70,7 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
         updatedRecurring.NextExecution.Value.ShouldBeGreaterThan(DateTime.UtcNow, "NextExecution should be in the future");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_SetsScheduleTimeToNow()
     {
         // Arrange: create a job with a future schedule time that has failed

--- a/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
@@ -20,7 +20,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_JobStillPending_SkipsScheduling()
     {
         // Arrange — recurring job with NextJobId pointing to an Enqueued (pending) job
@@ -72,7 +72,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         jobCountAfter.ShouldBe(jobCountBefore);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_MultipleDueJobs_SchedulesAll()
     {
         // Arrange — insert 3 recurring jobs with past NextExecution, each with a completed next job
@@ -123,7 +123,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         count.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_UpdatesNextExecution()
     {
         // Arrange
@@ -173,7 +173,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         rj.NextExecution.Value.ShouldBeGreaterThan(DateTime.UtcNow);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_UpdatesLastExecution()
     {
         // Arrange
@@ -223,7 +223,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         rj.LastExecution.Value.ShouldBe(pastTime, TimeSpan.FromSeconds(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_DisabledJob_CreatesSkippedLogEntry()
     {
         // Arrange
@@ -258,7 +258,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         log.JobId.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_DisabledJob_DoesNotCreateJob()
     {
         // Arrange
@@ -287,7 +287,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         jobCountAfter.ShouldBe(jobCountBefore);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_DisabledJob_AdvancesNextExecution()
     {
         // Arrange
@@ -316,7 +316,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         rj.NextExecution.Value.ShouldBeGreaterThan(DateTime.UtcNow);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_DisabledJob_AdvancesLastExecution()
     {
         // Arrange
@@ -345,7 +345,7 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         rj.LastExecution.Value.ShouldBe(pastTime, TimeSpan.FromSeconds(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ScheduleRecurringJobs_EnabledJob_CreatesJobNormally()
     {
         // Arrange — enabled recurring job (DisabledAt = null) with completed previous job

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCascadeTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCascadeTests.cs
@@ -18,7 +18,7 @@ public abstract class RecurringJobLogCascadeTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task WhenJobIsDeleted_RecurringJobLog_JobIdSetToNull()
     {
         // Arrange: create a recurring job, a job, and a log linking them
@@ -61,7 +61,7 @@ public abstract class RecurringJobLogCascadeTestsBase : IAsyncLifetime
         log.JobId.ShouldBeNull("JobId should be set to null by cascade");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task WhenJobExists_RecurringJobLog_JobIdIsSet()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
@@ -16,7 +16,7 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task CleanupRecurringJobLogs_KeepsLast100PerRecurringJob()
     {
         // Arrange: 150 logs for recurring job 1, 50 for recurring job 2
@@ -60,7 +60,7 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
         rj2Count.ShouldBe(50, "Should keep all 50 for rj2 (under limit)");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CleanupRecurringJobLogs_DeletesOldestEntries()
     {
         // Arrange: 110 logs, verify the 10 oldest are deleted
@@ -103,7 +103,7 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
         oldest.ShouldBeGreaterThan(newestBefore.AddMinutes(-100), "Oldest surviving entry should be within the last 100");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task CleanupRecurringJobLogs_NoLogsDoesNothing()
     {
         var cleanCtx = _fixture.CreateContext();

--- a/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
@@ -22,7 +22,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task AddOrUpdateRecurringJob_CreatesRecurringJobInDb()
     {
         // Arrange
@@ -43,7 +43,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         recurringJob.Queue.ShouldBe("default");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetRecurringJobs_ReturnsPaginated()
     {
         // Arrange
@@ -61,7 +61,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         result.TotalCount.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetRecurringJobById_ReturnsDetail()
     {
         // Arrange
@@ -82,7 +82,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         detail.Cron.ShouldBe("*/5 * * * *");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteRecurringJob_RemovesFromDb()
     {
         // Arrange
@@ -110,7 +110,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         deleted.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task TriggerRecurringJob_CreatesJob()
     {
         // Arrange
@@ -137,7 +137,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         jobCountAfter.ShouldBe(jobCountBefore + 1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DisableRecurringJob_SetsDisabledAt()
     {
         // Arrange
@@ -158,7 +158,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         updated.DisabledAt.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task EnableRecurringJob_ClearsDisabledAt()
     {
         // Arrange
@@ -188,7 +188,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         updated.DisabledAt.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetRecurringJobs_ReturnsDisabledAt()
     {
         // Arrange
@@ -216,7 +216,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         item.DisabledAt.Value.ShouldBe(disabledTime, TimeSpan.FromSeconds(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetRecurringJobById_ReturnsDisabledAt()
     {
         // Arrange
@@ -247,7 +247,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         detail.DisabledAt.Value.ShouldBe(disabledTime, TimeSpan.FromSeconds(1));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetRecurringJobHistory_ReturnsSkippedFlag()
     {
         // Arrange
@@ -282,7 +282,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         entry.JobId.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RecurringJobScheduler_CreatesJobWhenDue()
     {
         // Arrange — create a recurring job with NextExecution in the past

--- a/src/core/Jobly.Tests/Unit/RequeueEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RequeueEdgeCaseTests.cs
@@ -20,7 +20,7 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_AlreadyEnqueued_NoOpReturnsEarly()
     {
         // Arrange
@@ -51,7 +51,7 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
         logs.ShouldNotContain(l => l.EventType == "Requeued");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_DeletedJob_RequeuesSuccessfully()
     {
         // Arrange
@@ -81,7 +81,7 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
         job.ExpireAt.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_ParentNotFound_StillRequeues()
     {
         // Arrange — child job with ParentJobId pointing to non-existent parent
@@ -123,7 +123,7 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Enqueued);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_NonExistentJob_Throws()
     {
         // Act & Assert
@@ -134,7 +134,7 @@ public abstract class RequeueEdgeCaseTestsBase : IAsyncLifetime
         ex.Message.ShouldContain("Job not found");
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_NonExistentJob_Throws()
     {
         // Act & Assert

--- a/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionEdgeCaseTests.cs
@@ -99,7 +99,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailedJobWithRetries_StatNotIncrementedDuringRetry()
     {
         // Arrange
@@ -135,7 +135,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
         failedStat.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_StatisticsSurviveCleanup()
     {
         // Arrange — insert expired job and add stats
@@ -168,7 +168,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
         stat.Value.ShouldBe(10);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_CompletedJob_DecrementsSucceededAndIncrementsDeleted()
     {
         // Arrange — create a completed job with existing stats
@@ -213,7 +213,7 @@ public abstract class RetentionEdgeCaseTestsBase : IAsyncLifetime
         deletedAfter.ShouldBe(deletedBefore + 1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_FailedJob_DecrementsFailedStat()
     {
         // Arrange — create and process a failing job (no retries via metadata)

--- a/src/core/Jobly.Tests/Unit/RetentionTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetentionTests.cs
@@ -91,7 +91,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_CompletedJob_SetsExpireAt()
     {
         // Arrange
@@ -114,7 +114,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         job.ExpireAt.Value.ShouldBeGreaterThan(DateTime.UtcNow);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailedJob_ExpireAtIsNull()
     {
         // Arrange
@@ -146,7 +146,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         job.ExpireAt.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_CompletedJob_IncrementsSucceededStat()
     {
         // Arrange
@@ -177,7 +177,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         statAfter.ShouldBe(statBefore + 1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailedJob_IncrementsFailedStat()
     {
         // Arrange
@@ -218,7 +218,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         statAfter.ShouldBe(statBefore + 1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_IncrementsDeletedStat()
     {
         // Arrange
@@ -255,7 +255,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         statAfter.ShouldBe(statBefore + 1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_DecrementsSucceededStat()
     {
         // Arrange — enqueue and process a job so stats:succeeded is incremented
@@ -289,7 +289,7 @@ public abstract class RetentionTestsBase : IAsyncLifetime
         succeededAfter.ShouldBe(succeededBefore - 1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ExpirationCleanup_DeletesExpiredJobAndLogs()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/RetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetryTests.cs
@@ -114,7 +114,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
             new FakeLockProvider());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithMaxRetries3_RetriesThreeTimesThenFails()
     {
         // Arrange
@@ -148,7 +148,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithMaxRetries0_FailsImmediately()
     {
         // Arrange
@@ -180,7 +180,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_RetryDoesNotIncrementFailedStat()
     {
         // Arrange
@@ -222,7 +222,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_RetryThenSucceed_CompletesNormally()
     {
         // Arrange
@@ -266,7 +266,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryDelays_SetsScheduleTimeInFuture()
     {
         // Arrange
@@ -299,7 +299,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeGreaterThan(now.AddSeconds(3500));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryDelays_LastDelayReusedWhenArrayShorter()
     {
         // Arrange
@@ -341,7 +341,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeGreaterThan(DateTime.UtcNow.AddSeconds(15));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithEmptyRetryDelays_RetriesImmediately()
     {
         // Arrange
@@ -374,7 +374,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeLessThanOrEqualTo(TimeProvider.System.GetUtcNow().UtcDateTime);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryDelays_JobNotPickedUpBeforeDelay()
     {
         // Arrange
@@ -406,7 +406,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         didProcess.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithPerJobRetryDelays_OverridesGlobalConfig()
     {
         // Arrange — job has per-job $retryDelays in metadata
@@ -444,7 +444,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         job.ScheduleTime.ShouldBeGreaterThan(now.AddSeconds(7000));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithMaxRetriesInMetadata_UsesMetadataValue()
     {
         // Arrange — job has per-job $maxRetries in metadata
@@ -485,7 +485,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryAttributeOnHandler_UsesAttributeMaxRetries()
     {
         // Arrange — handler has [Retry(5)], global has 0
@@ -516,7 +516,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryAttributeOnJob_UsesAttributeMaxRetries()
     {
         // Arrange — job class has [Retry(4)], global has 0
@@ -547,7 +547,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryAttributeOnBothHandlerAndJob_HandlerWins()
     {
         // Arrange — handler has [Retry(7)], job has [Retry(2)], global has 0
@@ -587,7 +587,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(7);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_MetadataOverridesRetryAttribute()
     {
         // Arrange — handler has [Retry(5)], but metadata overrides to 1
@@ -626,7 +626,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         GetRetriedTimes(job).ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_WithRetryAttributeDelays_UsesAttributeDelays()
     {
         // Arrange — handler has [Retry(3, Delays = [100, 200, 300])]

--- a/src/core/Jobly.Tests/Unit/ServerCommandServiceTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerCommandServiceTests.cs
@@ -16,7 +16,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task PauseServer_SetsPausedAt()
     {
         // Arrange
@@ -41,7 +41,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         server.PausedAt.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ResumeServer_ClearsPausedAt()
     {
         // Arrange
@@ -67,7 +67,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         server.PausedAt.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseServer_ReturnsFalseForNonexistent()
     {
         var svc = new ServerCommandService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
@@ -75,7 +75,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseWorkerGroup_SetsPausedAt()
     {
         // Arrange
@@ -108,7 +108,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         group.PausedAt.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ResumeWorkerGroup_ClearsPausedAt()
     {
         // Arrange
@@ -142,7 +142,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         group.PausedAt.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseWorkerGroup_ReturnsFalseForNonexistent()
     {
         var svc = new ServerCommandService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
@@ -150,7 +150,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ResumeServer_ReturnsFalseForNonexistent()
     {
         var svc = new ServerCommandService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
@@ -158,7 +158,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task ResumeWorkerGroup_ReturnsFalseForNonexistent()
     {
         var svc = new ServerCommandService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
@@ -166,7 +166,7 @@ public abstract class ServerCommandServiceTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task PauseServer_AlreadyPaused_UpdatesTimestamp()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/ServerMonitoringTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerMonitoringTests.cs
@@ -15,7 +15,7 @@ public abstract class ServerMonitoringTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task GetServers_ReturnsServerWithWorkers()
     {
         // Arrange
@@ -55,7 +55,7 @@ public abstract class ServerMonitoringTestsBase : IAsyncLifetime
         servers[0].Workers.Count.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetServerById_ReturnsServerDetail()
     {
         // Arrange
@@ -91,7 +91,7 @@ public abstract class ServerMonitoringTestsBase : IAsyncLifetime
         server.Workers[0].WorkerId.ShouldBe(workerId);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetServerById_NonExistent_ReturnsNull()
     {
         // Act

--- a/src/core/Jobly.Tests/Unit/ServerQueryTests.cs
+++ b/src/core/Jobly.Tests/Unit/ServerQueryTests.cs
@@ -16,7 +16,7 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task GetServerLogs_ReturnsPaginatedLogs()
     {
         // Arrange
@@ -66,7 +66,7 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
         logs.PageCount.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetServerLogs_FilteredByTaskName()
     {
         // Arrange
@@ -135,7 +135,7 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
         logs.Items.ShouldAllBe(l => string.Equals(l.TaskName, "StaleJobRecovery", StringComparison.Ordinal));
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetServerTaskSummaries_ReturnsRegisteredTasks()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
+++ b/src/core/Jobly.Tests/Unit/SpanPropagationTests.cs
@@ -46,7 +46,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- Publisher.Enqueue ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithActiveActivity_CapturesParentSpanId()
     {
         // Arrange
@@ -71,7 +71,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
         job.ParentSpanId.ShouldBe(activity.SpanId.ToHexString());
     }
 
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_WithoutActivity_ParentSpanIdIsNull()
     {
         // Arrange
@@ -103,7 +103,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- Publisher.Publish (Message) ---
-    [Fact]
+    [TimedFact]
     public async Task Publish_WithActiveActivity_CapturesParentSpanId()
     {
         // Arrange
@@ -129,7 +129,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- BatchPublisher ---
-    [Fact]
+    [TimedFact]
     public async Task StartBatch_WithActiveActivity_CapturesParentSpanIdOnBatchAndChildren()
     {
         // Arrange
@@ -169,7 +169,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- MessageRoutingTask propagation ---
-    [Fact]
+    [TimedFact]
     public async Task MessageRouting_PropagatesParentSpanIdToChildJobs()
     {
         // Arrange
@@ -211,7 +211,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [TimedFact]
     public async Task MessageRouting_MessageWithNullParentSpanId_ChildJobsHaveNullParentSpanId()
     {
         // Arrange
@@ -253,7 +253,7 @@ public abstract class SpanPropagationTestsBase : IAsyncLifetime
     }
 
     // --- Publisher inside handler (JobExecutionContext active) ---
-    [Fact]
+    [TimedFact]
     public async Task Enqueue_InsideHandlerWithActivity_CapturesHandlerSpanId()
     {
         // Arrange — simulate handler execution context with an active Activity

--- a/src/core/Jobly.Tests/Unit/SqlServerRowLockInterceptorTests.cs
+++ b/src/core/Jobly.Tests/Unit/SqlServerRowLockInterceptorTests.cs
@@ -10,7 +10,7 @@ public class SqlServerRowLockInterceptorTests
 {
     private readonly SqlServerRowLockInterceptor _interceptor = new();
 
-    [Fact]
+    [TimedFact]
     public void ManipulateCommand_WithDefaultTableName_AddsReadPastHint()
     {
         var command = CreateCommand($"""
@@ -25,7 +25,7 @@ public class SqlServerRowLockInterceptorTests
         command.CommandText.ShouldContain("FROM [Job] AS [j] WITH (ROWLOCK, UPDLOCK, READPAST)");
     }
 
-    [Fact]
+    [TimedFact]
     public void ManipulateCommand_WithSchemaQualifiedTableName_AddsReadPastHint()
     {
         var command = CreateCommand($"""
@@ -40,7 +40,7 @@ public class SqlServerRowLockInterceptorTests
         command.CommandText.ShouldContain("FROM [jobly].[Job] AS [j] WITH (ROWLOCK, UPDLOCK, READPAST)");
     }
 
-    [Fact]
+    [TimedFact]
     public void ManipulateCommand_WithWaitTag_AddsUpdLockWithoutReadPast()
     {
         var command = CreateCommand($"""
@@ -56,7 +56,7 @@ public class SqlServerRowLockInterceptorTests
         command.CommandText.ShouldNotContain("READPAST");
     }
 
-    [Fact]
+    [TimedFact]
     public void ManipulateCommand_WithCounterTag_AddsReadPastHint()
     {
         var command = CreateCommand($"""

--- a/src/core/Jobly.Tests/Unit/StatCounterTests.cs
+++ b/src/core/Jobly.Tests/Unit/StatCounterTests.cs
@@ -20,7 +20,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_FromCompletedState_DecrementsSucceededCounter()
     {
         // Arrange
@@ -49,7 +49,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
         counterSum.ShouldBe(-1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_FromFailedState_DecrementsFailedCounter()
     {
         // Arrange
@@ -78,7 +78,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
         counterSum.ShouldBe(-1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_FromDeletedState_NoOp()
     {
         // Arrange
@@ -106,7 +106,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
         counterCount.ShouldBe(0);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_AddsDeletedCounter()
     {
         // Arrange
@@ -135,7 +135,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
         deletedCounterSum.ShouldBe(1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_FromCompletedState_DecrementsSucceededCounter()
     {
         // Arrange
@@ -164,7 +164,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
         counterSum.ShouldBe(-1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_FromFailedState_DecrementsFailedCounter()
     {
         // Arrange
@@ -193,7 +193,7 @@ public abstract class StatCounterTestsBase : IAsyncLifetime
         counterSum.ShouldBe(-1);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_AlreadyEnqueued_NoOp()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/StatsTests.cs
+++ b/src/core/Jobly.Tests/Unit/StatsTests.cs
@@ -18,7 +18,7 @@ public abstract class StatsTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task GetStatsHistory_ReturnsHourlyData()
     {
         // Arrange
@@ -36,7 +36,7 @@ public abstract class StatsTestsBase : IAsyncLifetime
         history.ShouldContain(p => p.Succeeded >= 5);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetJoblyStatus_ReturnsCorrectCounts()
     {
         // Arrange
@@ -90,7 +90,7 @@ public abstract class StatsTestsBase : IAsyncLifetime
         status.Total.ShouldBe(6);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetServers_ReturnsRegisteredServers()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/TypedMetadataTests.cs
+++ b/src/core/Jobly.Tests/Unit/TypedMetadataTests.cs
@@ -9,7 +9,7 @@ namespace Jobly.Tests.Unit;
 
 public class TypedMetadataTests
 {
-    [Fact]
+    [TimedFact]
     public void IRetryMetadata_GeneratedImpl_ExtendsFromDictionary()
     {
         var impl = MetadataFactory.Create<IRetryMetadata>([]);
@@ -17,7 +17,7 @@ public class TypedMetadataTests
         impl.ShouldBeAssignableTo<Dictionary<string, object>>();
     }
 
-    [Fact]
+    [TimedFact]
     public void IRetryMetadata_SetProperty_VisibleInDictionary()
     {
         var impl = MetadataFactory.Create<IRetryMetadata>([]);
@@ -28,7 +28,7 @@ public class TypedMetadataTests
         dict["MaxRetries"].ShouldBe(5);
     }
 
-    [Fact]
+    [TimedFact]
     public void IRetryMetadata_SetInDictionary_VisibleViaProperty()
     {
         var dict = new Dictionary<string, object> { ["MaxRetries"] = 3 };
@@ -37,7 +37,7 @@ public class TypedMetadataTests
         impl.MaxRetries.ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public void IRetryMetadata_ArrayProperty_RoundTrips()
     {
         var impl = MetadataFactory.Create<IRetryMetadata>([]);
@@ -51,7 +51,7 @@ public class TypedMetadataTests
         impl.RetryDelays[0].ShouldBe(15);
     }
 
-    [Fact]
+    [TimedFact]
     public void IRetryMetadata_DefaultValues_WhenKeysNotPresent()
     {
         var impl = MetadataFactory.Create<IRetryMetadata>([]);
@@ -61,7 +61,7 @@ public class TypedMetadataTests
         impl.RetryDelays.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public void IRetryMetadata_FromSerializedJson_ConvertsNativeTypes()
     {
         var json = """{"MaxRetries":3,"RetriedTimes":1,"RetryDelays":[15,60]}""";
@@ -74,7 +74,7 @@ public class TypedMetadataTests
         impl.RetryDelays.Length.ShouldBe(2);
     }
 
-    [Fact]
+    [TimedFact]
     public void ITestMetadata_GeneratedImpl_Works()
     {
         var impl = MetadataFactory.Create<ITestMetadata>([]);
@@ -87,7 +87,7 @@ public class TypedMetadataTests
         dict["TestCount"].ShouldBe(42);
     }
 
-    [Fact]
+    [TimedFact]
     public void TypedView_WritesVisibleInOwnDictionary()
     {
         var dict = new Dictionary<string, object>();
@@ -100,7 +100,7 @@ public class TypedMetadataTests
         implDict["MaxRetries"].ShouldBe(3);
     }
 
-    [Fact]
+    [TimedFact]
     public void JobContext_GetMetadata_WritesFlowToUnderlyingDictionary()
     {
         var jobContext = new JobContext
@@ -126,7 +126,7 @@ public class TypedMetadataTests
         typed.MaxRetries.ShouldBe(10);
     }
 
-    [Fact]
+    [TimedFact]
     public void PublishContext_GetMetadata_WritesFlowToUnderlyingDictionary()
     {
         var context = new PublishContext<object>
@@ -148,7 +148,7 @@ public class TypedMetadataTests
         context.Metadata["TestCount"].ShouldBe(42);
     }
 
-    [Fact]
+    [TimedFact]
     public void Serialize_TypedMetadata_ProducesCorrectJson()
     {
         var impl = MetadataFactory.Create<IRetryMetadata>([]);
@@ -164,7 +164,7 @@ public class TypedMetadataTests
         json.ShouldContain("\"RetryDelays\":[15,60]");
     }
 
-    [Fact]
+    [TimedFact]
     public void JobParameters_Configure_ChainedCalls_PreservesAllMetadata()
     {
         var parameters = new JobParameters()
@@ -181,7 +181,7 @@ public class TypedMetadataTests
         parameters.Metadata["TestCount"].ShouldBe(42);
     }
 
-    [Fact]
+    [TimedFact]
     public void JobParameters_Configure_SingleCall_SetsMetadata()
     {
         var parameters = new JobParameters()

--- a/src/core/Jobly.Tests/Unit/WorkerIdLogTests.cs
+++ b/src/core/Jobly.Tests/Unit/WorkerIdLogTests.cs
@@ -20,7 +20,7 @@ public abstract class WorkerIdLogTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [Fact]
+    [TimedFact]
     public async Task DeleteJob_LogHasNullWorkerId()
     {
         // Arrange
@@ -48,7 +48,7 @@ public abstract class WorkerIdLogTestsBase : IAsyncLifetime
         deletedLog.WorkerId.ShouldBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task RequeueJob_LogHasNullWorkerId()
     {
         // Arrange

--- a/src/core/Jobly.Tests/Unit/WorkerTests.cs
+++ b/src/core/Jobly.Tests/Unit/WorkerTests.cs
@@ -94,7 +94,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         return (worker, scopeFactory);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_EmptyQueue_ReturnsFalse()
     {
         // Arrange
@@ -107,7 +107,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_CompletesJob()
     {
         // Arrange
@@ -140,7 +140,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         job.HandlerType.ShouldNotBeNull();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_FailingJob_MarksFailed()
     {
         // Arrange
@@ -172,7 +172,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         job.CurrentState.ShouldBe(State.Failed);
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_SkipsFutureScheduledJob()
     {
         // Arrange
@@ -200,7 +200,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_SkipsNonSubscribedQueue()
     {
         // Arrange
@@ -228,7 +228,7 @@ public abstract class WorkerTestsBase : IAsyncLifetime
         result.ShouldBeFalse();
     }
 
-    [Fact]
+    [TimedFact]
     public async Task GetAndProcessJob_OnlyPicksJobKind()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Add `TimedFactAttribute` and `TimedTheoryAttribute` with a default 10-second timeout to prevent stuck tests
- Replace all `[Fact]` → `[TimedFact]` and `[Theory]` → `[TimedTheory]` across 767 tests (75 files)
- Individual tests can override: `[TimedFact(timeout: 30_000)]`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] 430/430 PostgreSQL tests pass
- [x] 767 tests discovered (same count as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)