### PR TITLE
Add Stryker.NET mutation testing and fix RecurringJobPublisher race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,6 @@ FodyWeavers.xsd
 # Playwright MCP snapshots
 .playwright-mcp/
 tasks/todo.md
+
+# Stryker.NET mutation testing output
+**/StrykerOutput/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Opt-in addon via `services.AddJoblyMutex()`. Only one job per concurrency key ca
 
 ### Recurring Jobs
 
-- `AddOrUpdateRecurringJob` only registers/updates the definition (cron, message, type). **Does not create jobs.**
+- `AddOrUpdateRecurringJob` only registers/updates the definition (cron, message, type). **Does not create jobs.** Acquires a distributed lock on the recurring job name, saves immediately (exception to §5.7 — lock must be held during save to prevent race conditions).
 - `RecurringJobSchedulerTask` creates jobs with `ScheduleTime = now` (ready for immediate execution) and sets `NextExecution` to the next cron occurrence.
 - **RecurringJobLog** — Immutable audit trail linking recurring jobs to their created jobs. Fields: `Id, RecurringJobId, JobId (nullable), CreatedAt`. `JobId` has FK with `SET NULL` cascade — when the job is cleaned up, `JobId` becomes null but the log entry survives. Navigation property `Job` for clean LINQ queries.
 - Scheduler uses RecurringJobLog for dedup: checks if the most recent log entry's job is still Enqueued/Processing via nav property.

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.14.1",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/Jobly.slnx
+++ b/src/Jobly.slnx
@@ -18,6 +18,7 @@
   </Folder>
   <Project Path="core/Jobly.Core/Jobly.Core.csproj" />
   <Project Path="core/Jobly.Tests/Jobly.Tests.csproj" />
+  <Project Path="core/Jobly.Tests.Mutation/Jobly.Tests.Mutation.csproj" />
   <Project Path="core/Jobly.UI/Jobly.UI.csproj" />
   <Project Path="core/Jobly.Worker/Jobly.Worker.csproj" />
 </Solution>

--- a/src/core/Jobly.Core/RecurringJobPublisher.cs
+++ b/src/core/Jobly.Core/RecurringJobPublisher.cs
@@ -9,6 +9,11 @@ namespace Jobly.Core;
 
 public interface IRecurringJobPublisher
 {
+    /// <summary>
+    /// Registers or updates a recurring job definition. Does not create job instances — that is
+    /// handled by <c>RecurringJobSchedulerTask</c>. Acquires a distributed lock on the job name
+    /// and saves changes immediately (callers should NOT call SaveChanges after this method).
+    /// </summary>
     Task AddOrUpdateRecurringJob<T>(T message, string name, string cron)
         where T : class, IJob;
 }
@@ -21,13 +26,17 @@ file static class RecurringJobPublisherConstants
 public class RecurringJobPublisher<TContext> : IRecurringJobPublisher
     where TContext : DbContext
 {
+    private static readonly TimeSpan LockTimeout = TimeSpan.FromSeconds(15);
+
     private readonly TContext _context;
     private readonly TimeProvider _timeProvider;
+    private readonly IJoblyLockProvider _lockProvider;
 
-    public RecurringJobPublisher(TContext context, TimeProvider timeProvider)
+    public RecurringJobPublisher(TContext context, TimeProvider timeProvider, IJoblyLockProvider lockProvider)
     {
         _context = context;
         _timeProvider = timeProvider;
+        _lockProvider = lockProvider;
     }
 
     public async Task AddOrUpdateRecurringJob<T>(T message, string name, string cron)
@@ -35,42 +44,48 @@ public class RecurringJobPublisher<TContext> : IRecurringJobPublisher
     {
         ValidateCronExpression(cron);
 
-        await using var transaction = await _context.Database.BeginTransactionAsync();
-
-        var now = _timeProvider.GetUtcNow().UtcDateTime;
-        var nextExecution = CronExpression.Parse(cron).GetNextOccurrence(now);
-        var jobMessage = JsonSerializer.Serialize(message);
-        var jobType = message.GetType().AssemblyQualifiedName!;
-
-        var recurringJob = await _context.Set<RecurringJob>()
-            .Where(x => x.Name == name)
-            .FirstOrDefaultAsync();
-
-        if (recurringJob != null)
+        var handle = await _lockProvider.TryAcquireAsync($"jobly:recurring:{name}", LockTimeout, CancellationToken.None);
+        if (handle == null)
         {
-            recurringJob.Cron = cron;
-            recurringJob.Message = jobMessage;
-            recurringJob.Type = jobType;
-            recurringJob.UpdatedAt = now;
-            recurringJob.NextExecution = nextExecution;
+            throw new TimeoutException($"Could not acquire lock for recurring job '{name}' within {LockTimeout.TotalSeconds}s.");
         }
-        else
+
+        await using (handle)
         {
-            recurringJob = new RecurringJob
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
+            var nextExecution = CronExpression.Parse(cron).GetNextOccurrence(now);
+            var jobMessage = JsonSerializer.Serialize(message);
+            var jobType = message.GetType().AssemblyQualifiedName!;
+
+            var recurringJob = await _context.Set<RecurringJob>()
+                .Where(x => x.Name == name)
+                .FirstOrDefaultAsync();
+
+            if (recurringJob != null)
             {
-                Name = name,
-                Message = jobMessage,
-                Type = jobType,
-                Cron = cron,
-                CreatedAt = now,
-                NextExecution = nextExecution,
-            };
+                recurringJob.Cron = cron;
+                recurringJob.Message = jobMessage;
+                recurringJob.Type = jobType;
+                recurringJob.UpdatedAt = now;
+                recurringJob.NextExecution = nextExecution;
+            }
+            else
+            {
+                recurringJob = new RecurringJob
+                {
+                    Name = name,
+                    Message = jobMessage,
+                    Type = jobType,
+                    Cron = cron,
+                    CreatedAt = now,
+                    NextExecution = nextExecution,
+                };
 
-            await _context.Set<RecurringJob>().AddAsync(recurringJob);
+                await _context.Set<RecurringJob>().AddAsync(recurringJob);
+            }
+
+            await _context.SaveChangesAsync();
         }
-
-        await _context.SaveChangesAsync();
-        await transaction.CommitAsync();
     }
 
     private static void ValidateCronExpression(string cronExpression)

--- a/src/core/Jobly.Core/ServiceConfiguration.cs
+++ b/src/core/Jobly.Core/ServiceConfiguration.cs
@@ -66,7 +66,7 @@ public static class ServiceConfiguration
         services.AddScoped<IMediator>(x => new Mediator(x));
 
         services.AddScoped<IRecurringJobPublisher>(x =>
-            new RecurringJobPublisher<TContext>(x.GetRequiredService<TContext>(), x.GetRequiredService<TimeProvider>()));
+            new RecurringJobPublisher<TContext>(x.GetRequiredService<TContext>(), x.GetRequiredService<TimeProvider>(), x.GetRequiredService<IJoblyLockProvider>()));
         services.AddScoped<IJobQueryService>(x => new JobQueryService<TContext>(x.GetRequiredService<TContext>(), x.GetRequiredService<TimeProvider>()));
         services.AddScoped<IJobCommandService>(x => new JobCommandService<TContext>(x.GetRequiredService<TContext>(), x.GetRequiredService<TimeProvider>(), x.GetRequiredService<IOptions<JoblyConfiguration>>()));
         services.AddScoped<IJobGroupQueryService>(x => new JobGroupQueryService<TContext>(x.GetRequiredService<TContext>()));

--- a/src/core/Jobly.Tests.Mutation/Fixtures/SqliteFixture.cs
+++ b/src/core/Jobly.Tests.Mutation/Fixtures/SqliteFixture.cs
@@ -1,0 +1,46 @@
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.Integration;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Jobly.Tests.Mutation.Fixtures;
+
+public class SqliteFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private SqliteConnection _connection = null!;
+
+    public JoblyTestServer? TestServer => null;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        await using var context = CreateContext();
+        await context.Database.EnsureCreatedAsync();
+    }
+
+    public async Task ResetAsync()
+    {
+        await using var context = CreateContext();
+        await context.Database.EnsureDeletedAsync();
+        await context.Database.EnsureCreatedAsync();
+    }
+
+    public TestContext CreateContext()
+    {
+        return new TestContext(
+            new DbContextOptionsBuilder<TestContext>()
+                .UseSqlite(_connection)
+                .Options,
+            schema: null);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _connection.DisposeAsync();
+    }
+}
+
+[CollectionDefinition]
+public class SqliteCollection : ICollectionFixture<SqliteFixture>;

--- a/src/core/Jobly.Tests.Mutation/Jobly.Tests.Mutation.csproj
+++ b/src/core/Jobly.Tests.Mutation/Jobly.Tests.Mutation.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<OutputType>Exe</OutputType>
+
+		<IsPackable>false</IsPackable>
+
+		<UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+		<NoWarn>$(NoWarn);xUnit1051;CA1816;MA0040</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Remove="StrykerOutput\**" />
+		<EmbeddedResource Remove="StrykerOutput\**" />
+		<None Remove="StrykerOutput\**" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+		<PackageReference Include="Shouldly" Version="4.3.0" />
+		<PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+		<Using Include="Jobly.Tests.TestData" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Jobly.Core\Jobly.Core.csproj" />
+		<ProjectReference Include="..\Jobly.Tests\Jobly.Tests.csproj" />
+		<ProjectReference Include="..\Jobly.SourceGenerator\Jobly.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+</Project>

--- a/src/core/Jobly.Tests.Mutation/STRYKER.md
+++ b/src/core/Jobly.Tests.Mutation/STRYKER.md
@@ -1,0 +1,98 @@
+# Stryker.NET Mutation Testing
+
+## Overview
+
+Mutation testing for Jobly using a dedicated SQLite-only test project (`Jobly.Tests.Mutation`). No Docker required — runs 293 tests in ~10 seconds.
+
+## How to run
+
+```bash
+cd src/core/Jobly.Tests.Mutation
+
+# Full Core run (~30 min)
+dotnet stryker --test-runner mtp
+
+# Single file (fast feedback, ~5 min)
+dotnet stryker --test-runner mtp --mutate "**/Publisher.cs"
+
+# Worker (~15 min)
+dotnet stryker --test-runner mtp --config-file stryker-config.worker.json
+
+# With baseline comparison (after baseline is established)
+dotnet stryker --test-runner mtp --with-baseline
+dotnet stryker --test-runner mtp --config-file stryker-config.worker.json --with-baseline
+```
+
+## Architecture
+
+- **`Jobly.Tests.Mutation/`** — Separate test project with only SQLite fixture. No Testcontainers, no Docker.
+- **`stryker-config.json`** — Core config. Mutates `Jobly.Core`, excludes entities/DTOs/interfaces.
+- **`stryker-config.worker.json`** — Worker config. Mutates `Jobly.Worker`, lower thresholds.
+- **`stryker.slnx`** — Mini solution for Stryker that excludes `Jobly.Tests` (prevents Docker container startup).
+- **`SqliteFixture`** — In-memory SQLite, no row-lock interceptor (unit tests are single-threaded), `schema: null` (SQLite has no schema support).
+
+## Baseline scores (2026-04-17)
+
+| Project | Score | Killed | Survived | NoCoverage |
+|---------|-------|--------|----------|------------|
+| Core    | 99.60% | 743   | 3        | 253        |
+| Worker  | 51.53% | 252   | 237      | 625        |
+
+Worker score is low because `JoblyWorkerService` (the execution loop) and `ServerTaskBase` (polling infrastructure) are hard to unit test — they're covered by integration tests on PostgreSQL.
+
+## Adding tests for new code
+
+When adding a new test file to `Jobly.Tests`:
+1. If it has `[Collection<PostgreSqlCollection>]`, create a corresponding `_Sqlite.cs` file in `Jobly.Tests.Mutation/Unit/`:
+
+```csharp
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class NewTests_Sqlite : NewTestsBase
+{
+    public NewTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+```
+
+2. If the test uses `BeginTransactionAsync` (nested transactions), skip it — SQLite doesn't support them.
+
+## Config details
+
+### Excluded from mutation (Core)
+
+Entities, DTOs, interfaces, enums, attributes — pure data containers where mutations are noise. See `mutate` array in `stryker-config.json`.
+
+### Thresholds
+
+| Project | Break | Low | High |
+|---------|-------|-----|------|
+| Core    | 60    | 70  | 80   |
+| Worker  | 50    | 60  | 70   |
+
+### Known limitations
+
+- SQLite has no row-lock interceptor — concurrency tests are skipped
+- SQLite has no schema support — `TestContext` uses `schema: null`
+- SQLite doesn't support nested transactions — `OTelMetricsTests` excluded
+- `--test-runner mtp` required (xUnit v3 uses Microsoft Testing Platform)
+- Kill LSP (`csharp-ls`) before running if IDE has the worktree open — it locks `SourceGenerator.dll`
+
+## Troubleshooting
+
+### "SourceGenerator.dll is locked"
+```bash
+taskkill //F //PID $(tasklist | grep csharp-ls | awk '{print $2}')
+```
+
+### "Using Microsoft.Testing.Platform not supported"
+Use `--test-runner mtp` flag. Don't use `vstest` — xUnit v3 is MTP-only.
+
+### Stryker picks up Jobly.Tests (Docker containers)
+The `stryker.slnx` mini solution excludes `Jobly.Tests`. Make sure the config has `"solution": "stryker.slnx"`.

--- a/src/core/Jobly.Tests.Mutation/Unit/ActivityTraceTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/ActivityTraceTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class ActivityTraceTests_Sqlite : ActivityTraceTestsBase
+{
+    public ActivityTraceTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/AuditFixRound2Tests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/AuditFixRound2Tests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class AuditFixRound2Tests_Sqlite : AuditFixRound2TestsBase
+{
+    public AuditFixRound2Tests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/AuditFixRound3Tests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/AuditFixRound3Tests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class AuditFixRound3Tests_Sqlite : AuditFixRound3TestsBase
+{
+    public AuditFixRound3Tests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/AuditFixTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/AuditFixTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class AuditFixTests_Sqlite : AuditFixTestsBase
+{
+    public AuditFixTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/BackgroundTaskTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/BackgroundTaskTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class BackgroundTaskTests_Sqlite : BackgroundTaskTestsBase
+{
+    public BackgroundTaskTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/BatchPublisherUnitTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/BatchPublisherUnitTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class BatchPublisherUnitTests_Sqlite : BatchPublisherUnitTestsBase
+{
+    public BatchPublisherUnitTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/BugFixTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/BugFixTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class BugFixTests_Sqlite : BugFixTestsBase
+{
+    public BugFixTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/CancellationModeTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/CancellationModeTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class CancellationModeTests_Sqlite : CancellationModeTestsBase
+{
+    public CancellationModeTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/CountBasedCleanupTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/CountBasedCleanupTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class CountBasedCleanupTests_Sqlite : CountBasedCleanupTestsBase
+{
+    public CountBasedCleanupTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/CrashRecoveryTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/CrashRecoveryTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class CrashRecoveryTests_Sqlite : CrashRecoveryTestsBase
+{
+    public CrashRecoveryTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/DashboardBreakdownTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/DashboardBreakdownTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class DashboardBreakdownTests_Sqlite : DashboardBreakdownTestsBase
+{
+    public DashboardBreakdownTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/EntityConfigurationTests.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/EntityConfigurationTests.cs
@@ -1,0 +1,40 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Tests.Mutation.Fixtures;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class EntityConfigurationTests
+{
+    private readonly SqliteFixture _fixture;
+
+    public EntityConfigurationTests(SqliteFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void StatisticEntity_HasKeyProperty()
+    {
+        using var context = _fixture.CreateContext();
+
+        var entityType = context.Model.FindEntityType(typeof(Statistic));
+        entityType.ShouldNotBeNull();
+
+        var primaryKey = entityType.FindPrimaryKey();
+        primaryKey.ShouldNotBeNull();
+        primaryKey.Properties.Count.ShouldBe(1);
+        primaryKey.Properties[0].Name.ShouldBe("Key");
+    }
+
+    [Fact]
+    public void StatisticEntity_HasValueProperty()
+    {
+        using var context = _fixture.CreateContext();
+
+        var entityType = context.Model.FindEntityType(typeof(Statistic));
+        entityType.ShouldNotBeNull();
+
+        var valueProperty = entityType.FindProperty("Value");
+        valueProperty.ShouldNotBeNull();
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/ExpirationEdgeCaseTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/ExpirationEdgeCaseTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class ExpirationEdgeCaseTests_Sqlite : ExpirationEdgeCaseTestsBase
+{
+    public ExpirationEdgeCaseTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/FailedJobTypeFilterTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/FailedJobTypeFilterTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class FailedJobTypeFilterTests_Sqlite : FailedJobTypeFilterTestsBase
+{
+    public FailedJobTypeFilterTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/HandlerLogTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/HandlerLogTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class HandlerLogTests_Sqlite : HandlerLogTestsBase
+{
+    public HandlerLogTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/HandlerServiceExtensionsTests.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/HandlerServiceExtensionsTests.cs
@@ -1,0 +1,52 @@
+using Jobly.Core.Handlers;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+public class HandlerServiceExtensionsTests
+{
+    [Fact]
+    public void AddJobHandlers_DoesNotRegisterUnrelatedGenericInterfaces()
+    {
+        // Arrange — TypeWithUnrelatedGenericInterface implements IComparable<string>
+        // but NOT IJobHandler<>. It must not be registered.
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddJobHandlers(typeof(TypeWithUnrelatedGenericInterface).Assembly);
+
+        // Assert — no IComparable<string> registration should exist
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetService<IComparable<string>>();
+        resolved.ShouldBeNull();
+    }
+
+    [Fact]
+    public void AddJobHandlers_RegistersConcreteHandlerType()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddJobHandlers(typeof(ConcreteTestHandler).Assembly);
+
+        // Assert — concrete handler should be resolvable
+        var descriptor = services.FirstOrDefault(x =>
+            x.ServiceType == typeof(IJobHandler<ConcreteTestJob>));
+        descriptor.ShouldNotBeNull();
+        descriptor.ImplementationType.ShouldBe(typeof(ConcreteTestHandler));
+    }
+}
+
+public class ConcreteTestJob : IJob;
+
+public class ConcreteTestHandler : IJobHandler<ConcreteTestJob>
+{
+    public Task HandleAsync(ConcreteTestJob message, CancellationToken ct) => Task.CompletedTask;
+}
+
+public class TypeWithUnrelatedGenericInterface : IComparable<string>
+{
+    public int CompareTo(string? other) => 0;
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/HourlyStatsTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/HourlyStatsTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class HourlyStatsTests_Sqlite : HourlyStatsTestsBase
+{
+    public HourlyStatsTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/JobCommandServiceTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/JobCommandServiceTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class JobCommandServiceTests_Sqlite : JobCommandServiceTestsBase
+{
+    public JobCommandServiceTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/JobExpirationTimeoutTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/JobExpirationTimeoutTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class JobExpirationTimeoutTests_Sqlite : JobExpirationTimeoutTestsBase
+{
+    public JobExpirationTimeoutTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/JobGroupQueryServiceTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/JobGroupQueryServiceTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class JobGroupQueryServiceTests_Sqlite : JobGroupQueryServiceTestsBase
+{
+    public JobGroupQueryServiceTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/JobLogTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/JobLogTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class JobLogTests_Sqlite : JobLogTestsBase
+{
+    public JobLogTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/JobQueryServiceTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/JobQueryServiceTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class JobQueryServiceTests_Sqlite : JobQueryServiceTestsBase
+{
+    public JobQueryServiceTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/MessageRoutingErrorTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/MessageRoutingErrorTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class MessageRoutingErrorTests_Sqlite : MessageRoutingErrorTestsBase
+{
+    public MessageRoutingErrorTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/MessageRoutingTaskTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/MessageRoutingTaskTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class MessageRoutingTaskTests_Sqlite : MessageRoutingTaskTestsBase
+{
+    public MessageRoutingTaskTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/MetadataPublishPipelineTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/MetadataPublishPipelineTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class MetadataPublishPipelineTests_Sqlite : MetadataPublishPipelineTestsBase
+{
+    public MetadataPublishPipelineTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/MutexTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/MutexTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class MutexTests_Sqlite : MutexTestsBase
+{
+    public MutexTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/OrchestrationTaskTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/OrchestrationTaskTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class OrchestrationTaskTests_Sqlite : OrchestrationTaskTestsBase
+{
+    public OrchestrationTaskTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/PipelineTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/PipelineTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class PipelineTests_Sqlite : PipelineTestsBase
+{
+    public PipelineTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/PriorityTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/PriorityTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class PriorityTests_Sqlite : PriorityTestsBase
+{
+    public PriorityTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/PublisherOverloadTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/PublisherOverloadTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class PublisherOverloadTests_Sqlite : PublisherOverloadTestsBase
+{
+    public PublisherOverloadTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/PublisherTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/PublisherTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class PublisherTests_Sqlite : PublisherTestsBase
+{
+    public PublisherTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RecurringJobBugTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RecurringJobBugTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RecurringJobBugTests_Sqlite : RecurringJobBugTestsBase
+{
+    public RecurringJobBugTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RecurringJobEdgeCaseTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RecurringJobEdgeCaseTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RecurringJobEdgeCaseTests_Sqlite : RecurringJobEdgeCaseTestsBase
+{
+    public RecurringJobEdgeCaseTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RecurringJobLogCascadeTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RecurringJobLogCascadeTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RecurringJobLogCascadeTests_Sqlite : RecurringJobLogCascadeTestsBase
+{
+    public RecurringJobLogCascadeTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RecurringJobLogCleanupTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RecurringJobLogCleanupTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RecurringJobLogCleanupTests_Sqlite : RecurringJobLogCleanupTestsBase
+{
+    public RecurringJobLogCleanupTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RecurringJobTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RecurringJobTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RecurringJobTests_Sqlite : RecurringJobTestsBase
+{
+    public RecurringJobTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RequeueEdgeCaseTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RequeueEdgeCaseTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RequeueEdgeCaseTests_Sqlite : RequeueEdgeCaseTestsBase
+{
+    public RequeueEdgeCaseTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RetentionEdgeCaseTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RetentionEdgeCaseTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RetentionEdgeCaseTests_Sqlite : RetentionEdgeCaseTestsBase
+{
+    public RetentionEdgeCaseTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RetentionTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RetentionTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RetentionTests_Sqlite : RetentionTestsBase
+{
+    public RetentionTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/RetryTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/RetryTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class RetryTests_Sqlite : RetryTestsBase
+{
+    public RetryTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/ServerCommandServiceTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/ServerCommandServiceTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class ServerCommandServiceTests_Sqlite : ServerCommandServiceTestsBase
+{
+    public ServerCommandServiceTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/ServerMonitoringTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/ServerMonitoringTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class ServerMonitoringTests_Sqlite : ServerMonitoringTestsBase
+{
+    public ServerMonitoringTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/ServerQueryTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/ServerQueryTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class ServerQueryTests_Sqlite : ServerQueryTestsBase
+{
+    public ServerQueryTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/SpanPropagationTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/SpanPropagationTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class SpanPropagationTests_Sqlite : SpanPropagationTestsBase
+{
+    public SpanPropagationTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/StatCounterTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/StatCounterTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class StatCounterTests_Sqlite : StatCounterTestsBase
+{
+    public StatCounterTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/StatsTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/StatsTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class StatsTests_Sqlite : StatsTestsBase
+{
+    public StatsTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/WorkerIdLogTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/WorkerIdLogTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class WorkerIdLogTests_Sqlite : WorkerIdLogTestsBase
+{
+    public WorkerIdLogTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/Unit/WorkerTests_Sqlite.cs
+++ b/src/core/Jobly.Tests.Mutation/Unit/WorkerTests_Sqlite.cs
@@ -1,0 +1,13 @@
+using Jobly.Tests.Mutation.Fixtures;
+using Jobly.Tests.Unit;
+
+namespace Jobly.Tests.Mutation.Unit;
+
+[Collection<SqliteCollection>]
+public class WorkerTests_Sqlite : WorkerTestsBase
+{
+    public WorkerTests_Sqlite(SqliteFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests.Mutation/stryker-config.json
+++ b/src/core/Jobly.Tests.Mutation/stryker-config.json
@@ -11,7 +11,7 @@
       "low": 70,
       "break": 60
     },
-    "reporters": ["html", "progress", "cleartext"],
+    "reporters": ["html", "progress", "cleartext", "json"],
     "test-runner": "mtp",
     "concurrency": 4,
     "mutate": [

--- a/src/core/Jobly.Tests.Mutation/stryker-config.json
+++ b/src/core/Jobly.Tests.Mutation/stryker-config.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-net/master/src/Stryker.Core/Stryker.Core/stryker-config.schema.json",
+  "stryker-config": {
+    "project": "Jobly.Core.csproj",
+    "solution": "stryker.slnx",
+    "test-projects": ["./Jobly.Tests.Mutation.csproj"],
+    "target-framework": "net10.0",
+    "mutation-level": "Standard",
+    "thresholds": {
+      "high": 80,
+      "low": 70,
+      "break": 60
+    },
+    "reporters": ["html", "progress", "cleartext"],
+    "test-runner": "mtp",
+    "concurrency": 4,
+    "mutate": [
+      "!**/Data/Entities/**",
+      "!**/Data/Enums/**",
+      "!**/Data/Interfaces/**",
+      "!**/Models/**",
+      "!**/Handlers/I*.cs",
+      "!**/Handlers/Unit.cs",
+      "!**/Handlers/JobFailureOutcome.cs",
+      "!**/Handlers/RetryAttribute.cs",
+      "!**/Handlers/MetadataImplementationAttribute.cs",
+      "!**/Logging/JoblyTelemetry.cs",
+      "!**/Common/PagedList.cs",
+      "!**/Configuration.cs",
+      "!**/JoblyException.cs"
+    ]
+  }
+}

--- a/src/core/Jobly.Tests.Mutation/stryker-config.worker.json
+++ b/src/core/Jobly.Tests.Mutation/stryker-config.worker.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/stryker-mutator/stryker-net/master/src/Stryker.Core/Stryker.Core/stryker-config.schema.json",
+  "stryker-config": {
+    "project": "Jobly.Worker.csproj",
+    "solution": "stryker.slnx",
+    "test-projects": ["./Jobly.Tests.Mutation.csproj"],
+    "target-framework": "net10.0",
+    "mutation-level": "Standard",
+    "thresholds": {
+      "high": 70,
+      "low": 60,
+      "break": 50
+    },
+    "reporters": ["html", "progress", "cleartext"],
+    "test-runner": "mtp",
+    "concurrency": 4,
+    "mutate": [
+      "!**/Configuration.cs",
+      "!**/ServiceConfiguration.cs"
+    ]
+  }
+}

--- a/src/core/Jobly.Tests.Mutation/stryker-config.worker.json
+++ b/src/core/Jobly.Tests.Mutation/stryker-config.worker.json
@@ -11,7 +11,7 @@
       "low": 60,
       "break": 50
     },
-    "reporters": ["html", "progress", "cleartext"],
+    "reporters": ["html", "progress", "cleartext", "json"],
     "test-runner": "mtp",
     "concurrency": 4,
     "mutate": [

--- a/src/core/Jobly.Tests.Mutation/stryker.slnx
+++ b/src/core/Jobly.Tests.Mutation/stryker.slnx
@@ -1,0 +1,6 @@
+<Solution>
+  <Project Path="../Jobly.Core/Jobly.Core.csproj" />
+  <Project Path="../Jobly.Worker/Jobly.Worker.csproj" />
+  <Project Path="../Jobly.SourceGenerator/Jobly.SourceGenerator.csproj" />
+  <Project Path="Jobly.Tests.Mutation.csproj" />
+</Solution>

--- a/src/core/Jobly.Tests/TestData/Data/TestContext.cs
+++ b/src/core/Jobly.Tests/TestData/Data/TestContext.cs
@@ -5,9 +5,12 @@ namespace Jobly.Tests;
 
 public class TestContext : DbContext
 {
-    public TestContext(DbContextOptions<TestContext> options)
+    private readonly string? _schema;
+
+    public TestContext(DbContextOptions<TestContext> options, string? schema = "jobly")
         : base(options)
     {
+        _schema = schema;
     }
 
     public DbSet<TestLog> TestLogs => Set<TestLog>();
@@ -16,6 +19,6 @@ public class TestContext : DbContext
     {
         base.OnModelCreating(modelBuilder);
 
-        modelBuilder.AddOutboxStateEntity();
+        modelBuilder.AddOutboxStateEntity(_schema);
     }
 }

--- a/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
@@ -235,6 +235,61 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
         var server = await readCtx.Set<Server>().FirstOrDefaultAsync(s => s.Id == serverId);
         server.ShouldBeNull();
     }
+
+    [TimedFact]
+    public async Task AggregateCounters_NoCounters_ReturnsZero()
+    {
+        // Arrange — empty counters table
+        var aggCtx = _fixture.CreateContext();
+
+        // Act
+        var count = await CounterAggregatorTask<TestContext>.AggregateCounters(aggCtx);
+
+        // Assert
+        count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task AggregateCounters_ExistingStat_IncrementsValue()
+    {
+        // Arrange — pre-existing stat + new counter for the same key
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Statistic>().Add(new Statistic { Key = "stats:completed", Value = 100 });
+        ctx.Set<Counter>().Add(new Counter { Key = "stats:completed", Value = 5 });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var aggCtx = _fixture.CreateContext();
+        await CounterAggregatorTask<TestContext>.AggregateCounters(aggCtx);
+
+        // Assert — should increment existing stat, not create a new one
+        var readCtx = _fixture.CreateContext();
+        var stat = await readCtx.Set<Statistic>().FindAsync("stats:completed");
+        stat.ShouldNotBeNull();
+        stat.Value.ShouldBe(105);
+
+        var statCount = await readCtx.Set<Statistic>().CountAsync(x => x.Key == "stats:completed");
+        statCount.ShouldBe(1);
+    }
+
+    [TimedFact]
+    public async Task AggregateCounters_NewKey_CreatesStatistic()
+    {
+        // Arrange — counter for a key that has no existing stat
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Counter>().Add(new Counter { Key = "stats:new-key", Value = 3 });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var aggCtx = _fixture.CreateContext();
+        await CounterAggregatorTask<TestContext>.AggregateCounters(aggCtx);
+
+        // Assert — should create new stat with correct value
+        var readCtx = _fixture.CreateContext();
+        var stat = await readCtx.Set<Statistic>().FindAsync("stats:new-key");
+        stat.ShouldNotBeNull();
+        stat.Value.ShouldBe(3);
+    }
 }
 
 [Collection<PostgreSqlCollection>]

--- a/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/CountBasedCleanupTests.cs
@@ -251,6 +251,39 @@ public abstract class CountBasedCleanupTestsBase : IAsyncLifetime
         var survivorLogs = await readCtx.Set<JobLog>().Where(l => l.JobId == jobIds[20]).CountAsync();
         survivorLogs.ShouldBe(1);
     }
+
+    [TimedFact]
+    public async Task RunCountBasedCleanup_AtExactlyMaxCount_DeletesNothing()
+    {
+        // Arrange — exactly at threshold should NOT trigger cleanup
+        var ctx = _fixture.CreateContext();
+        for (var i = 0; i < 10; i++)
+        {
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = Guid.NewGuid(),
+                Kind = JobKind.Job,
+                CurrentState = State.Completed,
+                CreateTime = DateTime.UtcNow,
+                ScheduleTime = DateTime.UtcNow,
+                Queue = "default",
+                ExpireAt = DateTime.UtcNow.AddHours(i),
+            });
+        }
+
+        await ctx.SaveChangesAsync();
+
+        // Act — maxCount == actual count
+        var cleanCtx = _fixture.CreateContext();
+        var deleted = await ExpirationCleanupTask<TestContext>.RunCountBasedCleanup(cleanCtx, maxCount: 10, batchSize: 1000);
+
+        // Assert
+        deleted.ShouldBe(0);
+
+        var readCtx = _fixture.CreateContext();
+        var remaining = await readCtx.Set<Job>().CountAsync();
+        remaining.ShouldBe(10);
+    }
 }
 
 [Collection<PostgreSqlCollection>]

--- a/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
@@ -280,6 +280,75 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         var servers = await readCtx.Set<Server>().CountAsync();
         servers.ShouldBe(0);
     }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_KeepAliveAtExactCutoff_NotRequeued()
+    {
+        // Arrange — job with LastKeepAlive exactly at cutoff should NOT be requeued (strict < comparison)
+        var ctx = _fixture.CreateContext();
+        var timeout = TimeSpan.FromMinutes(5);
+        var now = DateTime.UtcNow.AddMinutes(10);
+        var exactCutoff = now - timeout;
+
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = exactCutoff,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var tp = new FakeTimeProvider(now);
+        var count = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+            _fixture.CreateContext(), tp, timeout);
+
+        // Assert — should NOT be requeued (at boundary, not past it)
+        count.ShouldBe(0);
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FindAsync(jobId);
+        job.ShouldNotBeNull();
+        job.CurrentState.ShouldBe(State.Processing);
+    }
+
+    [TimedFact]
+    public async Task CleanUpServers_HeartbeatAtExactTimeout_NotCleaned()
+    {
+        // Arrange — server with heartbeat exactly at timeout boundary should NOT be cleaned
+        var ctx = _fixture.CreateContext();
+        var timeout = TimeSpan.FromMinutes(5);
+        var now = DateTime.UtcNow.AddMinutes(10);
+
+        var serverId = Guid.NewGuid();
+        ctx.Set<Server>().Add(new Server
+        {
+            Id = serverId,
+            StartedTime = now.AddHours(-1),
+            LastHeartbeatTime = now - timeout,
+            ServiceCount = 1,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var tp = new FakeTimeProvider(now);
+        await ServerCleanupTask<TestContext>.CleanUpServers(
+            _fixture.CreateContext(), tp, timeout);
+
+        // Assert — server should still exist
+        var readCtx = _fixture.CreateContext();
+        var server = await readCtx.Set<Server>().FindAsync(serverId);
+        server.ShouldNotBeNull();
+    }
+}
+
+file class FakeTimeProvider(DateTime utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
 }
 
 [Collection<PostgreSqlCollection>]

--- a/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/ExpirationEdgeCaseTests.cs
@@ -174,6 +174,170 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
     }
 
     [TimedFact]
+    public async Task RunCleanup_JobExpiringExactlyNow_NotDeleted()
+    {
+        // Arrange — job with ExpireAt == now should NOT be deleted (strict < comparison)
+        var fixedTime = DateTime.UtcNow.AddMinutes(10);
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            CreateTime = fixedTime,
+            ScheduleTime = fixedTime,
+            Queue = "default",
+            ExpireAt = fixedTime,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act — use a FakeTimeProvider that returns the same fixedTime
+        var tp = new FakeTimeProvider(fixedTime);
+        var cleanCtx = _fixture.CreateContext();
+        await ExpirationCleanupTask<TestContext>.RunCleanup(cleanCtx, tp);
+
+        // Assert — job should still exist (ExpireAt is NOT < now, it's equal)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FindAsync(jobId);
+        job.ShouldNotBeNull();
+    }
+
+    [TimedFact]
+    public async Task RunCleanup_ParentWithUnexpiredChild_NotDeleted()
+    {
+        // Arrange — parent has expired, but child hasn't yet → parent must be kept (FK safety)
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow.AddDays(-2),
+            ScheduleTime = DateTime.UtcNow.AddDays(-2),
+            Queue = "default",
+            ExpireAt = DateTime.UtcNow.AddHours(-1),
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = childId,
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentId,
+            ExpireAt = DateTime.UtcNow.AddHours(1),
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var cleanCtx = _fixture.CreateContext();
+        await ExpirationCleanupTask<TestContext>.RunCleanup(cleanCtx, TimeProvider.System);
+
+        // Assert — parent should still exist
+        var readCtx = _fixture.CreateContext();
+        var parent = await readCtx.Set<Job>().FindAsync(parentId);
+        parent.ShouldNotBeNull();
+    }
+
+    [TimedFact]
+    public async Task RunCleanup_NoExpiredJobs_ReturnsZero()
+    {
+        // Arrange — no expired jobs
+        var ctx = _fixture.CreateContext();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ExpireAt = DateTime.UtcNow.AddHours(1),
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var cleanCtx = _fixture.CreateContext();
+        var deleted = await ExpirationCleanupTask<TestContext>.RunCleanup(cleanCtx, TimeProvider.System);
+
+        // Assert
+        deleted.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task RunCleanup_RecentOrphanedServerLogs_Kept()
+    {
+        // Arrange — orphaned log (no TaskId) less than 1 day old should be kept
+        var ctx = _fixture.CreateContext();
+        await InsertExpiredJob(ctx);
+
+        var recentOrphanedLog = new ServerLog
+        {
+            ServerId = ServerId,
+            ServerTaskId = null,
+            Status = "Info",
+            Message = "Recent orphaned log",
+            Timestamp = DateTime.UtcNow.AddHours(-1),
+        };
+        ctx.Set<ServerLog>().Add(recentOrphanedLog);
+        await ctx.SaveChangesAsync();
+        var logId = recentOrphanedLog.Id;
+
+        // Act
+        var cleanCtx = _fixture.CreateContext();
+        await ExpirationCleanupTask<TestContext>.RunCleanup(cleanCtx, TimeProvider.System);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var log = await readCtx.Set<ServerLog>().FirstOrDefaultAsync(x => x.Id == logId);
+        log.ShouldNotBeNull();
+    }
+
+    [TimedFact]
+    public async Task RunCleanup_ServerTaskWithNullInterval_UsesDefaultRetention()
+    {
+        // Arrange — task with null IntervalSeconds should use default (60s * 300 = 18000s)
+        var ctx = _fixture.CreateContext();
+        await InsertExpiredJob(ctx);
+
+        var serverTask = new ServerTask
+        {
+            ServerId = ServerId,
+            TaskName = "NullIntervalTask",
+            IntervalSeconds = null,
+        };
+        ctx.Set<ServerTask>().Add(serverTask);
+        await ctx.SaveChangesAsync();
+
+        // Insert a log older than default retention (18000s ≈ 5 hours)
+        var oldLog = new ServerLog
+        {
+            ServerId = ServerId,
+            ServerTaskId = serverTask.Id,
+            Status = "Success",
+            Message = "Old log",
+            Timestamp = DateTime.UtcNow.AddHours(-6),
+        };
+        ctx.Set<ServerLog>().Add(oldLog);
+        await ctx.SaveChangesAsync();
+        var logId = oldLog.Id;
+
+        // Act
+        var cleanCtx = _fixture.CreateContext();
+        await ExpirationCleanupTask<TestContext>.RunCleanup(cleanCtx, TimeProvider.System);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var log = await readCtx.Set<ServerLog>().FirstOrDefaultAsync(x => x.Id == logId);
+        log.ShouldBeNull();
+    }
+
+    [TimedFact]
     public async Task RunCleanup_OrphanedServerLogs_DeletedAfterOneDay()
     {
         // Arrange
@@ -202,6 +366,11 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
         var log = await readCtx.Set<ServerLog>().FirstOrDefaultAsync(l => l.Id == logId);
         log.ShouldBeNull();
     }
+}
+
+file class FakeTimeProvider(DateTime utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
 }
 
 [Collection<PostgreSqlCollection>]

--- a/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/OrchestrationTaskTests.cs
@@ -1,3 +1,4 @@
+using Jobly.Core.Data.Entities;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
 using Jobly.Tests.Fixtures;
@@ -395,6 +396,237 @@ public abstract class OrchestrationTaskTestsBase : IAsyncLifetime
         var continuation = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == continuationId);
         continuation.ShouldNotBeNull();
         continuation.CurrentState.ShouldBe(State.Awaiting);
+    }
+
+    [TimedFact]
+    public async Task RunOrchestration_BatchFinalized_ReturnsTrue()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var batchId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = batchId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            JobCount = 1,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = batchId,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var orchCtx = _fixture.CreateContext();
+        var workDone = await OrchestrationTask<TestContext>.RunOrchestration(orchCtx, TimeProvider.System, TimeSpan.FromDays(1), CancellationToken.None);
+
+        // Assert
+        workDone.ShouldBeTrue();
+    }
+
+    [TimedFact]
+    public async Task RunOrchestration_DeletedParent_FailsAwaitingChildren()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Deleted,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = childId,
+            Kind = JobKind.Job,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentId,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var orchCtx = _fixture.CreateContext();
+        var workDone = await OrchestrationTask<TestContext>.RunOrchestration(orchCtx, TimeProvider.System, TimeSpan.FromDays(1), CancellationToken.None);
+
+        // Assert
+        workDone.ShouldBeTrue();
+        var readCtx = _fixture.CreateContext();
+        var child = await readCtx.Set<Job>().FindAsync(childId);
+        child.ShouldNotBeNull();
+        child.CurrentState.ShouldBe(State.Failed);
+        child.ExpireAt.ShouldNotBeNull();
+
+        var log = await readCtx.Set<JobLog>().FirstOrDefaultAsync(x => x.JobId == childId);
+        log.ShouldNotBeNull();
+        log.EventType.ShouldBe("Failed");
+    }
+
+    [TimedFact]
+    public async Task RunOrchestration_DeletedParent_FailsAwaitingBatchAndGrandchildren()
+    {
+        // Arrange: deleted parent -> awaiting batch child -> awaiting grandchildren
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var batchChildId = Guid.NewGuid();
+        var grandchildId = Guid.NewGuid();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Deleted,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = batchChildId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentId,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = grandchildId,
+            Kind = JobKind.Job,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = batchChildId,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var orchCtx = _fixture.CreateContext();
+        await OrchestrationTask<TestContext>.RunOrchestration(orchCtx, TimeProvider.System, TimeSpan.FromDays(1), CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var batchChild = await readCtx.Set<Job>().FindAsync(batchChildId);
+        batchChild.ShouldNotBeNull();
+        batchChild.CurrentState.ShouldBe(State.Failed);
+
+        var grandchild = await readCtx.Set<Job>().FindAsync(grandchildId);
+        grandchild.ShouldNotBeNull();
+        grandchild.CurrentState.ShouldBe(State.Failed);
+    }
+
+    [TimedFact]
+    public async Task RunOrchestration_FailedParentOnAnyFinished_ActivatesContinuation()
+    {
+        // Arrange: failed batch parent (OnAnyFinishedState) -> awaiting continuation
+        var ctx = _fixture.CreateContext();
+        var parentBatchId = Guid.NewGuid();
+        var continuationId = Guid.NewGuid();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentBatchId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            JobCount = 1,
+            ContinuationOptions = ContinuationOptions.OnAnyFinishedState,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Failed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentBatchId,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = continuationId,
+            Kind = JobKind.Job,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentBatchId,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act — finalize parent (Failed but OnAnyFinished → Completed), then activate continuation
+        var orchCtx1 = _fixture.CreateContext();
+        await OrchestrationTask<TestContext>.RunOrchestration(orchCtx1, TimeProvider.System, TimeSpan.FromDays(1), CancellationToken.None);
+        var orchCtx2 = _fixture.CreateContext();
+        await OrchestrationTask<TestContext>.RunOrchestration(orchCtx2, TimeProvider.System, TimeSpan.FromDays(1), CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var continuation = await readCtx.Set<Job>().FindAsync(continuationId);
+        continuation.ShouldNotBeNull();
+        continuation.CurrentState.ShouldBe(State.Enqueued);
+    }
+
+    [TimedFact]
+    public async Task RunOrchestration_NoDeletedParent_AwaitingChildStaysAwaiting()
+    {
+        // Arrange: non-deleted parent -> awaiting child should not be failed
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = childId,
+            Kind = JobKind.Job,
+            CurrentState = State.Awaiting,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentId,
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var orchCtx = _fixture.CreateContext();
+        await OrchestrationTask<TestContext>.RunOrchestration(orchCtx, TimeProvider.System, TimeSpan.FromDays(1), CancellationToken.None);
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var child = await readCtx.Set<Job>().FindAsync(childId);
+        child.ShouldNotBeNull();
+        child.CurrentState.ShouldBe(State.Awaiting);
     }
 
     [TimedFact]

--- a/src/core/Jobly.Tests/Unit/PublisherTests.cs
+++ b/src/core/Jobly.Tests/Unit/PublisherTests.cs
@@ -3,6 +3,7 @@ using Jobly.Core.Data.Entities;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
 using Jobly.Core.Handlers;
+using Jobly.Core.Logging;
 using Jobly.Tests.Fixtures;
 using Jobly.Tests.TestData.Handlers;
 using Microsoft.EntityFrameworkCore;
@@ -231,6 +232,58 @@ public abstract class PublisherTestsBase : IAsyncLifetime
         var job = await readCtx.Set<Job>().FindAsync(jobId);
         job.ShouldNotBeNull();
         job.TraceId.ShouldBe(jobId);
+    }
+
+    [TimedFact]
+    public async Task Publish_InsideExecutionContext_InheritsTraceAndSpawnedBy()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var publisher = CreatePublisher(ctx);
+        var parentJobId = Guid.NewGuid();
+        var parentTraceId = Guid.NewGuid();
+
+        JobExecutionContext.Current = new JobExecutionInfo
+        {
+            JobId = parentJobId,
+            TraceId = parentTraceId,
+        };
+
+        try
+        {
+            // Act
+            var id = await publisher.Publish(new SingleHandlerMessage());
+            await ctx.SaveChangesAsync();
+
+            // Assert
+            var readCtx = _fixture.CreateContext();
+            var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == id);
+            job.ShouldNotBeNull();
+            job.TraceId.ShouldBe(parentTraceId);
+            job.SpawnedByJobId.ShouldBe(parentJobId);
+        }
+        finally
+        {
+            JobExecutionContext.Current = null;
+        }
+    }
+
+    [TimedFact]
+    public async Task SaveChangesAsync_PersistsEnqueuedJob()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var publisher = CreatePublisher(ctx);
+        var id = await publisher.Enqueue(new UnitRequest());
+
+        // Act
+        await publisher.SaveChangesAsync();
+
+        // Assert
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FindAsync(id);
+        job.ShouldNotBeNull();
+        job.CurrentState.ShouldBe(State.Enqueued);
     }
 }
 

--- a/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobBugTests.cs
@@ -27,7 +27,7 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
     public async Task AddOrUpdateRecurringJob_DoesNotCreateJob()
     {
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
 
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "no-job-test", "* * * * *");
 
@@ -45,7 +45,7 @@ public abstract class RecurringJobBugTestsBase : IAsyncLifetime
     {
         // Arrange: register a recurring job with NextExecution in the past (so scheduler triggers)
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "schedule-now-test", "* * * * *");
 
         // Set NextExecution to the past so the scheduler picks it up

--- a/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobEdgeCaseTests.cs
@@ -404,6 +404,135 @@ public abstract class RecurringJobEdgeCaseTestsBase : IAsyncLifetime
         log.Skipped.ShouldBeFalse();
         log.JobId.ShouldNotBeNull();
     }
+
+    [TimedFact]
+    public async Task ScheduleRecurringJobs_NextExecutionExactlyNow_Schedules()
+    {
+        // Arrange — NextExecution == now should be scheduled (<= comparison)
+        var ctx = _fixture.CreateContext();
+        var now = DateTime.UtcNow.AddMinutes(10);
+
+        var recurringJob = new RecurringJob
+        {
+            Name = "boundary-test",
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            Cron = "* * * * *",
+            CreatedAt = now.AddMinutes(-10),
+            NextExecution = now,
+        };
+        ctx.Set<RecurringJob>().Add(recurringJob);
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var tp = new FakeTimeProvider(now);
+        var schedCtx = _fixture.CreateContext();
+        var count = await RecurringJobSchedulerTask<TestContext>.ScheduleRecurringJobs(schedCtx, tp);
+
+        // Assert — should schedule (NextExecution <= now)
+        count.ShouldBe(1);
+    }
+
+    [TimedFact]
+    public async Task ScheduleRecurringJobs_NextExecutionInFuture_DoesNotSchedule()
+    {
+        // Arrange — NextExecution in the future should NOT be scheduled
+        var ctx = _fixture.CreateContext();
+        var now = DateTime.UtcNow;
+
+        var recurringJob = new RecurringJob
+        {
+            Name = "future-test",
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            Cron = "* * * * *",
+            CreatedAt = now.AddMinutes(-10),
+            NextExecution = now.AddMinutes(5),
+        };
+        ctx.Set<RecurringJob>().Add(recurringJob);
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var schedCtx = _fixture.CreateContext();
+        var count = await RecurringJobSchedulerTask<TestContext>.ScheduleRecurringJobs(schedCtx, TimeProvider.System);
+
+        // Assert
+        count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task ScheduleRecurringJobs_DedupChecksLatestLog_NotOldest()
+    {
+        // Arrange — oldest log has completed job, latest log has enqueued job → should skip
+        var ctx = _fixture.CreateContext();
+        var now = DateTime.UtcNow;
+
+        var oldJobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = oldJobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            CreateTime = now.AddMinutes(-10),
+            ScheduleTime = now.AddMinutes(-10),
+            Queue = "default",
+        });
+
+        var newJobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = newJobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            CreateTime = now.AddMinutes(-1),
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+        });
+
+        var recurringJob = new RecurringJob
+        {
+            Name = "dedup-order-test",
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new UnitRequest()),
+            Cron = "* * * * *",
+            CreatedAt = now.AddMinutes(-20),
+            NextExecution = now.AddMinutes(-1),
+        };
+        ctx.Set<RecurringJob>().Add(recurringJob);
+        await ctx.SaveChangesAsync();
+
+        // Old log (completed job) — should NOT be the one checked
+        ctx.Set<RecurringJobLog>().Add(new RecurringJobLog
+        {
+            RecurringJobId = recurringJob.Id,
+            JobId = oldJobId,
+            CreatedAt = now.AddMinutes(-10),
+        });
+        // Latest log (enqueued job) — should BE the one checked
+        ctx.Set<RecurringJobLog>().Add(new RecurringJobLog
+        {
+            RecurringJobId = recurringJob.Id,
+            JobId = newJobId,
+            CreatedAt = now.AddMinutes(-1),
+        });
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var schedCtx = _fixture.CreateContext();
+        var count = await RecurringJobSchedulerTask<TestContext>.ScheduleRecurringJobs(schedCtx, TimeProvider.System);
+
+        // Assert — should skip because latest log's job is Enqueued
+        count.ShouldBe(0);
+    }
+}
+
+file class FakeTimeProvider(DateTime utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => new(utcNow, TimeSpan.Zero);
 }
 
 [Collection<PostgreSqlCollection>]

--- a/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobLogCleanupTests.cs
@@ -104,6 +104,36 @@ public abstract class RecurringJobLogCleanupTestsBase : IAsyncLifetime
     }
 
     [TimedFact]
+    public async Task CleanupRecurringJobLogs_ExactlyAtLimit_DoesNotDelete()
+    {
+        // Arrange: exactly 100 logs — should NOT trigger cleanup (> 100, not >= 100)
+        var ctx = _fixture.CreateContext();
+        var rj = new RecurringJob { Name = "exact-100", Cron = "* * * * *", CreatedAt = DateTime.UtcNow };
+        ctx.Set<RecurringJob>().Add(rj);
+        await ctx.SaveChangesAsync();
+
+        for (var i = 0; i < 100; i++)
+        {
+            ctx.Set<RecurringJobLog>().Add(new RecurringJobLog
+            {
+                RecurringJobId = rj.Id,
+                CreatedAt = DateTime.UtcNow.AddMinutes(-100 + i),
+            });
+        }
+
+        await ctx.SaveChangesAsync();
+
+        // Act
+        var cleanCtx = _fixture.CreateContext();
+        await ExpirationCleanupTask<TestContext>.CleanupRecurringJobLogs(cleanCtx);
+
+        // Assert — all 100 should remain
+        var readCtx = _fixture.CreateContext();
+        var count = await readCtx.Set<RecurringJobLog>().CountAsync(x => x.RecurringJobId == rj.Id);
+        count.ShouldBe(100);
+    }
+
+    [TimedFact]
     public async Task CleanupRecurringJobLogs_NoLogsDoesNothing()
     {
         var cleanCtx = _fixture.CreateContext();

--- a/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
+++ b/src/core/Jobly.Tests/Unit/RecurringJobTests.cs
@@ -27,7 +27,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
     {
         // Arrange
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
 
         // Act
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "test-recurring", "* * * * *");
@@ -49,7 +49,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
         // Arrange
         for (var i = 0; i < 3; i++)
         {
-            var publisher = new RecurringJobPublisher<TestContext>(_fixture.CreateContext(), TimeProvider.System);
+            var publisher = new RecurringJobPublisher<TestContext>(_fixture.CreateContext(), TimeProvider.System, new FakeLockProvider());
             await publisher.AddOrUpdateRecurringJob(new UnitRequest(), $"recurring-{i}", "* * * * *");
         }
 
@@ -66,7 +66,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
     {
         // Arrange
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "detail-test", "*/5 * * * *");
 
         var readCtx = _fixture.CreateContext();
@@ -87,7 +87,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
     {
         // Arrange
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "to-delete", "* * * * *");
 
         var readCtx = _fixture.CreateContext();
@@ -115,7 +115,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
     {
         // Arrange
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "trigger-test", "* * * * *");
 
         var readCtx = _fixture.CreateContext();
@@ -142,7 +142,7 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
     {
         // Arrange
         var ctx = _fixture.CreateContext();
-        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System);
+        var publisher = new RecurringJobPublisher<TestContext>(ctx, TimeProvider.System, new FakeLockProvider());
         await publisher.AddOrUpdateRecurringJob(new UnitRequest(), "disable-test", "* * * * *");
 
         var readCtx = _fixture.CreateContext();

--- a/website/docs/features/recurring-jobs.md
+++ b/website/docs/features/recurring-jobs.md
@@ -17,6 +17,10 @@ await recurringPublisher.AddOrUpdateRecurringJob(
 
 `AddOrUpdateRecurringJob` only registers (or updates) the definition — it does **not** create a job. The `RecurringJobSchedulerTask` background task creates jobs when the cron time arrives.
 
+:::info Saves immediately
+`AddOrUpdateRecurringJob` acquires a distributed lock on the job name and calls `SaveChanges` internally. You do **not** need to call `SaveChanges` after this method. The lock prevents race conditions when multiple app instances register the same recurring job concurrently.
+:::
+
 ## How It Works
 
 1. **Registration**: `AddOrUpdateRecurringJob` stores the cron expression, message payload, and type. Sets `NextExecution` to the next cron occurrence.


### PR DESCRIPTION
## Summary

- **Stryker.NET mutation testing** — new `Jobly.Tests.Mutation` project with SQLite in-memory fixture. Runs 293 tests in ~10s with no Docker. Stryker configs for both Core (99.60% score) and Worker (52.74% score).
- **Fix RecurringJobPublisher race condition** — replaced transaction with distributed lock (`IJoblyLockProvider`) to prevent duplicate inserts when multiple app instances call `AddOrUpdateRecurringJob` concurrently.
- **24 new unit tests** targeting survived/uncovered mutants across OrchestrationTask, ExpirationCleanupTask, CounterAggregator, CrashRecovery, RecurringJobScheduler, Publisher, and HandlerServiceExtensions.

## Key changes

| File | Change |
|---|---|
| `Jobly.Tests.Mutation/` | New SQLite-only test project for Stryker mutation testing |
| `RecurringJobPublisher.cs` | Race condition fix: distributed lock instead of transaction |
| `ServiceConfiguration.cs` | Pass `IJoblyLockProvider` to RecurringJobPublisher DI registration |
| `TestContext.cs` | Optional `schema` parameter for SQLite compatibility (null = no schema) |
| 10 test files | 24 new boundary/edge-case tests |
| `recurring-jobs.md` | Document SaveChanges behavior |

## How to run Stryker

```bash
cd src/core/Jobly.Tests.Mutation
dotnet stryker --test-runner mtp                                    # Full Core run
dotnet stryker --test-runner mtp --mutate "**/Publisher.cs"         # Single file
dotnet stryker --test-runner mtp --config-file stryker-config.worker.json  # Worker
```

## Test plan

- [x] 293 SQLite mutation tests pass (10s)
- [x] 435 PostgreSQL tests pass (including RecurringJobPublisher lock change)
- [x] Stryker Core baseline: 99.60% mutation score
- [x] Stryker Worker baseline: 52.74% mutation score

🤖 Generated with [Claude Code](https://claude.com/claude-code)