### PR TITLE
Add exponential polling backoff for idle workers

### DIFF
--- a/src/core/Jobly.Tests/Unit/JoblyWorkerConfigurationTests.cs
+++ b/src/core/Jobly.Tests/Unit/JoblyWorkerConfigurationTests.cs
@@ -1,0 +1,25 @@
+using Jobly.Worker;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public class JoblyWorkerConfigurationTests
+{
+    [TimedFact]
+    public void GetEffectiveWorkerGroups_PropagatesBackoffProperties()
+    {
+        var config = new JoblyWorkerConfiguration
+        {
+            PollingInterval = TimeSpan.FromSeconds(2),
+            MaxPollingInterval = TimeSpan.FromSeconds(45),
+            PollingIntervalFactor = 3.0,
+        };
+
+        var groups = config.GetEffectiveWorkerGroups();
+
+        groups.Count.ShouldBe(1);
+        groups[0].PollingInterval.ShouldBe(TimeSpan.FromSeconds(2));
+        groups[0].MaxPollingInterval.ShouldBe(TimeSpan.FromSeconds(45));
+        groups[0].PollingIntervalFactor.ShouldBe(3.0);
+    }
+}

--- a/src/core/Jobly.Tests/Unit/PollingBackoffTests.cs
+++ b/src/core/Jobly.Tests/Unit/PollingBackoffTests.cs
@@ -1,0 +1,123 @@
+using Jobly.Worker;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public class PollingBackoffTests
+{
+    private static readonly TimeSpan Floor = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan Max = TimeSpan.FromSeconds(30);
+
+    [TimedFact]
+    public void Next_FactorOne_ReturnsFloor()
+    {
+        var result = PollingBackoff.Next(TimeSpan.FromSeconds(5), Floor, Max, 1.0);
+
+        result.ShouldBe(Floor);
+    }
+
+    [TimedFact]
+    public void Next_FactorBelowOne_ReturnsFloor()
+    {
+        var result = PollingBackoff.Next(TimeSpan.FromSeconds(5), Floor, Max, 0.5);
+
+        result.ShouldBe(Floor);
+    }
+
+    [TimedFact]
+    public void Next_CurrentBelowFloor_StartsAtFloor()
+    {
+        var result = PollingBackoff.Next(TimeSpan.Zero, Floor, Max, 2.0);
+
+        result.ShouldBe(Floor);
+    }
+
+    [TimedFact]
+    public void Next_FirstMiss_DoubledFromFloor()
+    {
+        var result = PollingBackoff.Next(Floor, Floor, Max, 2.0);
+
+        result.ShouldBe(TimeSpan.FromSeconds(2));
+    }
+
+    [TimedFact]
+    public void Next_GrowsGeometrically()
+    {
+        var current = Floor;
+        var expected = new[]
+        {
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(4),
+            TimeSpan.FromSeconds(8),
+            TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(30),
+        };
+
+        foreach (var step in expected)
+        {
+            current = PollingBackoff.Next(current, Floor, Max, 2.0);
+            current.ShouldBe(step);
+        }
+    }
+
+    [TimedFact]
+    public void Next_ClampedAtMax()
+    {
+        var result = PollingBackoff.Next(TimeSpan.FromSeconds(20), Floor, Max, 2.0);
+
+        result.ShouldBe(Max);
+    }
+
+    [TimedFact]
+    public void Next_AlreadyAtMax_StaysAtMax()
+    {
+        var result = PollingBackoff.Next(Max, Floor, Max, 2.0);
+
+        result.ShouldBe(Max);
+    }
+
+    [TimedFact]
+    public void Next_CustomFactor_ComputesCorrectly()
+    {
+        var result = PollingBackoff.Next(Floor, Floor, Max, 1.5);
+
+        result.ShouldBe(TimeSpan.FromMilliseconds(1500));
+    }
+
+    [TimedFact]
+    public void Next_FractionalSeconds_HandledViaTicks()
+    {
+        var current = TimeSpan.FromMilliseconds(100);
+        var floor = TimeSpan.FromMilliseconds(50);
+
+        var result = PollingBackoff.Next(current, floor, Max, 2.0);
+
+        result.ShouldBe(TimeSpan.FromMilliseconds(200));
+    }
+
+    [TimedFact]
+    public void Next_FactorNaN_ReturnsFloor()
+    {
+        var result = PollingBackoff.Next(TimeSpan.FromSeconds(5), Floor, Max, double.NaN);
+
+        result.ShouldBe(Floor);
+    }
+
+    [TimedFact]
+    public void Next_FactorPositiveInfinity_ReturnsFloor()
+    {
+        var result = PollingBackoff.Next(TimeSpan.FromSeconds(5), Floor, Max, double.PositiveInfinity);
+
+        result.ShouldBe(Floor);
+    }
+
+    [TimedFact]
+    public void Next_MaxBelowFloor_ReturnsFloor()
+    {
+        var misconfiguredMax = TimeSpan.FromMilliseconds(500);
+
+        var result = PollingBackoff.Next(TimeSpan.FromSeconds(5), Floor, misconfiguredMax, 2.0);
+
+        result.ShouldBe(Floor);
+    }
+}

--- a/src/core/Jobly.Worker/Configuration.cs
+++ b/src/core/Jobly.Worker/Configuration.cs
@@ -8,7 +8,26 @@ public class WorkerGroupConfiguration
 
     public string[] Queues { get; set; } = ["default"];
 
+    /// <summary>
+    /// Each time the worker polls for a job, it will wait for this interval before polling again.
+    /// Also serves as the floor for exponential backoff when consecutive polls return no work.
+    /// </summary>
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Upper bound on the polling delay when consecutive polls return no work.
+    /// The delay grows from <see cref="PollingInterval"/> by <see cref="PollingIntervalFactor"/>
+    /// on each empty poll, clamped to this value. Resets to <see cref="PollingInterval"/>
+    /// instantly when a job is processed.
+    /// </summary>
+    public TimeSpan MaxPollingInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Multiplier applied to the current polling delay on each consecutive empty poll.
+    /// Set to 1.0 (or lower) to disable exponential backoff — the delay stays at
+    /// <see cref="PollingInterval"/>.
+    /// </summary>
+    public double PollingIntervalFactor { get; set; } = 2.0;
 }
 
 public class JoblyWorkerConfiguration : JoblyConfiguration
@@ -22,9 +41,22 @@ public class JoblyWorkerConfiguration : JoblyConfiguration
 
     /// <summary>
     /// Each time the worker polls for a job, it will wait for this interval before polling again.
-    /// Applies to the implicit default worker group.
+    /// Applies to the implicit default worker group. Also serves as the floor for exponential
+    /// backoff when consecutive polls return no work.
     /// </summary>
     public TimeSpan PollingInterval { get; set; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Upper bound on the polling delay when consecutive polls return no work.
+    /// Applies to the implicit default worker group.
+    /// </summary>
+    public TimeSpan MaxPollingInterval { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Multiplier applied to the current polling delay on each consecutive empty poll.
+    /// Set to 1.0 (or lower) to disable exponential backoff. Applies to the implicit default worker group.
+    /// </summary>
+    public double PollingIntervalFactor { get; set; } = 2.0;
 
     /// <summary>
     /// Queues this worker subscribes to. Applies to the implicit default worker group.
@@ -118,6 +150,8 @@ public class JoblyWorkerConfiguration : JoblyConfiguration
                 WorkerCount = WorkerCount,
                 Queues = Queues,
                 PollingInterval = PollingInterval,
+                MaxPollingInterval = MaxPollingInterval,
+                PollingIntervalFactor = PollingIntervalFactor,
             },
         };
 

--- a/src/core/Jobly.Worker/Jobly.Worker.csproj
+++ b/src/core/Jobly.Worker/Jobly.Worker.csproj
@@ -9,6 +9,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="Jobly.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="DistributedLock.Postgres" Version="1.3.0" />
 		<PackageReference Include="DistributedLock.SqlServer" Version="1.0.7" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/src/core/Jobly.Worker/JoblyDispatcher.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcher.cs
@@ -55,21 +55,31 @@ public class JoblyDispatcher<TContext> : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        var floor = _groupConfiguration.PollingInterval;
+        var max = _groupConfiguration.MaxPollingInterval;
+        var factor = _groupConfiguration.PollingIntervalFactor;
+        var currentDelay = floor;
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
                 if (_pauseStateHolder.IsPaused(_workerGroupId))
                 {
-                    await Task.Delay(_groupConfiguration.PollingInterval, stoppingToken);
+                    currentDelay = floor;
+                    await Task.Delay(floor, stoppingToken);
                     continue;
                 }
 
-                var fetched = await FetchAndDistribute(stoppingToken);
-                if (!fetched)
+                var result = await FetchAndDistribute(stoppingToken);
+                if (result == FetchResult.Empty)
                 {
-                    await Task.Delay(_groupConfiguration.PollingInterval, stoppingToken);
+                    currentDelay = PollingBackoff.Next(currentDelay, floor, max, factor);
+                    await Task.Delay(currentDelay, stoppingToken);
+                    continue;
                 }
+
+                currentDelay = floor;
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -78,20 +88,21 @@ public class JoblyDispatcher<TContext> : BackgroundService
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Dispatcher fetch failed");
-                await Task.Delay(_groupConfiguration.PollingInterval, stoppingToken);
+                currentDelay = PollingBackoff.Next(currentDelay, floor, max, factor);
+                await Task.Delay(currentDelay, stoppingToken);
             }
         }
 
         _jobChannel.Writer.Complete();
     }
 
-    private async Task<bool> FetchAndDistribute(CancellationToken ct)
+    private async Task<FetchResult> FetchAndDistribute(CancellationToken ct)
     {
         var available = _workerCount - _jobChannel.Reader.Count;
         if (available <= 0)
         {
             await Task.Delay(TimeSpan.FromMilliseconds(10), ct);
-            return true;
+            return FetchResult.ChannelFull;
         }
 
         using var scope = _scopeFactory.CreateScope();
@@ -114,7 +125,7 @@ public class JoblyDispatcher<TContext> : BackgroundService
         if (jobs.Count == 0)
         {
             await transaction.CommitAsync(ct);
-            return false;
+            return FetchResult.Empty;
         }
 
         // Batch mark all fetched jobs as Processing
@@ -143,6 +154,13 @@ public class JoblyDispatcher<TContext> : BackgroundService
             await _jobChannel.Writer.WriteAsync(job, ct);
         }
 
-        return true;
+        return FetchResult.Fetched;
+    }
+
+    private enum FetchResult
+    {
+        Empty,
+        Fetched,
+        ChannelFull,
     }
 }

--- a/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
@@ -48,6 +48,8 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // Channel-based pull: blocks on ReadAllAsync until the dispatcher produces a job.
+        // No idle polling loop here — polling backoff lives in JoblyDispatcher.ExecuteAsync.
         await foreach (var job in _jobReader.ReadAllAsync(stoppingToken))
         {
             try

--- a/src/core/Jobly.Worker/JoblyWorker.cs
+++ b/src/core/Jobly.Worker/JoblyWorker.cs
@@ -24,19 +24,29 @@ public class JoblyWorker<TContext> : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        var floor = _groupConfiguration.PollingInterval;
+        var max = _groupConfiguration.MaxPollingInterval;
+        var factor = _groupConfiguration.PollingIntervalFactor;
+        var currentDelay = floor;
+
         while (!stoppingToken.IsCancellationRequested)
         {
             if (_pauseStateHolder.IsPaused(_workerGroupId))
             {
-                await Task.Delay(_groupConfiguration.PollingInterval, stoppingToken);
+                currentDelay = floor;
+                await Task.Delay(floor, stoppingToken);
                 continue;
             }
 
             var didProcessJob = await _joblyWorkerService.GetAndProcessJob(stoppingToken);
-            if (!didProcessJob)
+            if (didProcessJob)
             {
-                await Task.Delay(_groupConfiguration.PollingInterval, stoppingToken);
+                currentDelay = floor;
+                continue;
             }
+
+            currentDelay = PollingBackoff.Next(currentDelay, floor, max, factor);
+            await Task.Delay(currentDelay, stoppingToken);
         }
 
         _logger.LogInformation("Jobly worker is stopping.");

--- a/src/core/Jobly.Worker/PollingBackoff.cs
+++ b/src/core/Jobly.Worker/PollingBackoff.cs
@@ -1,0 +1,30 @@
+namespace Jobly.Worker;
+
+internal static class PollingBackoff
+{
+    public static TimeSpan Next(TimeSpan current, TimeSpan floor, TimeSpan max, double factor)
+    {
+        if (!double.IsFinite(factor) || factor <= 1.0)
+        {
+            return floor;
+        }
+
+        if (max < floor)
+        {
+            return floor;
+        }
+
+        if (current < floor)
+        {
+            return floor;
+        }
+
+        var ticks = (long)(current.Ticks * factor);
+        if (ticks > max.Ticks)
+        {
+            ticks = max.Ticks;
+        }
+
+        return TimeSpan.FromTicks(ticks);
+    }
+}

--- a/website/docs/operations/configuration.md
+++ b/website/docs/operations/configuration.md
@@ -73,7 +73,9 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
 {
     // Worker
     options.WorkerCount = 10;
-    options.PollingInterval = TimeSpan.FromSeconds(1);
+    options.PollingInterval = TimeSpan.FromSeconds(1);    // floor
+    options.MaxPollingInterval = TimeSpan.FromSeconds(30); // ceiling for exponential backoff
+    options.PollingIntervalFactor = 2.0;                   // multiplier on each empty poll (1.0 disables backoff)
     options.Queues = ["a-critical", "b-default", "c-low"];
 
     // Dispatcher mode (batch-fetch instead of per-worker polling)
@@ -114,8 +116,20 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `WorkerCount` | `int` | `min(CPU * 5, 20)` | Number of concurrent worker threads |
-| `PollingInterval` | `TimeSpan` | `1 second` | Delay between polls when no jobs are available |
+| `PollingInterval` | `TimeSpan` | `1 second` | Delay between polls when no jobs are available. Also serves as the floor for exponential backoff. |
+| `MaxPollingInterval` | `TimeSpan` | `30 seconds` | Upper bound on the polling delay during idle periods. The delay grows from `PollingInterval` by `PollingIntervalFactor` on each empty poll, clamped to this value, and resets instantly when a job is processed. |
+| `PollingIntervalFactor` | `double` | `2.0` | Multiplier applied to the current polling delay on each consecutive empty poll. Set to `1.0` (or lower) to disable exponential backoff — the delay stays at `PollingInterval`. |
 | `Queues` | `string[]` | `["default"]` | Queues this worker subscribes to. Processed in alphabetical order |
+
+### Exponential Polling Backoff
+
+On idle queues, the poll delay grows geometrically from `PollingInterval` (floor) toward `MaxPollingInterval` (ceiling) by `PollingIntervalFactor` on each consecutive empty poll. The delay resets to the floor instantly when any job is processed, so latency remains bounded by `PollingInterval` under load.
+
+With defaults (`1s` → `30s`, factor `2.0`), an idle worker backs off through `1s → 2s → 4s → 8s → 16s → 30s` before capping at 30s. A burst of work resets it back to 1s immediately.
+
+To disable backoff entirely, set `PollingIntervalFactor = 1.0`. The delay then stays at `PollingInterval` on every poll.
+
+Paused workers/groups always poll at the floor (no backoff while paused).
 
 ### Handler Logging
 
@@ -157,6 +171,8 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
         group.WorkerCount = 2;
         group.Queues = ["reports", "default"];
         group.PollingInterval = TimeSpan.FromSeconds(5);
+        group.MaxPollingInterval = TimeSpan.FromSeconds(60);
+        group.PollingIntervalFactor = 2.0;
     });
 });
 ```
@@ -167,7 +183,9 @@ This creates 7 workers total: 5 polling `critical` every 100ms, and 2 polling `r
 |--------|------|---------|-------------|
 | `WorkerCount` | `int` | `min(CPU * 5, 20)` | Number of workers in this group |
 | `Queues` | `string[]` | `["default"]` | Queues this group subscribes to |
-| `PollingInterval` | `TimeSpan` | `1 second` | Delay between polls for this group |
+| `PollingInterval` | `TimeSpan` | `1 second` | Delay between polls for this group. Also the floor for exponential backoff. |
+| `MaxPollingInterval` | `TimeSpan` | `30 seconds` | Upper bound on the polling delay during idle periods for this group |
+| `PollingIntervalFactor` | `double` | `2.0` | Multiplier on each consecutive empty poll for this group. Set to `1.0` to disable backoff. |
 
 ### Server Identity
 

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,16 @@ sidebar_position: 6
 
 # Releases
 
+## 0.8.0
+
+*Unreleased*
+
+### New Features
+
+- **Exponential Polling Backoff** — Workers and the batch-fetch dispatcher now back off geometrically when queues are idle, reducing database load during quiet periods. Configure via `MaxPollingInterval` (default `30s`, ceiling) and `PollingIntervalFactor` (default `2.0`, multiplier). `PollingInterval` becomes the floor. On any processed job, the delay resets to the floor instantly, so throughput under load is unchanged. Paused workers stay at the floor (no compounding while paused). Available on both top-level `JoblyWorkerConfiguration` and per-group `WorkerGroupConfiguration`. Set `PollingIntervalFactor = 1.0` to disable backoff. See [Operations → Configuration → Exponential Polling Backoff](/docs/operations/configuration#exponential-polling-backoff).
+
+---
+
 ## 0.7.0
 
 *2026-04-17*

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -709,7 +709,9 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
 {
     // Worker
     options.WorkerCount = 10;                                  // Concurrent workers (default: min(CPU*5, 20))
-    options.PollingInterval = TimeSpan.FromSeconds(1);         // Poll delay when idle (default: 1s)
+    options.PollingInterval = TimeSpan.FromSeconds(1);         // Poll delay when idle; also floor for backoff (default: 1s)
+    options.MaxPollingInterval = TimeSpan.FromSeconds(30);     // Ceiling for exponential backoff (default: 30s)
+    options.PollingIntervalFactor = 2.0;                       // Multiplier per empty poll; 1.0 disables backoff (default: 2.0)
     options.Queues = ["a-critical", "b-default", "c-low"];     // Subscribed queues (default: ["default"])
 
     // Handler logging
@@ -766,9 +768,13 @@ builder.Services.AddJoblyWorker<AppDbContext>(options =>
         group.WorkerCount = 2;
         group.Queues = ["reports", "default"];
         group.PollingInterval = TimeSpan.FromSeconds(5);
+        group.MaxPollingInterval = TimeSpan.FromSeconds(60);   // per-group ceiling
+        group.PollingIntervalFactor = 2.0;                      // per-group multiplier
     });
 });
 // Creates 7 workers total: 5 on "critical" @ 100ms, 2 on "reports"/"default" @ 5s
+// On idle queues, each group backs off geometrically: floor → floor*factor → … → MaxPollingInterval.
+// Any processed job resets the delay to the floor instantly.
 ```
 
 ### Dashboard Configuration


### PR DESCRIPTION
## Summary

- Workers and the batch-fetch dispatcher back off geometrically on consecutive empty polls, reducing DB load on idle queues. Any processed job resets the delay to the floor instantly — no throughput impact under load.
- New `MaxPollingInterval` (default `30s`) and `PollingIntervalFactor` (default `2.0`) on both `JoblyWorkerConfiguration` and `WorkerGroupConfiguration`. `PollingInterval` becomes the floor. Set factor to `1.0` to disable.
- Docs updated (Configuration page + llms-full.txt). Added to 0.8.0 release notes (unreleased).

## Design

- Per-worker local `currentDelay` — no shared state, no DI service, no DB columns.
- Pure `PollingBackoff.Next()` helper; zero-cost when factor ≤ 1.0 (short-circuits to floor).
- `JoblyDispatcher` exception handler also backs off (DB outages no longer hammer at 1s).
- Paused workers always stay at the floor.

## Test plan

- [x] New unit tests `PollingBackoffTests` (12) + `JoblyWorkerConfigurationTests` (1) — all green.
- [x] Full PostgreSQL unit suite passes (pre-existing `CrashRecoveryTests.CleanUpServers_HeartbeatAtExactTimeout_NotCleaned` flake confirmed unrelated by running against baseline).
- [x] `Jobly.Worker` builds with zero warnings.
- [x] `Jobly.Tests` builds with zero new warnings.
- [x] Docusaurus site builds clean (no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)