### PR TITLE
Add JitterFactor option to Retry addon

### DIFF
--- a/src/core/Jobly.Core/Retry/RetryOptions.cs
+++ b/src/core/Jobly.Core/Retry/RetryOptions.cs
@@ -5,4 +5,10 @@ public class RetryOptions
     public int MaxRetries { get; set; }
 
     public int[] Delays { get; set; } = [15, 60, 300];
+
+    /// <summary>
+    /// Multiplicative jitter factor applied to each retry delay. Clamped to [0, 1].
+    /// Formula: delay * (1 + JitterFactor * rand(-1, 1)). Default 0.0 (no jitter).
+    /// </summary>
+    public double JitterFactor { get; set; }
 }

--- a/src/core/Jobly.Core/Retry/RetryPipelineBehavior.cs
+++ b/src/core/Jobly.Core/Retry/RetryPipelineBehavior.cs
@@ -44,7 +44,18 @@ public class RetryPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
                 if (delays.Length > 0)
                 {
                     var idx = Math.Min(retriedTimes, delays.Length - 1);
-                    scheduleTime = now + TimeSpan.FromSeconds(delays[idx]);
+                    var baseDelaySeconds = (double)delays[idx];
+                    var jitterFactor = Math.Clamp(_options.Value.JitterFactor, 0.0, 1.0);
+
+                    if (jitterFactor > 0)
+                    {
+                        var r = (Random.Shared.NextDouble() * 2.0) - 1.0;
+                        baseDelaySeconds *= 1.0 + (jitterFactor * r);
+                    }
+
+                    // Defensive: guards against a future clamp loosening producing a negative delay.
+                    baseDelaySeconds = Math.Max(0.0, baseDelaySeconds);
+                    scheduleTime = now + TimeSpan.FromSeconds(baseDelaySeconds);
                 }
 
                 meta.RetriedTimes = retriedTimes + 1;

--- a/src/core/Jobly.Tests/Unit/RetryTests.cs
+++ b/src/core/Jobly.Tests/Unit/RetryTests.cs
@@ -67,7 +67,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         return 0;
     }
 
-    private JoblyWorkerService<TestContext> CreateWorker(int maxRetries = 3, int[]? delays = null)
+    private JoblyWorkerService<TestContext> CreateWorker(int maxRetries = 3, int[]? delays = null, double jitterFactor = 0)
     {
         var services = new ServiceCollection();
         services.AddHandlers(typeof(RetryTestsBase).Assembly);
@@ -82,6 +82,7 @@ public abstract class RetryTestsBase : IAsyncLifetime
         {
             o.MaxRetries = maxRetries;
             o.Delays = delays ?? [];
+            o.JitterFactor = jitterFactor;
         });
 
         var workerConfig = new OptionsWrapper<JoblyWorkerConfiguration>(new JoblyWorkerConfiguration
@@ -655,6 +656,220 @@ public abstract class RetryTestsBase : IAsyncLifetime
         var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
         job.CurrentState.ShouldBe(State.Enqueued);
         job.ScheduleTime.ShouldBeGreaterThan(now.AddSeconds(90));
+    }
+
+    [TimedFact]
+    public async Task GetAndProcessJob_WithJitterFactorZero_ScheduleTimeIsExactDelay()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = now,
+            ScheduleTime = now,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 1, delays: [100], jitterFactor: 0);
+
+        // Act
+        var before = DateTime.UtcNow;
+        await worker.GetAndProcessJob(CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        // Assert — ScheduleTime ≈ now + 100s (no jitter)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(100).AddSeconds(-1));
+        job.ScheduleTime.ShouldBeLessThanOrEqualTo(after.AddSeconds(100).AddSeconds(1));
+    }
+
+    [TimedFact]
+    public async Task GetAndProcessJob_WithJitterFactor_ScheduleTimeWithinJitteredWindowAndVaries()
+    {
+        // Arrange — run N iterations to verify both the [50s, 150s] window AND that jitter actually varies
+        var worker = CreateWorker(maxRetries: 1, delays: [100], jitterFactor: 0.5);
+        var scheduleTimes = new List<DateTime>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var ctx = _fixture.CreateContext();
+            var jobId = Guid.NewGuid();
+            var now = DateTime.UtcNow;
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = jobId,
+                Kind = JobKind.Job,
+                CurrentState = State.Enqueued,
+                Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+                Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+                CreateTime = now,
+                ScheduleTime = now,
+                Queue = "default",
+            });
+            await ctx.SaveChangesAsync();
+
+            var before = DateTime.UtcNow;
+
+            // Act
+            await worker.GetAndProcessJob(CancellationToken.None);
+
+            var after = DateTime.UtcNow;
+
+            // Assert — each ScheduleTime ∈ [now + 50s, now + 150s]
+            var readCtx = _fixture.CreateContext();
+            var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+            job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(50).AddSeconds(-1));
+            job.ScheduleTime.ShouldBeLessThanOrEqualTo(after.AddSeconds(150).AddSeconds(1));
+            scheduleTimes.Add(job.ScheduleTime);
+        }
+
+        // Assert — jitter actually produces variation across iterations (≥2 distinct values)
+        scheduleTimes.Distinct().Count().ShouldBeGreaterThanOrEqualTo(2);
+    }
+
+    [TimedFact]
+    public async Task GetAndProcessJob_WithJitterFactorAboveOne_ClampedToOne()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = now,
+            ScheduleTime = now,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 1, delays: [100], jitterFactor: 5.0);
+
+        // Act
+        var before = DateTime.UtcNow;
+        await worker.GetAndProcessJob(CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        // Assert — clamped to 1.0, so ScheduleTime ∈ [now, now + 200s]
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        job.ScheduleTime.ShouldBeLessThanOrEqualTo(after.AddSeconds(200).AddSeconds(1));
+    }
+
+    [TimedFact]
+    public async Task GetAndProcessJob_WithJitterFactorBelowZero_ClampedToZero()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = now,
+            ScheduleTime = now,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 1, delays: [100], jitterFactor: -1.0);
+
+        // Act
+        var before = DateTime.UtcNow;
+        await worker.GetAndProcessJob(CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        // Assert — clamped to 0, so ScheduleTime ≈ now + 100s (no jitter)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(100).AddSeconds(-1));
+        job.ScheduleTime.ShouldBeLessThanOrEqualTo(after.AddSeconds(100).AddSeconds(1));
+    }
+
+    [TimedFact]
+    public async Task GetAndProcessJob_WithJitterFactor_DoesNotProduceNegativeDelay()
+    {
+        // Arrange — factor 1.0 can produce r = -1, multiply by 0; run many iterations
+        var worker = CreateWorker(maxRetries: 1, delays: [100], jitterFactor: 1.0);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var ctx = _fixture.CreateContext();
+            var jobId = Guid.NewGuid();
+            var now = DateTime.UtcNow;
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = jobId,
+                Kind = JobKind.Job,
+                CurrentState = State.Enqueued,
+                Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+                Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+                CreateTime = now,
+                ScheduleTime = now,
+                Queue = "default",
+            });
+            await ctx.SaveChangesAsync();
+
+            var before = DateTime.UtcNow;
+
+            // Act
+            await worker.GetAndProcessJob(CancellationToken.None);
+
+            // Assert — ScheduleTime must never be before 'before' (no negative delay)
+            var readCtx = _fixture.CreateContext();
+            var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+            job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(before.AddSeconds(-1));
+        }
+    }
+
+    [TimedFact]
+    public async Task GetAndProcessJob_WithEmptyDelaysAndJitter_StillHasNoDelay()
+    {
+        // Arrange — empty delays with jitter factor should short-circuit (no scheduleTime)
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        var originalScheduleTime = DateTime.UtcNow;
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = JsonSerializer.Serialize(new ThrowExceptionRequest()),
+            CreateTime = originalScheduleTime,
+            ScheduleTime = originalScheduleTime,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(maxRetries: 1, delays: [], jitterFactor: 0.5);
+
+        // Act
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        // Assert — ScheduleTime should remain in the past (empty-delays short-circuit preserved)
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == jobId);
+        job.CurrentState.ShouldBe(State.Enqueued);
+        job.ScheduleTime.ShouldBeLessThanOrEqualTo(TimeProvider.System.GetUtcNow().UtcDateTime);
     }
 }
 

--- a/website/docs/operations/configuration.md
+++ b/website/docs/operations/configuration.md
@@ -44,6 +44,7 @@ services.AddJoblyRetry(options =>
 {
     options.MaxRetries = 3;               // Default max retries (default: 0)
     options.Delays = [15, 60, 300];       // Retry delays in seconds (default: [15, 60, 300])
+    options.JitterFactor = 0.2;           // Random ±20% jitter on each delay (default: 0, no jitter)
 });
 ```
 
@@ -51,6 +52,7 @@ services.AddJoblyRetry(options =>
 |--------|------|---------|-------------|
 | `MaxRetries` | `int` | `0` | Default max retries when no `[Retry]` attribute is present |
 | `Delays` | `int[]` | `[15, 60, 300]` | Delay in seconds between retries. Last value is reused if fewer delays than retries |
+| `JitterFactor` | `double` | `0.0` | Multiplicative jitter applied to each delay: `delay * (1 + JitterFactor * rand(-1, 1))`. Clamped to `[0, 1]`. Global only — no per-job override. Helps avoid retry thundering herds |
 
 Per-job override via `[Retry]` attribute on handler or job class, or per-enqueue via metadata. See [Jobs](/docs/patterns/jobs#retries).
 

--- a/website/docs/patterns/jobs.md
+++ b/website/docs/patterns/jobs.md
@@ -71,12 +71,15 @@ services.AddJoblyRetry(o =>
 {
     o.MaxRetries = 3;
     o.Delays = [15, 60, 300]; // seconds
+    o.JitterFactor = 0.2;     // ±20% random jitter on each delay (default: 0, no jitter)
 });
 ```
 
 Priority: per-enqueue metadata > handler attribute > job attribute > global `RetryOptions`.
 
 Failed jobs are retried automatically. Crash requeues (server died mid-execution) do **not** count against the retry limit.
+
+`JitterFactor` is a multiplicative, global-only jitter applied to each computed delay: `delay * (1 + JitterFactor * rand(-1, 1))`. Clamped to `[0, 1]`. Useful when many jobs fail at the same time (e.g. downstream outage) to spread their retry attempts and avoid a thundering herd.
 
 ## Named Queues
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -228,10 +228,12 @@ public class GenerateReportHandler : IJobHandler<GenerateReport> { ... }
 Or configure global defaults:
 
 ```csharp
-services.AddJoblyRetry(o => { o.MaxRetries = 3; o.Delays = [15, 60, 300]; });
+services.AddJoblyRetry(o => { o.MaxRetries = 3; o.Delays = [15, 60, 300]; o.JitterFactor = 0.2; });
 ```
 
 Priority: per-enqueue metadata > handler attribute > job attribute > global RetryOptions. Failed jobs are retried automatically. Crash requeues do NOT count against the retry limit.
+
+`JitterFactor` (global only, default `0.0`, clamped to `[0, 1]`) applies multiplicative random jitter to each computed delay: `delay * (1 + JitterFactor * rand(-1, 1))`. Spreads retries to avoid thundering herds when many jobs fail at the same time.
 
 ### Named queues
 


### PR DESCRIPTION
## Summary
- Adds opt-in `JitterFactor` (`double`, default `0.0`) to `RetryOptions`. Applies multiplicative jitter to each computed retry delay via `delay * (1 + JitterFactor * rand(-1, 1))` using `Random.Shared`.
- `JitterFactor` is clamped to `[0, 1]` at the consumption site in `RetryPipelineBehavior`; a defensive `Math.Max(0, ...)` guards the final delay.
- Global-only: no attribute override, no per-publish metadata. Default `0.0` preserves today's exact behavior.
- Docs updated: `website/docs/patterns/jobs.md`, `website/docs/operations/configuration.md`, and `website/static/llms-full.txt`.

Motivation: when many jobs fail at the same time (e.g. a downstream outage), all their retries otherwise fire on the same schedule and hammer the recovered service in lock-step. Jitter spreads them across a window.

## Test plan
- [x] 6 new unit tests in `RetryTests` (× PostgreSQL + SQL Server = 12 tests): zero-factor exact delay, jitter window bounds with variance assertion (≥2 distinct `ScheduleTime` values across 10 iterations), above-one clamp, below-zero clamp, non-negative-delay invariant (50 iterations at factor `1.0`), empty-delays-with-jitter short-circuit.
- [x] Full `RetryTests` suite passes: 21/21 on PostgreSQL, 21/21 on SQL Server.
- [x] Full PostgreSQL test pass (460/461 succeed); the 1 failure (`CrashRecoveryTests_PostgreSql.CleanUpServers_HeartbeatAtExactTimeout_NotCleaned`) is pre-existing on `main` and unrelated to retry.
- [x] Zero new build warnings (baseline 45 → branch 45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)