### PR TITLE
feat: add NoRestart stale-recovery opt-out

### DIFF
--- a/src/core/Jobly.Core/Handlers/MetadataSerializer.cs
+++ b/src/core/Jobly.Core/Handlers/MetadataSerializer.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Jobly.Core.Handlers;
 
-internal static class MetadataSerializer
+public static class MetadataSerializer
 {
     private static readonly JsonSerializerOptions Options = new()
     {

--- a/src/core/Jobly.Core/NoRestart/ICanBeRestartedMetadata.cs
+++ b/src/core/Jobly.Core/NoRestart/ICanBeRestartedMetadata.cs
@@ -1,0 +1,8 @@
+using Jobly.Core.Handlers;
+
+namespace Jobly.Core.NoRestart;
+
+public partial interface ICanBeRestartedMetadata : IJobMetadata
+{
+    bool? CanBeRestarted { get; set; }
+}

--- a/src/core/Jobly.Core/NoRestart/NoRestartAttribute.cs
+++ b/src/core/Jobly.Core/NoRestart/NoRestartAttribute.cs
@@ -1,0 +1,4 @@
+namespace Jobly.Core.NoRestart;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class NoRestartAttribute : Attribute;

--- a/src/core/Jobly.Core/NoRestart/NoRestartExtensions.cs
+++ b/src/core/Jobly.Core/NoRestart/NoRestartExtensions.cs
@@ -1,0 +1,13 @@
+using Jobly.Core.Helper;
+
+namespace Jobly.Core.NoRestart;
+
+public static class NoRestartExtensions
+{
+    public static JobParameters WithRestart(this JobParameters parameters, bool canBeRestarted)
+    {
+        parameters.Configure<ICanBeRestartedMetadata>(x => x.CanBeRestarted = canBeRestarted);
+
+        return parameters;
+    }
+}

--- a/src/core/Jobly.Core/NoRestart/NoRestartPublishBehavior.cs
+++ b/src/core/Jobly.Core/NoRestart/NoRestartPublishBehavior.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Jobly.Core.Handlers;
+
+namespace Jobly.Core.NoRestart;
+
+public class NoRestartPublishBehavior<T> : IPublishPipelineBehavior<T>
+{
+    // Static on a generic type ⇒ one dictionary per closed T (per-type cache, not shared across Ts).
+    // When both attributes are present the factory throws; GetOrAdd does not cache exceptions,
+    // so the throw repeats on every publish until the attribute conflict is resolved.
+    private static readonly ConcurrentDictionary<Type, bool?> AttributeCache = new();
+
+    public Task PublishAsync(PublishContext<T> context, PublishDelegate next, CancellationToken ct)
+    {
+        var meta = context.GetMetadata<ICanBeRestartedMetadata>();
+
+        if (meta.CanBeRestarted == null)
+        {
+            var fromAttribute = AttributeCache.GetOrAdd(typeof(T), static t =>
+            {
+                var hasNoRestart = t.GetCustomAttribute<NoRestartAttribute>() != null;
+                var hasRestart = t.GetCustomAttribute<RestartAttribute>() != null;
+
+                if (hasNoRestart && hasRestart)
+                {
+                    throw new InvalidOperationException(
+                        $"Type '{t.FullName}' has both [NoRestart] and [Restart] attributes. Choose one.");
+                }
+
+                if (hasNoRestart)
+                {
+                    return false;
+                }
+
+                if (hasRestart)
+                {
+                    return true;
+                }
+
+                return null;
+            });
+
+            if (fromAttribute != null)
+            {
+                meta.CanBeRestarted = fromAttribute;
+            }
+        }
+
+        return next();
+    }
+}

--- a/src/core/Jobly.Core/NoRestart/NoRestartServiceConfiguration.cs
+++ b/src/core/Jobly.Core/NoRestart/NoRestartServiceConfiguration.cs
@@ -1,0 +1,14 @@
+using Jobly.Core.Handlers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jobly.Core.NoRestart;
+
+public static class NoRestartServiceConfiguration
+{
+    public static IServiceCollection AddJoblyNoRestart(this IServiceCollection services)
+    {
+        services.AddTransient(typeof(IPublishPipelineBehavior<>), typeof(NoRestartPublishBehavior<>));
+
+        return services;
+    }
+}

--- a/src/core/Jobly.Core/NoRestart/RestartAttribute.cs
+++ b/src/core/Jobly.Core/NoRestart/RestartAttribute.cs
@@ -1,0 +1,4 @@
+namespace Jobly.Core.NoRestart;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class RestartAttribute : Attribute;

--- a/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
+++ b/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
@@ -7,6 +7,7 @@ using Jobly.Core.Services;
 using Jobly.Tests.Fixtures;
 using Jobly.Worker;
 using Jobly.Core.Mutex;
+using Jobly.Core.NoRestart;
 using Jobly.Core.Retry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -140,6 +141,7 @@ public class JoblyTestServer : IAsyncDisposable
                     o.Delays = [1];
                 });
                 services.AddJoblyMutex();
+                services.AddJoblyNoRestart();
             })
             .Build();
 

--- a/src/core/Jobly.Tests/Integration/NoRestart/NoRestartIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/NoRestart/NoRestartIntegrationTests.cs
@@ -1,0 +1,101 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.NoRestart;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace Jobly.Tests.Integration.NoRestart;
+
+public abstract class NoRestartIntegrationTestsBase : IntegrationTestBase
+{
+    protected NoRestartIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [TimedFact(60_000)]
+    public async Task GivenStaleNoRestartJob_WhenRecovered_ThenMarkedFailed()
+    {
+        var metadata = MetadataSerializer.Serialize(
+            new Dictionary<string, object> { [nameof(ICanBeRestartedMetadata.CanBeRestarted)] = false })!;
+        var staleKeepAlive = DateTime.UtcNow.AddMinutes(-10);
+
+        var ctx = Server.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = staleKeepAlive,
+            Metadata = metadata,
+        });
+        await ctx.SaveChangesAsync();
+
+        await Server.WaitForJobState(jobId, State.Failed, timeout: TimeSpan.FromSeconds(45));
+
+        var job = await Server.GetJob(jobId);
+        job.CurrentState.ShouldBe(State.Failed);
+        job.ExpireAt.ShouldBeNull();
+
+        var logs = await Server.GetJobLogs(jobId);
+        logs.ShouldContain(l => l.EventType == "Failed" && l.Message.Contains("opted out of restart"));
+    }
+
+    [TimedFact(60_000)]
+    public async Task GivenNoRestartAttributeJob_WhenPublishedAndStale_ThenMarkedFailed()
+    {
+        // Publish through the real pipeline so NoRestartPublishBehavior writes CanBeRestarted=false.
+        var publisher = Server.CreatePublisher();
+        var jobId = await publisher.Enqueue(new NoRestartAttributeRequest());
+        await publisher.SaveChangesAsync();
+
+        // Let the worker run it to completion so we know the behavior wrote metadata that persisted.
+        await Server.WaitForJobState(jobId, State.Completed);
+        var published = await Server.GetJob(jobId);
+        published.Metadata.ShouldNotBeNull();
+        var publishedMeta = MetadataSerializer.Deserialize(published.Metadata);
+        publishedMeta[nameof(ICanBeRestartedMetadata.CanBeRestarted)].ShouldBe(false);
+
+        // Force the completed job back into Processing with a stale keep-alive — simulates a
+        // crashed worker. The stale recovery task must now honor the metadata and mark it Failed.
+        var ctx = Server.CreateContext();
+        await ctx.Set<Job>()
+            .Where(x => x.Id == jobId)
+            .ExecuteUpdateAsync(x => x
+                .SetProperty(p => p.CurrentState, State.Processing)
+                .SetProperty(p => p.LastKeepAlive, DateTime.UtcNow.AddMinutes(-10)));
+
+        await Server.WaitForJobState(jobId, State.Failed, timeout: TimeSpan.FromSeconds(45));
+
+        var job = await Server.GetJob(jobId);
+        job.CurrentState.ShouldBe(State.Failed);
+        job.ExpireAt.ShouldBeNull();
+    }
+}
+
+[Collection<PostgreSqlIntegrationCollection>]
+public class NoRestartIntegrationTests_PostgreSql : NoRestartIntegrationTestsBase
+{
+    public NoRestartIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerIntegrationCollection>]
+[Trait("Category", "SqlServer")]
+public class NoRestartIntegrationTests_SqlServer : NoRestartIntegrationTestsBase
+{
+    public NoRestartIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests/TestData/Handlers/NoRestartAttributeCommands.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/NoRestartAttributeCommands.cs
@@ -1,0 +1,38 @@
+using Jobly.Core.Handlers;
+using Jobly.Core.NoRestart;
+
+namespace Jobly.Tests.TestData.Handlers;
+
+[NoRestart]
+public class NoRestartAttributeRequest : IJob;
+
+[Restart]
+public class RestartAttributeRequest : IJob;
+
+[NoRestart]
+[Restart]
+public class BothAttributesRequest : IJob;
+
+public class NoRestartAttributeCommand : IJobHandler<NoRestartAttributeRequest>
+{
+    public Task HandleAsync(NoRestartAttributeRequest message, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public class RestartAttributeCommand : IJobHandler<RestartAttributeRequest>
+{
+    public Task HandleAsync(RestartAttributeRequest message, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+public class BothAttributesCommand : IJobHandler<BothAttributesRequest>
+{
+    public Task HandleAsync(BothAttributesRequest message, CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/core/Jobly.Tests/Unit/AuditFixTests.cs
+++ b/src/core/Jobly.Tests/Unit/AuditFixTests.cs
@@ -56,7 +56,7 @@ public abstract class AuditFixTestsBase : IAsyncLifetime
 
         // Act: run stale recovery
         var recoveryCtx = _fixture.CreateContext();
-        await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(recoveryCtx, TimeProvider.System, TimeSpan.FromMinutes(5));
+        await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(recoveryCtx, TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert: job should be Deleted (not Enqueued) because user intended to cancel it
         var readCtx = _fixture.CreateContext();

--- a/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
+++ b/src/core/Jobly.Tests/Unit/BackgroundTaskTests.cs
@@ -169,10 +169,10 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
 
         // Act
         var recoveryCtx = _fixture.CreateContext();
-        var count = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(recoveryCtx, TimeProvider.System, TimeSpan.FromMinutes(5));
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(recoveryCtx, TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert
-        count.ShouldBe(1);
+        result.Requeued.ShouldBe(1);
         var readCtx = _fixture.CreateContext();
         var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == jobId);
         job.ShouldNotBeNull();
@@ -199,10 +199,10 @@ public abstract class BackgroundTaskTestsBase : IAsyncLifetime
 
         // Act
         var recoveryCtx = _fixture.CreateContext();
-        var count = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(recoveryCtx, TimeProvider.System, TimeSpan.FromMinutes(5));
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(recoveryCtx, TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert
-        count.ShouldBe(0);
+        result.Total.ShouldBe(0);
         var readCtx = _fixture.CreateContext();
         var job = await readCtx.Set<Job>().FirstOrDefaultAsync(j => j.Id == jobId);
         job.ShouldNotBeNull();

--- a/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
@@ -43,11 +43,11 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
 
         // Act
-        var count = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
             _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert
-        count.ShouldBe(5);
+        result.Requeued.ShouldBe(5);
         var readCtx = _fixture.CreateContext();
         foreach (var id in jobIds)
         {
@@ -101,11 +101,11 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
 
         // Act
-        var count = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
             _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert
-        count.ShouldBe(0);
+        result.Total.ShouldBe(0);
 
         var readCtx = _fixture.CreateContext();
         (await readCtx.Set<Job>().FirstAsync(j => j.Id == completedId)).CurrentState.ShouldBe(State.Completed);
@@ -134,7 +134,7 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
 
         // Act
-        await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+        await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
             _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert
@@ -164,14 +164,14 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
 
         // Act — run 5 concurrent requeue attempts
         var tasks = Enumerable.Range(0, 5)
-            .Select(_ => StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+            .Select(_ => StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
                 _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5)))
             .ToList();
 
         var results = await Task.WhenAll(tasks);
 
         // Assert — exactly 1 should have requeued the job
-        results.Sum().ShouldBe(1);
+        results.Sum(x => x.Requeued).ShouldBe(1);
 
         var logs = await _fixture.CreateContext().Set<JobLog>()
             .Where(x => x.JobId == jobId && x.EventType == "Requeued")
@@ -264,13 +264,13 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
         await ctx.SaveChangesAsync();
 
         // Act — run both cleanup + recovery (as health manager would)
-        var requeued = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+        var recovery = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
             _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5));
         var removed = await ServerCleanupTask<TestContext>.CleanUpServers(
             _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5));
 
         // Assert
-        requeued.ShouldBe(1);
+        recovery.Requeued.ShouldBe(1);
         removed.ShouldBe(1);
 
         var readCtx = _fixture.CreateContext();
@@ -305,11 +305,11 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
 
         // Act
         var tp = new FakeTimeProvider(now);
-        var count = await StaleJobRecoveryTask<TestContext>.RequeueStaleJobs(
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
             _fixture.CreateContext(), tp, timeout);
 
         // Assert — should NOT be requeued (at boundary, not past it)
-        count.ShouldBe(0);
+        result.Total.ShouldBe(0);
         var readCtx = _fixture.CreateContext();
         var job = await readCtx.Set<Job>().FindAsync(jobId);
         job.ShouldNotBeNull();

--- a/src/core/Jobly.Tests/Unit/NoRestart/NoRestartAddonTests.cs
+++ b/src/core/Jobly.Tests/Unit/NoRestart/NoRestartAddonTests.cs
@@ -1,0 +1,133 @@
+using Jobly.Core;
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Handlers;
+using Jobly.Core.NoRestart;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Jobly.Tests.Unit.NoRestart;
+
+public abstract class NoRestartAddonTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+
+    protected NoRestartAddonTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private ServiceProvider BuildProvider(bool registerAddon)
+    {
+        var services = new ServiceCollection();
+        services.AddHandlers(typeof(NoRestartAddonTestsBase).Assembly);
+        services.AddLogging();
+        services.AddScoped<TestContext>(_ => _fixture.CreateContext());
+        services.AddScoped<JobContext>();
+        services.AddScoped<IJobContext>(x => x.GetRequiredService<JobContext>());
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<IOptions<JoblyConfiguration>>(new OptionsWrapper<JoblyConfiguration>(new JoblyConfiguration()));
+
+        if (registerAddon)
+        {
+            services.AddJoblyNoRestart();
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    [TimedFact]
+    public async Task NoRestartAttribute_AddonRegistered_SetsCanBeRestartedFalse()
+    {
+        var provider = BuildProvider(registerAddon: true);
+        await using var scope = provider.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestContext>();
+        var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, scope.ServiceProvider);
+
+        var jobId = await publisher.Enqueue(new NoRestartAttributeRequest());
+        await publisher.SaveChangesAsync();
+
+        var job = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.Metadata.ShouldNotBeNull();
+        var metadata = MetadataSerializer.Deserialize(job.Metadata);
+        metadata.ShouldContainKey(nameof(ICanBeRestartedMetadata.CanBeRestarted));
+        metadata[nameof(ICanBeRestartedMetadata.CanBeRestarted)].ShouldBe(false);
+    }
+
+    [TimedFact]
+    public async Task RestartAttribute_AddonRegistered_SetsCanBeRestartedTrue()
+    {
+        var provider = BuildProvider(registerAddon: true);
+        await using var scope = provider.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestContext>();
+        var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, scope.ServiceProvider);
+
+        var jobId = await publisher.Enqueue(new RestartAttributeRequest());
+        await publisher.SaveChangesAsync();
+
+        var job = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.Metadata.ShouldNotBeNull();
+        var metadata = MetadataSerializer.Deserialize(job.Metadata);
+        metadata[nameof(ICanBeRestartedMetadata.CanBeRestarted)].ShouldBe(true);
+    }
+
+    [TimedFact]
+    public async Task NoRestartAttribute_AddonNotRegistered_AttributeIgnored()
+    {
+        // Proves the feature is truly opt-in: without AddJoblyNoRestart(), the publish pipeline
+        // does not inspect the attribute and no metadata is written.
+        var provider = BuildProvider(registerAddon: false);
+        await using var scope = provider.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestContext>();
+        var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, scope.ServiceProvider);
+
+        var jobId = await publisher.Enqueue(new NoRestartAttributeRequest());
+        await publisher.SaveChangesAsync();
+
+        var job = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.Metadata.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task WithRestart_AddonNotRegistered_ExplicitMetadataStillPersisted()
+    {
+        // .WithRestart() writes directly to JobParameters.Metadata, so it bypasses the
+        // publish behavior entirely — the value must persist even without the addon.
+        var provider = BuildProvider(registerAddon: false);
+        await using var scope = provider.CreateAsyncScope();
+        var ctx = scope.ServiceProvider.GetRequiredService<TestContext>();
+        var publisher = new Publisher<TestContext>(ctx, Options.Create(new JoblyConfiguration()), TimeProvider.System, scope.ServiceProvider);
+
+        var jobId = await publisher.Enqueue(new UnitRequest(), new Jobly.Core.Helper.JobParameters().WithRestart(canBeRestarted: false));
+        await publisher.SaveChangesAsync();
+
+        var job = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.Metadata.ShouldNotBeNull();
+        var metadata = MetadataSerializer.Deserialize(job.Metadata);
+        metadata[nameof(ICanBeRestartedMetadata.CanBeRestarted)].ShouldBe(false);
+    }
+}
+
+[Collection<PostgreSqlCollection>]
+public class NoRestartAddonTests_PostgreSql : NoRestartAddonTestsBase
+{
+    public NoRestartAddonTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerCollection>]
+[Trait("Category", "SqlServer")]
+public class NoRestartAddonTests_SqlServer : NoRestartAddonTestsBase
+{
+    public NoRestartAddonTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests/Unit/NoRestart/NoRestartCrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/NoRestart/NoRestartCrashRecoveryTests.cs
@@ -1,0 +1,226 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.NoRestart;
+using Jobly.Tests.Fixtures;
+using Jobly.Worker.Services;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace Jobly.Tests.Unit.NoRestart;
+
+public abstract class NoRestartCrashRecoveryTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+
+    protected NoRestartCrashRecoveryTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private static string SerializeCanBeRestarted(bool value)
+    {
+        var dict = new Dictionary<string, object>();
+        var meta = MetadataFactory.Create<ICanBeRestartedMetadata>(dict);
+        meta.CanBeRestarted = value;
+
+        return MetadataSerializer.Serialize((Dictionary<string, object>)(object)meta)!;
+    }
+
+    private static async Task<Guid> InsertStaleJob(IDatabaseFixture fixture, string? metadata)
+    {
+        var ctx = fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = DateTime.UtcNow.AddMinutes(-10),
+            Metadata = metadata,
+        });
+        await ctx.SaveChangesAsync();
+
+        return jobId;
+    }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_StaleJob_NoMetadata_DefaultTrue_Requeued()
+    {
+        var jobId = await InsertStaleJob(_fixture, metadata: null);
+
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
+            _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5), restartByDefault: true);
+
+        result.Requeued.ShouldBe(1);
+        result.Failed.ShouldBe(0);
+        var job = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.CurrentState.ShouldBe(State.Enqueued);
+        job.ExpireAt.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_StaleJob_NoMetadata_DefaultFalse_Failed()
+    {
+        var jobId = await InsertStaleJob(_fixture, metadata: null);
+
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
+            _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5), restartByDefault: false);
+
+        result.Failed.ShouldBe(1);
+        result.Requeued.ShouldBe(0);
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.CurrentState.ShouldBe(State.Failed);
+        job.ExpireAt.ShouldBeNull();
+
+        var counter = await readCtx.Set<Counter>().FirstOrDefaultAsync(x => x.Key == "stats:failed");
+        counter.ShouldNotBeNull();
+        counter.Value.ShouldBe(1);
+
+        var log = await readCtx.Set<JobLog>()
+            .Where(x => x.JobId == jobId)
+            .Where(x => x.EventType == "Failed")
+            .FirstOrDefaultAsync();
+        log.ShouldNotBeNull();
+        log.Level.ShouldBe("Error");
+        log.Message.ShouldContain("opted out of restart");
+    }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_StaleJob_MetadataTrue_DefaultFalse_Requeued()
+    {
+        var jobId = await InsertStaleJob(_fixture, metadata: SerializeCanBeRestarted(true));
+
+        await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
+            _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5), restartByDefault: false);
+
+        var job = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.CurrentState.ShouldBe(State.Enqueued);
+    }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_StaleJob_MetadataFalse_DefaultTrue_Failed()
+    {
+        var jobId = await InsertStaleJob(_fixture, metadata: SerializeCanBeRestarted(false));
+
+        await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
+            _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5), restartByDefault: true);
+
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.CurrentState.ShouldBe(State.Failed);
+        job.ExpireAt.ShouldBeNull();
+
+        var counter = await readCtx.Set<Counter>().FirstOrDefaultAsync(x => x.Key == "stats:failed");
+        counter.ShouldNotBeNull();
+        counter.Value.ShouldBe(1);
+    }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_StaleJob_CancellationPending_NoRestartMetadata_Deleted()
+    {
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = DateTime.UtcNow.AddMinutes(-10),
+            CancellationMode = CancellationMode.Graceful,
+            Metadata = SerializeCanBeRestarted(false),
+        });
+        await ctx.SaveChangesAsync();
+
+        await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
+            _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5), restartByDefault: true);
+
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(x => x.Id == jobId);
+        job.CurrentState.ShouldBe(State.Deleted);
+        job.CancellationMode.ShouldBe(CancellationMode.None);
+        job.ExpireAt.ShouldNotBeNull();
+    }
+
+    [TimedFact]
+    public async Task RequeueStaleJobs_MixedJobs_EachRoutedCorrectly()
+    {
+        var ctx = _fixture.CreateContext();
+        var requeuedId = Guid.NewGuid();
+        var failedId = Guid.NewGuid();
+        var defaultId = Guid.NewGuid();
+        var stale = DateTime.UtcNow.AddMinutes(-10);
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = requeuedId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = stale,
+            Metadata = SerializeCanBeRestarted(true),
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = failedId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = stale,
+            Metadata = SerializeCanBeRestarted(false),
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = defaultId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            LastKeepAlive = stale,
+        });
+        await ctx.SaveChangesAsync();
+
+        var result = await StaleJobRecoveryTask<TestContext>.RecoverStaleJobs(
+            _fixture.CreateContext(), TimeProvider.System, TimeSpan.FromMinutes(5), restartByDefault: true);
+
+        result.Total.ShouldBe(3);
+        result.Requeued.ShouldBe(2);
+        result.Failed.ShouldBe(1);
+        var readCtx = _fixture.CreateContext();
+        (await readCtx.Set<Job>().FirstAsync(x => x.Id == requeuedId)).CurrentState.ShouldBe(State.Enqueued);
+        (await readCtx.Set<Job>().FirstAsync(x => x.Id == failedId)).CurrentState.ShouldBe(State.Failed);
+        (await readCtx.Set<Job>().FirstAsync(x => x.Id == defaultId)).CurrentState.ShouldBe(State.Enqueued);
+    }
+}
+
+[Collection<PostgreSqlCollection>]
+public class NoRestartCrashRecoveryTests_PostgreSql : NoRestartCrashRecoveryTestsBase
+{
+    public NoRestartCrashRecoveryTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerCollection>]
+[Trait("Category", "SqlServer")]
+public class NoRestartCrashRecoveryTests_SqlServer : NoRestartCrashRecoveryTestsBase
+{
+    public NoRestartCrashRecoveryTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests/Unit/NoRestart/NoRestartExtensionTests.cs
+++ b/src/core/Jobly.Tests/Unit/NoRestart/NoRestartExtensionTests.cs
@@ -1,0 +1,31 @@
+using Jobly.Core.Handlers;
+using Jobly.Core.Helper;
+using Jobly.Core.NoRestart;
+using Shouldly;
+
+namespace Jobly.Tests.Unit.NoRestart;
+
+public class NoRestartExtensionTests
+{
+    [TimedFact]
+    public Task WithRestart_True_SetsMetadataTrue()
+    {
+        var parameters = new JobParameters().WithRestart(canBeRestarted: true);
+
+        parameters.Metadata.ShouldNotBeNull();
+        var meta = MetadataFactory.Create<ICanBeRestartedMetadata>(parameters.Metadata);
+        meta.CanBeRestarted.ShouldBe(true);
+        return Task.CompletedTask;
+    }
+
+    [TimedFact]
+    public Task WithRestart_False_SetsMetadataFalse()
+    {
+        var parameters = new JobParameters().WithRestart(canBeRestarted: false);
+
+        parameters.Metadata.ShouldNotBeNull();
+        var meta = MetadataFactory.Create<ICanBeRestartedMetadata>(parameters.Metadata);
+        meta.CanBeRestarted.ShouldBe(false);
+        return Task.CompletedTask;
+    }
+}

--- a/src/core/Jobly.Tests/Unit/NoRestart/NoRestartPublishBehaviorTests.cs
+++ b/src/core/Jobly.Tests/Unit/NoRestart/NoRestartPublishBehaviorTests.cs
@@ -1,0 +1,85 @@
+using Jobly.Core.Handlers;
+using Jobly.Core.NoRestart;
+using Jobly.Tests.TestData.Handlers;
+using Shouldly;
+
+namespace Jobly.Tests.Unit.NoRestart;
+
+public class NoRestartPublishBehaviorTests
+{
+    private static async Task<ICanBeRestartedMetadata> RunBehavior<T>(T job, Dictionary<string, object>? startingMetadata = null)
+    {
+        var behavior = new NoRestartPublishBehavior<T>();
+        var context = new PublishContext<T>
+        {
+            Job = job!,
+            Metadata = startingMetadata ?? [],
+        };
+
+        await behavior.PublishAsync(context, () => Task.CompletedTask, CancellationToken.None);
+
+        return context.GetMetadata<ICanBeRestartedMetadata>();
+    }
+
+    [TimedFact]
+    public async Task PublishAsync_NoAttribute_MetadataUnchanged()
+    {
+        var meta = await RunBehavior(new UnitRequest());
+
+        meta.CanBeRestarted.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task PublishAsync_NoRestartAttribute_SetsMetadataFalse()
+    {
+        var meta = await RunBehavior(new NoRestartAttributeRequest());
+
+        meta.CanBeRestarted.ShouldBe(false);
+    }
+
+    [TimedFact]
+    public async Task PublishAsync_RestartAttribute_SetsMetadataTrue()
+    {
+        var meta = await RunBehavior(new RestartAttributeRequest());
+
+        meta.CanBeRestarted.ShouldBe(true);
+    }
+
+    [TimedFact]
+    public async Task PublishAsync_MetadataAlreadySet_AttributeIgnored()
+    {
+        var starting = new Dictionary<string, object> { ["CanBeRestarted"] = true };
+        var meta = await RunBehavior(new NoRestartAttributeRequest(), starting);
+
+        meta.CanBeRestarted.ShouldBe(true);
+    }
+
+    [TimedFact]
+    public async Task PublishAsync_BothAttributes_Throws()
+    {
+        await Should.ThrowAsync<InvalidOperationException>(() => RunBehavior(new BothAttributesRequest()));
+    }
+
+    [TimedFact]
+    public async Task PublishAsync_CallsNext()
+    {
+        var called = false;
+        var behavior = new NoRestartPublishBehavior<UnitRequest>();
+        var context = new PublishContext<UnitRequest>
+        {
+            Job = new UnitRequest(),
+            Metadata = [],
+        };
+
+        await behavior.PublishAsync(
+            context,
+            () =>
+            {
+                called = true;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        called.ShouldBeTrue();
+    }
+}

--- a/src/core/Jobly.Worker/Configuration.cs
+++ b/src/core/Jobly.Worker/Configuration.cs
@@ -60,6 +60,13 @@ public class JoblyWorkerConfiguration : JoblyConfiguration
     public TimeSpan InvisibilityTimeout { get; set; } = TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// When a job's worker dies and the job is recovered, by default it is requeued (true).
+    /// Set to false to fail stale jobs by default. Can be overridden per-job with
+    /// [NoRestart]/[Restart] attributes or .WithRestart(bool).
+    /// </summary>
+    public bool RestartStaleJobsByDefault { get; set; } = true;
+
+    /// <summary>
     /// Worker Id should be unique for each worker. If you need to control the worker id, you can set it here.
     /// </summary>
     public Guid ServerId { get; set; } = Guid.NewGuid();

--- a/src/core/Jobly.Worker/Services/StaleJobRecoveryResult.cs
+++ b/src/core/Jobly.Worker/Services/StaleJobRecoveryResult.cs
@@ -1,0 +1,6 @@
+namespace Jobly.Worker.Services;
+
+public readonly record struct StaleJobRecoveryResult(int Requeued, int Failed, int Deleted)
+{
+    public int Total => Requeued + Failed + Deleted;
+}

--- a/src/core/Jobly.Worker/Services/StaleJobRecoveryTask.cs
+++ b/src/core/Jobly.Worker/Services/StaleJobRecoveryTask.cs
@@ -2,7 +2,9 @@ using Jobly.Core;
 using Jobly.Core.Data.Entities;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
 using Jobly.Core.Interceptors;
+using Jobly.Core.NoRestart;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -31,15 +33,25 @@ public class StaleJobRecoveryTask<TContext> : ServerTaskBase<TContext>
 
     protected override async Task<string?> RunServerTask(TContext context, CancellationToken ct)
     {
-        var count = await RequeueStaleJobs(context, TimeProvider, Configuration.InvisibilityTimeout);
-        return count > 0 ? $"Requeued {count} stale jobs" : null;
+        var result = await RecoverStaleJobs(context, TimeProvider, Configuration.InvisibilityTimeout, Configuration.RestartStaleJobsByDefault);
+        if (result.Total == 0)
+        {
+            return null;
+        }
+
+        return $"Recovered {result.Total} stale jobs ({result.Requeued} requeued, {result.Failed} failed, {result.Deleted} deleted)";
     }
 
     /// <summary>
-    /// Finds jobs stuck in Processing with stale LastKeepAlive and requeues them.
-    /// Public static so tests can call it directly.
+    /// Finds jobs stuck in Processing with stale LastKeepAlive and recovers them —
+    /// requeueing, failing (per <see cref="ICanBeRestartedMetadata.CanBeRestarted"/>),
+    /// or deleting (when cancellation was pending). Public static so tests can call it directly.
     /// </summary>
-    public static async Task<int> RequeueStaleJobs<TCtx>(TCtx context, TimeProvider timeProvider, TimeSpan invisibilityTimeout)
+    public static async Task<StaleJobRecoveryResult> RecoverStaleJobs<TCtx>(
+        TCtx context,
+        TimeProvider timeProvider,
+        TimeSpan invisibilityTimeout,
+        bool restartByDefault = true)
         where TCtx : DbContext
     {
         var now = timeProvider.GetUtcNow().UtcDateTime;
@@ -51,6 +63,10 @@ public class StaleJobRecoveryTask<TContext> : ServerTaskBase<TContext>
             .Where(x => x.LastKeepAlive != null && x.LastKeepAlive < cutoff)
             .TagWith(InterceptorConstants.RowLockTableJob)
             .ToListAsync();
+
+        var requeued = 0;
+        var failed = 0;
+        var deleted = 0;
 
         foreach (var job in staleJobs)
         {
@@ -72,8 +88,14 @@ public class StaleJobRecoveryTask<TContext> : ServerTaskBase<TContext>
                     Level = "Warning",
                     Message = "Cancelled by crash recovery — cancellation was pending when worker stopped",
                 });
+                deleted++;
+
+                continue;
             }
-            else
+
+            var canRestart = ReadCanBeRestarted(job.Metadata) ?? restartByDefault;
+
+            if (canRestart)
             {
                 job.CurrentState = State.Enqueued;
                 context.Set<JobLog>().Add(new JobLog
@@ -84,12 +106,41 @@ public class StaleJobRecoveryTask<TContext> : ServerTaskBase<TContext>
                     Level = "Warning",
                     Message = "Requeued by crash recovery — worker stopped responding",
                 });
+                requeued++;
+            }
+            else
+            {
+                job.CurrentState = State.Failed;
+                job.ExpireAt = null;
+                context.Set<Counter>().Add(new Counter { Key = "stats:failed", Value = 1 });
+                context.Set<JobLog>().Add(new JobLog
+                {
+                    JobId = job.Id,
+                    EventType = "Failed",
+                    Timestamp = now,
+                    Level = "Error",
+                    Message = "Failed by crash recovery — job opted out of restart",
+                });
+                failed++;
             }
         }
 
         await context.SaveChangesAsync();
         await transaction.CommitAsync();
 
-        return staleJobs.Count;
+        return new StaleJobRecoveryResult(requeued, failed, deleted);
+    }
+
+    private static bool? ReadCanBeRestarted(string? metadataJson)
+    {
+        if (string.IsNullOrEmpty(metadataJson))
+        {
+            return null;
+        }
+
+        var dict = MetadataSerializer.Deserialize(metadataJson);
+        var meta = MetadataFactory.Create<ICanBeRestartedMetadata>(dict);
+
+        return meta.CanBeRestarted;
     }
 }

--- a/website/docs/features/no-restart.md
+++ b/website/docs/features/no-restart.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 8
+---
+
+# NoRestart (Stale-Recovery Opt-Out)
+
+When a worker crashes mid-job, Jobly's `StaleJobRecoveryTask` normally requeues the job so another worker can pick it up. That's the right default for idempotent work — but some jobs must never run twice (charge a card, send an email, call a non-idempotent API). The NoRestart feature lets those jobs opt out: on worker crash they are marked `Failed` instead of requeued.
+
+## Setup
+
+NoRestart is an opt-in addon. Register it alongside `AddJobly` / `AddJoblyWorker`:
+
+```csharp
+builder.Services.AddJoblyWorker<AppDbContext>();
+builder.Services.AddJoblyNoRestart();
+```
+
+Without `AddJoblyNoRestart()`, the `[NoRestart]` / `[Restart]` attributes are silently ignored (the publish behavior isn't registered). `.WithRestart(bool)` still works — it writes metadata directly and doesn't need the addon.
+
+## Usage
+
+Three ways to opt a job out of restart:
+
+### `[NoRestart]` attribute
+
+Apply to the job class for a blanket "never restart me" policy:
+
+```csharp
+[NoRestart]
+public class ChargeCard : IJob
+{
+    public int CustomerId { get; set; }
+    public decimal Amount { get; set; }
+}
+
+await publisher.Enqueue(new ChargeCard { CustomerId = 123, Amount = 50 });
+```
+
+### `[Restart]` attribute
+
+Explicitly opts in (useful if you've flipped the global default to `false`):
+
+```csharp
+[Restart]
+public class RegenerateThumbnail : IJob { /* idempotent */ }
+```
+
+Applying both `[NoRestart]` and `[Restart]` to the same class throws `InvalidOperationException` at publish time.
+
+### `.WithRestart(bool)` fluent extension
+
+Per-publish override — wins over attributes and over the global default:
+
+```csharp
+await publisher.Enqueue(
+    new SendWebhook { Url = url },
+    new JobParameters().WithRestart(canBeRestarted: false));
+```
+
+### Global default
+
+Set `RestartStaleJobsByDefault` on `JoblyWorkerConfiguration` to flip the fleet-wide default:
+
+```csharp
+builder.Services.AddJoblyWorker<AppDbContext>(config =>
+{
+    config.RestartStaleJobsByDefault = false; // jobs fail on crash unless they opt in
+});
+```
+
+## Override Chain
+
+When `StaleJobRecoveryTask` evaluates a stale job, it resolves `CanBeRestarted` in this order (first non-null wins):
+
+1. Per-publish metadata set via `.WithRestart()`
+2. `[NoRestart]` / `[Restart]` attribute on the job class (written at publish time by `NoRestartPublishBehavior`)
+3. `RestartStaleJobsByDefault` on `JoblyWorkerConfiguration` (default `true`)
+
+## How It Works
+
+NoRestart has two moving parts:
+
+- **`NoRestartPublishBehavior<T>`** runs at publish time. If metadata doesn't already carry a `CanBeRestarted` value, it inspects the job type for `[NoRestart]` / `[Restart]` and writes `CanBeRestarted = false` / `true` into the job's metadata. Attribute lookups are cached per closed generic type.
+- **`StaleJobRecoveryTask`** runs on each server (default every 30s). It finds jobs in `Processing` with `LastKeepAlive` older than `InvisibilityTimeout`, then for each:
+  - If `CancellationMode != None` → `Deleted` (user intent wins).
+  - Else read `CanBeRestarted` from metadata, fall back to `RestartStaleJobsByDefault`.
+    - `true` → `Enqueued` with an `EventType = "Requeued"` warning log.
+    - `false` → `Failed`, `ExpireAt = null`, `stats:failed` counter incremented, `EventType = "Failed"` error log `"Failed by crash recovery — job opted out of restart"`.
+
+`Failed` jobs are never auto-deleted (per the project-wide rule); they stay visible in the dashboard for operator review until explicitly cleaned up.
+
+## Dashboard
+
+Jobs failed by crash recovery appear in the `Failed` tab with an error-level log `"Failed by crash recovery — job opted out of restart"`. The task activity log shows the per-sweep breakdown: `"Recovered 3 stale jobs (2 requeued, 1 failed, 0 deleted)"`.
+
+## When To Use
+
+- **Payments / charges** — single side effect, never retry on crash.
+- **Outbound notifications** (email, SMS, webhooks) — duplicate delivery is worse than missed delivery.
+- **External API calls** against non-idempotent endpoints.
+- **Legal / compliance workflows** where retry semantics must be explicit.
+
+For idempotent work — the large majority of background jobs — leave the default in place and let the worker requeue on crash.
+
+## Relationship to Retry
+
+NoRestart and the Retry addon are independent:
+
+- **Retry** governs what happens when the handler *throws*. Catches the exception, increments `RetriedTimes`, reschedules.
+- **NoRestart** governs what happens when the worker *dies* mid-execution without ever completing the handler. Affects stale-recovery only.
+
+A `[NoRestart]` job can still declare `[Retry(MaxRetries = 3)]` — the two policies never collide.


### PR DESCRIPTION
## Summary
- Opt-out mechanism so non-idempotent jobs (payments, webhooks) are marked `Failed` instead of requeued when their worker crashes mid-execution.
- Three override knobs — per-publish `.WithRestart(bool)` → `[NoRestart]`/`[Restart]` attribute → global `RestartStaleJobsByDefault` on `JoblyWorkerConfiguration`.
- Registered as an opt-in addon (`AddJoblyNoRestart()`), mirroring the Mutex/Retry pattern. `StaleJobRecoveryTask.RequeueStaleJobs` renamed to `RecoverStaleJobs` and now returns `StaleJobRecoveryResult(Requeued, Failed, Deleted)` so the task activity log reports an accurate per-sweep breakdown.
- Docs at `website/docs/features/no-restart.md`.

## Files of note
- `src/core/Jobly.Core/NoRestart/` — attributes, metadata interface, publish behavior, `.WithRestart()` extension, `AddJoblyNoRestart()` addon registration.
- `src/core/Jobly.Worker/Configuration.cs` — adds `RestartStaleJobsByDefault` (default `true`).
- `src/core/Jobly.Worker/Services/StaleJobRecoveryTask.cs` — new Failed branch with `stats:failed` counter, Error-level JobLog, `ExpireAt = null` (failed jobs never auto-delete per §8.2). `ReadCanBeRestarted` resolves metadata via the now-public `MetadataSerializer`.
- `src/core/Jobly.Core/Handlers/MetadataSerializer.cs` — promoted from `internal` to `public` so worker + future addons don't rely on `InternalsVisibleTo`.

## Test plan
- [x] `dotnet test --project core/Jobly.Tests/Jobly.Tests.csproj --filter-namespace "Jobly.Tests.Unit.NoRestart" --filter-not-trait "Category=SqlServer"` — 18/18 pass
- [x] `dotnet test --project core/Jobly.Tests/Jobly.Tests.csproj --filter-namespace "Jobly.Tests.Integration.NoRestart" --filter-not-trait "Category=SqlServer"` — 2/2 pass
- [x] Full PG unit suite — 389/390 (one pre-existing `CleanUpServers_HeartbeatAtExactTimeout_NotCleaned` flake, unrelated to this branch)
- [x] Full PG integration suite — 65/65 pass
- [x] `dotnet build Jobly.slnx` succeeds; only warning from new code is the same CS8601 on source-gen `bool?` that Mutex/Retry already emit

### Coverage highlights
- `NoRestartAddonTests` proves opt-in semantics both ways: `[NoRestart]` is honored only when `AddJoblyNoRestart()` is registered, and `.WithRestart()` (direct metadata) works even without it.
- `NoRestartCrashRecoveryTests` covers every branch of the override chain (attribute/metadata/default) plus the cancellation-precedence path and a mixed-batch test asserting `Total=3, Requeued=2, Failed=1`.
- `NoRestartIntegrationTests` exercises both the raw-metadata path and the attribute-driven publish → persist → crash → recover flow with `JoblyTestServer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)