### PR TITLE
Add circuit breaker pipeline behavior addon

### DIFF
--- a/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerAttribute.cs
+++ b/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerAttribute.cs
@@ -1,0 +1,28 @@
+namespace Jobly.Core.CircuitBreaker;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class CircuitBreakerAttribute : Attribute
+{
+    public string? Group { get; set; }
+
+    public int Threshold { get; set; }
+
+    public int DurationSeconds { get; set; }
+
+    public int ResetJitterSeconds { get; set; }
+
+    public int GetThreshold(CircuitBreakerOptions options)
+    {
+        return Threshold > 0 ? Threshold : options.Threshold;
+    }
+
+    public TimeSpan GetDuration(CircuitBreakerOptions options)
+    {
+        return DurationSeconds > 0 ? TimeSpan.FromSeconds(DurationSeconds) : options.Duration;
+    }
+
+    public TimeSpan GetResetJitter(CircuitBreakerOptions options)
+    {
+        return ResetJitterSeconds > 0 ? TimeSpan.FromSeconds(ResetJitterSeconds) : options.ResetJitter;
+    }
+}

--- a/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerOptions.cs
@@ -1,0 +1,10 @@
+namespace Jobly.Core.CircuitBreaker;
+
+public class CircuitBreakerOptions
+{
+    public int Threshold { get; set; } = 3;
+
+    public TimeSpan Duration { get; set; } = TimeSpan.FromMinutes(1);
+
+    public TimeSpan ResetJitter { get; set; } = TimeSpan.FromSeconds(10);
+}

--- a/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerPipelineBehavior.cs
+++ b/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerPipelineBehavior.cs
@@ -1,0 +1,98 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Microsoft.Extensions.Options;
+
+namespace Jobly.Core.CircuitBreaker;
+
+public class CircuitBreakerPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>, IJob
+{
+    private static readonly ConcurrentDictionary<Type, CircuitBreakerAttribute?> AttributeCache = new();
+
+    private readonly IJobContext _jobContext;
+    private readonly IOptions<CircuitBreakerOptions> _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly ICircuitBreakerStore _store;
+
+    public CircuitBreakerPipelineBehavior(
+        IJobContext jobContext,
+        IOptions<CircuitBreakerOptions> options,
+        TimeProvider timeProvider,
+        ICircuitBreakerStore store)
+    {
+        _jobContext = jobContext;
+        _options = options;
+        _timeProvider = timeProvider;
+        _store = store;
+    }
+
+    public async Task<TResponse> HandleAsync(TRequest request, RequestHandlerDelegate<TRequest, TResponse> next, CancellationToken cancellationToken)
+    {
+        var attr = GetCircuitBreakerAttribute();
+        var groupKey = attr?.Group ?? typeof(TRequest).Name;
+        var options = _options.Value;
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var state = await _store.GetAsync(groupKey, cancellationToken);
+        if (state?.OpenUntil is { } openUntil && openUntil > now)
+        {
+            var jitter = attr?.GetResetJitter(options) ?? options.ResetJitter;
+            var jitterMs = (int)jitter.TotalMilliseconds;
+            var delayMs = jitterMs > 0 ? Random.Shared.Next(0, jitterMs + 1) : 0;
+            _jobContext.Outcome = new JobOutcome
+            {
+                State = State.Enqueued,
+                ScheduleTime = openUntil.AddMilliseconds(delayMs),
+                LogMessage = $"Rescheduled due to open circuit breaker '{groupKey}'",
+            };
+
+            return default!;
+        }
+
+        try
+        {
+            var response = await next(request, cancellationToken);
+
+            // Only reset on a real handler success. If another behavior (e.g. Mutex) set an Outcome,
+            // the handler didn't actually complete — treat as a non-event for the circuit counter.
+            // state is a pre-execution snapshot: if a concurrent worker incremented FailureCount during
+            // next(), our snapshot may show 0 and we skip the reset. The next clean success corrects it.
+            if (_jobContext.Outcome is null && state?.FailureCount > 0)
+            {
+                await _store.ResetAsync(groupKey, cancellationToken);
+            }
+
+            return response;
+        }
+        catch
+        {
+            if (_jobContext.Outcome is not null)
+            {
+                throw;
+            }
+
+            var threshold = attr?.GetThreshold(options) ?? options.Threshold;
+            var duration = attr?.GetDuration(options) ?? options.Duration;
+            await _store.RecordFailureAsync(groupKey, threshold, duration, now, cancellationToken);
+
+            throw;
+        }
+    }
+
+    private CircuitBreakerAttribute? GetCircuitBreakerAttribute()
+    {
+        var handlerType = _jobContext.HandlerType;
+        if (handlerType != null)
+        {
+            var handlerAttr = AttributeCache.GetOrAdd(handlerType, static t => t.GetCustomAttribute<CircuitBreakerAttribute>());
+            if (handlerAttr != null)
+            {
+                return handlerAttr;
+            }
+        }
+
+        return AttributeCache.GetOrAdd(typeof(TRequest), static t => t.GetCustomAttribute<CircuitBreakerAttribute>());
+    }
+}

--- a/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerServiceConfiguration.cs
+++ b/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerServiceConfiguration.cs
@@ -1,0 +1,33 @@
+using Jobly.Core.Handlers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jobly.Core.CircuitBreaker;
+
+public static class CircuitBreakerServiceConfiguration
+{
+    public static IServiceCollection AddJoblyCircuitBreaker<TContext>(
+        this IServiceCollection services,
+        Action<CircuitBreakerOptions>? configure = null)
+        where TContext : DbContext
+    {
+        if (configure != null)
+        {
+            services.Configure(configure);
+        }
+        else
+        {
+            services.AddOptions<CircuitBreakerOptions>();
+        }
+
+        // Contribute the CircuitBreakerState entity only when the addon is opted in.
+        // JoblyModelCustomizer invokes these during OnModelCreating so the schema is
+        // created exclusively for users of the addon.
+        services.Configure<JoblyConfiguration>(c => c.EntityConfigurators.Add(ServiceConfiguration.AddCircuitBreakerStateEntity));
+
+        services.AddScoped<ICircuitBreakerStore, CircuitBreakerStore<TContext>>();
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(CircuitBreakerPipelineBehavior<,>));
+
+        return services;
+    }
+}

--- a/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerStore.cs
+++ b/src/core/Jobly.Core/CircuitBreaker/CircuitBreakerStore.cs
@@ -1,0 +1,91 @@
+using Jobly.Core.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jobly.Core.CircuitBreaker;
+
+public class CircuitBreakerStore<TContext> : ICircuitBreakerStore
+    where TContext : DbContext
+{
+    private readonly TContext _context;
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public CircuitBreakerStore(TContext context, IServiceScopeFactory scopeFactory)
+    {
+        _context = context;
+        _scopeFactory = scopeFactory;
+    }
+
+    public Task<CircuitBreakerState?> GetAsync(string groupKey, CancellationToken cancellationToken)
+    {
+        return _context.Set<CircuitBreakerState>()
+            .AsNoTracking()
+            .Where(x => x.GroupKey == groupKey)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task ResetAsync(string groupKey, CancellationToken cancellationToken)
+    {
+        await _context.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == groupKey)
+            .Where(x => x.FailureCount > 0)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(x => x.FailureCount, 0)
+                    .SetProperty(x => x.OpenUntil, (DateTime?)null),
+                cancellationToken);
+    }
+
+    public async Task RecordFailureAsync(string groupKey, int threshold, TimeSpan duration, DateTime now, CancellationToken cancellationToken)
+    {
+        var openUntilIfThreshold = now + duration;
+        var affected = await _context.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == groupKey)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(x => x.FailureCount, x => x.FailureCount + 1)
+                    .SetProperty(x => x.LastFailureAt, now)
+                    .SetProperty(x => x.OpenUntil, x => x.FailureCount + 1 >= threshold ? openUntilIfThreshold : x.OpenUntil),
+                cancellationToken);
+
+        if (affected > 0)
+        {
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var insertContext = scope.ServiceProvider.GetRequiredService<TContext>();
+        try
+        {
+            insertContext.Set<CircuitBreakerState>().Add(
+                new CircuitBreakerState
+                {
+                    GroupKey = groupKey,
+                    FailureCount = 1,
+                    LastFailureAt = now,
+                    OpenUntil = threshold <= 1 ? openUntilIfThreshold : null,
+                });
+            await insertContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            var rowExists = await _context.Set<CircuitBreakerState>()
+                .AsNoTracking()
+                .Where(x => x.GroupKey == groupKey)
+                .AnyAsync(cancellationToken);
+            if (!rowExists)
+            {
+                throw;
+            }
+
+            await _context.Set<CircuitBreakerState>()
+                .Where(x => x.GroupKey == groupKey)
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(x => x.FailureCount, x => x.FailureCount + 1)
+                        .SetProperty(x => x.LastFailureAt, now)
+                        .SetProperty(x => x.OpenUntil, x => x.FailureCount + 1 >= threshold ? openUntilIfThreshold : x.OpenUntil),
+                    cancellationToken);
+        }
+    }
+}

--- a/src/core/Jobly.Core/CircuitBreaker/ICircuitBreakerStore.cs
+++ b/src/core/Jobly.Core/CircuitBreaker/ICircuitBreakerStore.cs
@@ -1,0 +1,12 @@
+using Jobly.Core.Data.Entities;
+
+namespace Jobly.Core.CircuitBreaker;
+
+public interface ICircuitBreakerStore
+{
+    Task<CircuitBreakerState?> GetAsync(string groupKey, CancellationToken cancellationToken);
+
+    Task ResetAsync(string groupKey, CancellationToken cancellationToken);
+
+    Task RecordFailureAsync(string groupKey, int threshold, TimeSpan duration, DateTime now, CancellationToken cancellationToken);
+}

--- a/src/core/Jobly.Core/Configuration.cs
+++ b/src/core/Jobly.Core/Configuration.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+
 namespace Jobly.Core;
 
 public class JoblyConfiguration
@@ -11,4 +13,11 @@ public class JoblyConfiguration
     /// Failed jobs are never auto-expired.
     /// </summary>
     public TimeSpan JobExpirationTimeout { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Model builder callbacks contributed by opt-in addons (e.g. CircuitBreaker).
+    /// Invoked by JoblyModelCustomizer after the core entities are registered.
+    /// Addons append via services.Configure&lt;JoblyConfiguration&gt;.
+    /// </summary>
+    internal List<Action<ModelBuilder, string?>> EntityConfigurators { get; } = [];
 }

--- a/src/core/Jobly.Core/Data/Entities/CircuitBreakerState.cs
+++ b/src/core/Jobly.Core/Data/Entities/CircuitBreakerState.cs
@@ -1,0 +1,12 @@
+namespace Jobly.Core.Data.Entities;
+
+public class CircuitBreakerState
+{
+    public string GroupKey { get; set; } = string.Empty;
+
+    public int FailureCount { get; set; }
+
+    public DateTime? OpenUntil { get; set; }
+
+    public DateTime LastFailureAt { get; set; }
+}

--- a/src/core/Jobly.Core/JoblyModelCustomizer.cs
+++ b/src/core/Jobly.Core/JoblyModelCustomizer.cs
@@ -19,5 +19,13 @@ internal sealed class JoblyModelCustomizer : RelationalModelCustomizer
         var config = context.GetService<IOptions<JoblyConfiguration>>()?.Value;
         var schema = config != null ? config.Schema : "jobly";
         modelBuilder.AddOutboxStateEntity(schema);
+
+        if (config != null)
+        {
+            foreach (var configurator in config.EntityConfigurators)
+            {
+                configurator(modelBuilder, schema);
+            }
+        }
     }
 }

--- a/src/core/Jobly.Core/Retry/RetryPipelineBehavior.cs
+++ b/src/core/Jobly.Core/Retry/RetryPipelineBehavior.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 namespace Jobly.Core.Retry;
 
 public class RetryPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-    where TRequest : IRequest<TResponse>
+    where TRequest : IRequest<TResponse>, IJob
 {
     private static readonly ConcurrentDictionary<Type, RetryAttribute?> AttributeCache = new();
 
@@ -28,7 +28,7 @@ public class RetryPipelineBehavior<TRequest, TResponse> : IPipelineBehavior<TReq
         {
             return await next(request, cancellationToken);
         }
-        catch (Exception) when (request is IJob)
+        catch (Exception)
         {
             var meta = _jobContext.GetMetadata<IRetryMetadata>();
             var attr = GetRetryAttribute();

--- a/src/core/Jobly.Core/ServiceConfiguration.cs
+++ b/src/core/Jobly.Core/ServiceConfiguration.cs
@@ -403,4 +403,20 @@ public static class ServiceConfiguration
 
         serverLog.Metadata.SetSchema(schema);
     }
+
+    public static void AddCircuitBreakerStateEntity(ModelBuilder modelBuilder, string? schema)
+    {
+        var state = modelBuilder.Entity<CircuitBreakerState>();
+
+        state.Property(p => p.GroupKey).HasMaxLength(200).IsRequired();
+        state.HasKey(p => p.GroupKey);
+
+        state.Property(p => p.FailureCount);
+        state.Property(p => p.OpenUntil);
+        state.Property(p => p.LastFailureAt);
+
+        state.HasIndex(p => p.OpenUntil);
+
+        state.Metadata.SetSchema(schema);
+    }
 }

--- a/src/core/Jobly.Tests/Integration/CircuitBreakerIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/CircuitBreakerIntegrationTests.cs
@@ -1,0 +1,128 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.Helper;
+using Jobly.Core.Retry;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace Jobly.Tests.Integration;
+
+public abstract class CircuitBreakerIntegrationTestsBase : IntegrationTestBase
+{
+    protected CircuitBreakerIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [TimedFact]
+    public async Task GivenFailingHandler_WhenThresholdHit_ThenCircuitOpensAndSubsequentJobsRescheduled()
+    {
+        var groupKey = nameof(ThrowExceptionRequest);
+
+        // Seed the state to threshold - 1, then drive one more failure to open the circuit.
+        // This avoids waiting through the global Retry (MaxRetries=3) on every failure.
+        var seedCtx = Server.CreateContext();
+        seedCtx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = groupKey,
+            FailureCount = 999,
+            LastFailureAt = DateTime.UtcNow,
+        });
+        await seedCtx.SaveChangesAsync();
+
+        var failingPublisher = Server.CreatePublisher();
+        var failingJobId = await failingPublisher.Enqueue(
+            new ThrowExceptionRequest(),
+            new JobParameters().Configure<IRetryMetadata>(m => m.MaxRetries = 0));
+        await failingPublisher.SaveChangesAsync();
+
+        await Server.WaitForJobState(failingJobId, State.Failed, timeout: TimeSpan.FromSeconds(30));
+
+        // Verify circuit is open
+        var stateCtx = Server.CreateContext();
+        var state = await stateCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == groupKey)
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBeGreaterThanOrEqualTo(1000);
+        state.OpenUntil.ShouldNotBeNull();
+
+        // Publish a subsequent job — circuit is open so it should be rescheduled
+        var nextPublisher = Server.CreatePublisher();
+        var nextJobId = await nextPublisher.Enqueue(new ThrowExceptionRequest());
+        await nextPublisher.SaveChangesAsync();
+
+        await Server.WaitForJobLog(nextJobId, "Requeued", timeout: TimeSpan.FromSeconds(15));
+
+        var readCtx = Server.CreateContext();
+        var nextJob = await readCtx.Set<Job>()
+            .Where(x => x.Id == nextJobId)
+            .FirstOrDefaultAsync(CancellationToken.None);
+        nextJob.ShouldNotBeNull();
+        nextJob.CurrentState.ShouldBe(State.Enqueued);
+        nextJob.ScheduleTime.ShouldBeGreaterThanOrEqualTo(state.OpenUntil!.Value);
+
+        var log = await readCtx.Set<JobLog>()
+            .Where(x => x.JobId == nextJobId)
+            .Where(x => x.Message.Contains("circuit breaker"))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        log.ShouldNotBeNull();
+        log.Message.ShouldContain(groupKey);
+
+        // Cancel rescheduled job so it doesn't linger
+        var cmd = Server.CreateCommandService();
+        await cmd.DeleteJob(nextJobId);
+    }
+
+    [TimedFact]
+    public async Task GivenSuccessAfterFailures_WhenJobSucceeds_ThenCounterResets()
+    {
+        var groupKey = nameof(UnitRequest);
+
+        var seedCtx = Server.CreateContext();
+        seedCtx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = groupKey,
+            FailureCount = 2,
+            LastFailureAt = DateTime.UtcNow,
+        });
+        await seedCtx.SaveChangesAsync();
+
+        var publisher = Server.CreatePublisher();
+        var jobId = await publisher.Enqueue(new UnitRequest());
+        await publisher.SaveChangesAsync();
+
+        await Server.WaitForJobState(jobId, State.Completed, timeout: TimeSpan.FromSeconds(30));
+
+        var readCtx = Server.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == groupKey)
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(0);
+        state.OpenUntil.ShouldBeNull();
+    }
+}
+
+[Collection<PostgreSqlIntegrationCollection>]
+public class CircuitBreakerIntegrationTests_PostgreSql : CircuitBreakerIntegrationTestsBase
+{
+    public CircuitBreakerIntegrationTests_PostgreSql(PostgreSqlIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerIntegrationCollection>]
+[Trait("Category", "SqlServer")]
+public class CircuitBreakerIntegrationTests_SqlServer : CircuitBreakerIntegrationTestsBase
+{
+    public CircuitBreakerIntegrationTests_SqlServer(SqlServerIntegrationFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
+++ b/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
@@ -1,13 +1,14 @@
 using Jobly.Core;
+using Jobly.Core.CircuitBreaker;
 using Jobly.Core.Data.Entities;
 using Jobly.Core.Entities;
 using Jobly.Core.Enums;
 using Jobly.Core.Handlers;
+using Jobly.Core.Mutex;
+using Jobly.Core.Retry;
 using Jobly.Core.Services;
 using Jobly.Tests.Fixtures;
 using Jobly.Worker;
-using Jobly.Core.Mutex;
-using Jobly.Core.Retry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -140,6 +141,12 @@ public class JoblyTestServer : IAsyncDisposable
                     o.Delays = [1];
                 });
                 services.AddJoblyMutex();
+                services.AddJoblyCircuitBreaker<TestContext>(o =>
+                {
+                    o.Threshold = 1000;
+                    o.Duration = TimeSpan.FromHours(1);
+                    o.ResetJitter = TimeSpan.FromSeconds(1);
+                });
             })
             .Build();
 

--- a/src/core/Jobly.Tests/TestData/Data/TestContext.cs
+++ b/src/core/Jobly.Tests/TestData/Data/TestContext.cs
@@ -20,5 +20,11 @@ public class TestContext : DbContext
         base.OnModelCreating(modelBuilder);
 
         modelBuilder.AddOutboxStateEntity(_schema);
+
+        // Tests use the CircuitBreaker addon, which contributes its own entity via
+        // JoblyConfiguration.EntityConfigurators when AddJoblyCircuitBreaker is called.
+        // TestContext is constructed directly by fixtures without going through DI,
+        // so we must explicitly include the addon entity here.
+        ServiceConfiguration.AddCircuitBreakerStateEntity(modelBuilder, _schema);
     }
 }

--- a/src/core/Jobly.Tests/TestData/Handlers/CircuitBreakerGroupCommand.cs
+++ b/src/core/Jobly.Tests/TestData/Handlers/CircuitBreakerGroupCommand.cs
@@ -1,0 +1,15 @@
+using Jobly.Core.CircuitBreaker;
+using Jobly.Core.Handlers;
+
+namespace Jobly.Tests.TestData.Handlers;
+
+public class CircuitBreakerGroupCommand : IJobHandler<CircuitBreakerGroupRequest>
+{
+    public Task HandleAsync(CircuitBreakerGroupRequest message, CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Always fails");
+    }
+}
+
+[CircuitBreaker(Group = "email-service")]
+public class CircuitBreakerGroupRequest : IJob;

--- a/src/core/Jobly.Tests/Unit/CircuitBreakerTests.cs
+++ b/src/core/Jobly.Tests/Unit/CircuitBreakerTests.cs
@@ -1,0 +1,524 @@
+using System.Text.Json;
+using Jobly.Core;
+using Jobly.Core.CircuitBreaker;
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Core.Handlers;
+using Jobly.Core.Mutex;
+using Jobly.Core.Retry;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Jobly.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Shouldly;
+
+namespace Jobly.Tests.Unit;
+
+public abstract class CircuitBreakerTestsBase : IAsyncLifetime
+{
+    private static readonly Guid WorkerId = Guid.NewGuid();
+    private static readonly Guid ServerId = Guid.NewGuid();
+    private static readonly string[] DefaultQueues = ["default"];
+
+    private readonly IDatabaseFixture _fixture;
+
+    protected CircuitBreakerTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [TimedFact]
+    public async Task GroupBelowThreshold_Increments()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(ThrowExceptionRequest),
+            FailureCount = 1,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker();
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(ThrowExceptionRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(2);
+        state.OpenUntil.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task FailureHitsThreshold_OpensCircuit()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(ThrowExceptionRequest),
+            FailureCount = 2,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var duration = TimeSpan.FromMinutes(1);
+        var worker = CreateWorker(duration: duration);
+
+        var before = DateTime.UtcNow;
+        await worker.GetAndProcessJob(CancellationToken.None);
+        var after = DateTime.UtcNow;
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(ThrowExceptionRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(3);
+        state.OpenUntil.ShouldNotBeNull();
+        state.OpenUntil!.Value.ShouldBeGreaterThanOrEqualTo(before + duration - TimeSpan.FromSeconds(5));
+        state.OpenUntil.Value.ShouldBeLessThanOrEqualTo(after + duration + TimeSpan.FromSeconds(5));
+    }
+
+    [TimedFact]
+    public async Task OpenCircuit_ReschedulesJob()
+    {
+        var now = DateTime.UtcNow;
+        var openUntil = now.AddMinutes(5);
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(UnitRequest),
+            FailureCount = 3,
+            OpenUntil = openUntil,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var jitter = TimeSpan.FromSeconds(10);
+        var worker = CreateWorker(resetJitter: jitter);
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FindAsync(jobId);
+        job.ShouldNotBeNull();
+        job.CurrentState.ShouldBe(State.Enqueued);
+        job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(openUntil);
+        job.ScheduleTime.ShouldBeLessThanOrEqualTo(openUntil + jitter);
+
+        var log = await readCtx.Set<JobLog>()
+            .Where(x => x.JobId == jobId)
+            .Where(x => x.Message.Contains("circuit breaker"))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        log.ShouldNotBeNull();
+        log.Message.ShouldContain(nameof(UnitRequest));
+    }
+
+    [TimedFact]
+    public async Task Success_ResetsCounter()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(UnitRequest),
+            FailureCount = 2,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(UnitRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker();
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(UnitRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(0);
+        state.OpenUntil.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task OutcomeAlreadyEnqueued_SkipsCount()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(ThrowExceptionRequest),
+            FailureCount = 1,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(retryMaxRetries: 5);
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(ThrowExceptionRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(1);
+    }
+
+    [TimedFact]
+    public async Task AttributeGroupOverride_UsesCustomKey()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(CircuitBreakerGroupRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker();
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == "email-service")
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(1);
+
+        var byTypeName = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(CircuitBreakerGroupRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        byTypeName.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task FirstFailure_CreatesRowLazily()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(ThrowExceptionRequest).AssemblyQualifiedName,
+            Message = "{}",
+        });
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker();
+        await worker.GetAndProcessJob(CancellationToken.None);
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(ThrowExceptionRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(1);
+        state.OpenUntil.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task RescheduleTime_WithinJitterWindow()
+    {
+        var now = DateTime.UtcNow;
+        var openUntil = now.AddMinutes(5);
+        var jitter = TimeSpan.FromSeconds(1);
+
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(UnitRequest),
+            FailureCount = 3,
+            OpenUntil = openUntil,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+
+        var jobIds = new List<Guid>();
+        for (var i = 0; i < 20; i++)
+        {
+            var jobId = Guid.NewGuid();
+            jobIds.Add(jobId);
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = jobId,
+                Kind = JobKind.Job,
+                CurrentState = State.Enqueued,
+                CreateTime = now,
+                ScheduleTime = now.AddMinutes(-1),
+                Queue = "default",
+                Type = typeof(UnitRequest).AssemblyQualifiedName,
+                Message = "{}",
+            });
+        }
+
+        await ctx.SaveChangesAsync();
+
+        var worker = CreateWorker(resetJitter: jitter);
+        for (var i = 0; i < 20; i++)
+        {
+            await worker.GetAndProcessJob(CancellationToken.None);
+        }
+
+        var readCtx = _fixture.CreateContext();
+        var jobs = await readCtx.Set<Job>()
+            .Where(x => jobIds.Contains(x.Id))
+            .ToListAsync(CancellationToken.None);
+        jobs.Count.ShouldBe(20);
+        foreach (var job in jobs)
+        {
+            job.CurrentState.ShouldBe(State.Enqueued);
+            job.ScheduleTime.ShouldBeGreaterThanOrEqualTo(openUntil);
+            job.ScheduleTime.ShouldBeLessThanOrEqualTo(openUntil + jitter);
+        }
+    }
+
+    [TimedFact]
+    public async Task MutexDeletedOutcome_SkipsCountAndReset()
+    {
+        var now = DateTime.UtcNow;
+        var ctx = _fixture.CreateContext();
+        ctx.Set<CircuitBreakerState>().Add(new CircuitBreakerState
+        {
+            GroupKey = nameof(MutexAttributeRequest),
+            FailureCount = 2,
+            LastFailureAt = now.AddSeconds(-30),
+        });
+        var jobId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = jobId,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = now,
+            ScheduleTime = now.AddMinutes(-1),
+            Queue = "default",
+            Type = typeof(MutexAttributeRequest).AssemblyQualifiedName,
+            Message = "{}",
+            Metadata = JsonSerializer.Serialize(new Dictionary<string, object> { ["ConcurrencyKey"] = "static-key" }),
+        });
+        await ctx.SaveChangesAsync();
+
+        var lockProvider = new FakeLockProvider();
+        var heldHandle = lockProvider.HoldLock("jobly:mutex:static-key");
+
+        var worker = CreateWorker(lockProvider: lockProvider);
+        await worker.GetAndProcessJob(CancellationToken.None);
+        await heldHandle.DisposeAsync();
+
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FindAsync(jobId);
+        job.ShouldNotBeNull();
+        job.CurrentState.ShouldBe(State.Deleted);
+
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == nameof(MutexAttributeRequest))
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(2);
+        state.OpenUntil.ShouldBeNull();
+    }
+
+    // Probabilistic: this test exercises the DbUpdateException fallback path by firing 10
+    // concurrent RecordFailureAsync calls with no pre-existing row. At least one task is
+    // overwhelmingly likely to hit the PK-collision branch, but this can't be enforced
+    // deterministically without test-only hooks inside the store. The final-count invariant
+    // (== 10) holds regardless of whether the race fired or calls fully serialized — so the
+    // fallback branch's correctness is validated in practice, not strictly guaranteed by
+    // assertion. If this becomes flaky under heavy parallelism, move to a hook-based test.
+    [TimedFact]
+    public async Task RecordFailure_ConcurrentFirstFailures_AllCounted()
+    {
+        var key = "race-" + Guid.NewGuid().ToString("N");
+        var scopeFactory = CreateStoreScopeFactory();
+        var now = DateTime.UtcNow;
+
+        var tasks = Enumerable.Range(0, 10).Select(_ =>
+        {
+            var store = new CircuitBreakerStore<TestContext>(_fixture.CreateContext(), scopeFactory);
+
+            return store.RecordFailureAsync(key, threshold: 100, duration: TimeSpan.FromMinutes(1), now, CancellationToken.None);
+        }).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        var readCtx = _fixture.CreateContext();
+        var state = await readCtx.Set<CircuitBreakerState>()
+            .Where(x => x.GroupKey == key)
+            .FirstOrDefaultAsync(CancellationToken.None);
+        state.ShouldNotBeNull();
+        state.FailureCount.ShouldBe(10);
+        state.OpenUntil.ShouldBeNull();
+    }
+
+    private IServiceScopeFactory CreateStoreScopeFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<TestContext>(_ => _fixture.CreateContext());
+
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private JoblyWorkerService<TestContext> CreateWorker(
+        TimeSpan? duration = null,
+        TimeSpan? resetJitter = null,
+        int? retryMaxRetries = null,
+        FakeLockProvider? lockProvider = null)
+    {
+        var services = new ServiceCollection();
+        services.AddHandlers(typeof(CircuitBreakerTestsBase).Assembly);
+        services.AddLogging();
+        services.AddScoped<TestContext>(_ => _fixture.CreateContext());
+        services.AddScoped<JobContext>();
+        services.AddScoped<IJobContext>(x => x.GetRequiredService<JobContext>());
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddJoblyCircuitBreaker<TestContext>(o =>
+        {
+            if (duration != null)
+            {
+                o.Duration = duration.Value;
+            }
+
+            if (resetJitter != null)
+            {
+                o.ResetJitter = resetJitter.Value;
+            }
+        });
+
+        if (retryMaxRetries != null)
+        {
+            services.AddJoblyRetry(o => o.MaxRetries = retryMaxRetries.Value);
+        }
+
+        if (lockProvider != null)
+        {
+            services.AddSingleton<IJoblyLockProvider>(lockProvider);
+            services.AddJoblyMutex();
+        }
+
+        var workerConfig = new OptionsWrapper<JoblyWorkerConfiguration>(new JoblyWorkerConfiguration
+        {
+            WorkerCount = 1,
+            ServerId = ServerId,
+            Queues = DefaultQueues,
+        });
+        services.AddSingleton<IOptions<JoblyWorkerConfiguration>>(workerConfig);
+        services.AddSingleton<IOptions<JoblyConfiguration>>(workerConfig);
+
+        var provider = services.BuildServiceProvider();
+        var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        var groupConfig = new WorkerGroupConfiguration
+        {
+            WorkerCount = 1,
+            Queues = DefaultQueues,
+        };
+
+        return new JoblyWorkerService<TestContext>(
+            WorkerId,
+            scopeFactory,
+            new NullLogger<JoblyWorkerService<TestContext>>(),
+            workerConfig,
+            groupConfig,
+            TimeProvider.System);
+    }
+}
+
+[Collection<PostgreSqlCollection>]
+public class CircuitBreakerTests_PostgreSql : CircuitBreakerTestsBase
+{
+    public CircuitBreakerTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerCollection>]
+[Trait("Category", "SqlServer")]
+public class CircuitBreakerTests_SqlServer : CircuitBreakerTestsBase
+{
+    public CircuitBreakerTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
+++ b/src/core/Jobly.Tests/Unit/CrashRecoveryTests.cs
@@ -319,10 +319,15 @@ public abstract class CrashRecoveryTestsBase : IAsyncLifetime
     [TimedFact]
     public async Task CleanUpServers_HeartbeatAtExactTimeout_NotCleaned()
     {
-        // Arrange — server with heartbeat exactly at timeout boundary should NOT be cleaned
+        // Arrange — server with heartbeat exactly at timeout boundary should NOT be cleaned.
+        // Round `now` to microsecond precision so LastHeartbeatTime survives PostgreSQL round-trip
+        // (timestamp has 6-digit precision; raw .NET ticks have 7 digits). Without this, the saved
+        // value would be truncated and `now - savedHeartbeat` would exceed timeout by sub-microsecond
+        // ticks, falsely tripping the `>` boundary check.
         var ctx = _fixture.CreateContext();
         var timeout = TimeSpan.FromMinutes(5);
-        var now = DateTime.UtcNow.AddMinutes(10);
+        var rawNow = DateTime.UtcNow.AddMinutes(10);
+        var now = new DateTime(rawNow.Ticks - (rawNow.Ticks % 10), DateTimeKind.Utc);
 
         var serverId = Guid.NewGuid();
         ctx.Set<Server>().Add(new Server


### PR DESCRIPTION
## Summary

- Adds opt-in circuit-breaker addon (`AddJoblyCircuitBreaker<TContext>()`) that suspends execution of a job group once failures exceed a threshold, rescheduling subsequent jobs past an `OpenUntil + jitter` window rather than piling retries on a known-broken resource.
- Introduces `JoblyConfiguration.EntityConfigurators` as an extension point so addons can contribute EF Core entities only when opted in — the new `CircuitBreakerState` table is not created for users who don't register the addon.
- Constrains `RetryPipelineBehavior` and `CircuitBreakerPipelineBehavior` to `IJob` so DI skips constructing them for non-IJob pipelines.
- Fixes an unrelated pre-existing flake in `CleanUpServers_HeartbeatAtExactTimeout_NotCleaned` caused by PostgreSQL microsecond timestamp precision.

## Design notes

- **Group identity**: defaults to the job's type name. Override with `[CircuitBreaker(Group = "email-service")]` to share one group across multiple types.
- **Per-attribute overrides**: `Threshold`, `DurationSeconds`, `ResetJitterSeconds` — zero means "use global".
- **Cooperates with Retry**: skips the counter increment when any prior behavior set `IJobContext.Outcome` (covers both Retry-retrying and Mutex-deleted cases). On success, also skips resetting the counter when an Outcome was set so mutex-skipped jobs don't wipe CB state.
- **Storage**: `ExecuteUpdateAsync` for both the reset and the increment (no `SaveChanges` on the hot path, bypasses change tracker). Lazy insert on first failure runs in an isolated `IServiceScopeFactory` scope so handler-tracked changes don't leak. PK-collision races fall through to a re-query + UPDATE path that's provider-agnostic (no reflection, no Npgsql/SqlClient dependency in Core).
- **Hot-path cost**: one `SELECT` on entry and one `UPDATE` on reset only when `state.FailureCount > 0` — clean successful jobs pay a single round-trip.

## Test plan

- [x] `dotnet test` — 841/841 pass across PostgreSQL + SQL Server
- [x] 10 new unit tests covering: threshold increment, threshold-hit opens circuit, open circuit reschedules, success resets, cooperation with Retry, attribute group override, lazy row creation, jitter distribution, mutex-deleted outcome skip, concurrent first-failure race
- [x] 2 new integration tests covering circuit open → reschedule and success → reset via the full worker stack
- [x] Retry tests still pass after `IJob` constraint change (15 unit + 3 integration)
- [x] Zero new build warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)