### PR TITLE
Add batched completions for dispatcher-mode workers

### DIFF
--- a/src/benchmarks/Jobly.ServerBenchmarks/Benchmarks/CompletionBatchBenchmark.cs
+++ b/src/benchmarks/Jobly.ServerBenchmarks/Benchmarks/CompletionBatchBenchmark.cs
@@ -1,0 +1,89 @@
+using BenchmarkDotNet.Attributes;
+using Jobly.Core;
+using Jobly.Core.Handlers;
+using Jobly.ServerBenchmarks.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jobly.ServerBenchmarks.Benchmarks;
+
+/// <summary>
+/// Measures the impact of per-worker completion batching in dispatcher mode.
+/// <para>
+/// Baseline (<c>CompletionBatchSize = 1</c>): every job completion opens its own
+/// transaction and commits immediately — same behaviour as before the feature.
+/// </para>
+/// <para>
+/// Batched (<c>CompletionBatchSize = 50</c>): completions are buffered per worker
+/// and flushed as a single multi-row transaction on size / time / idle / shutdown.
+/// </para>
+/// <para>
+/// Both variants run with <c>UseDispatcher = true</c> (the batching is dispatcher-only).
+/// Workload: <see cref="JobCount"/> empty-handler jobs, 10 workers, handler logging off.
+/// </para>
+/// </summary>
+[Config(typeof(ServerBenchmarkConfig))]
+public class CompletionBatchBenchmark
+{
+    private PostgresServerFixture _fixture = null!;
+
+    [Params(10_000)]
+    public int JobCount { get; set; }
+
+    [Params(1, 50)]
+    public int CompletionBatchSize { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _fixture = new PostgresServerFixture();
+        await _fixture.InitializeAsync(workerCount: 10, useDispatcher: true, completionBatchSize: CompletionBatchSize);
+
+        // Warmup: prime JIT, type caches, connection pool, dispatcher channel.
+        var publisher = _fixture.CreatePublisher();
+        for (var i = 0; i < 100; i++)
+        {
+            await publisher.Enqueue(new EmptyRequest());
+        }
+
+        await publisher.SaveChangesAsync();
+        await _fixture.WaitForCompletion();
+        await _fixture.CleanJobTables();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IterationCleanup]
+    public void AfterIteration()
+    {
+        _fixture.CleanJobTables().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Publishes <see cref="JobCount"/> no-op jobs and waits for every one to reach Completed.
+    /// Wall-clock captures end-to-end throughput across workers + background tasks.
+    /// </summary>
+    [Benchmark]
+    public async Task ProcessJobs()
+    {
+        const int batchSize = 1000;
+        var remaining = JobCount;
+        while (remaining > 0)
+        {
+            var publisher = _fixture.CreatePublisher();
+            var count = Math.Min(batchSize, remaining);
+            for (var i = 0; i < count; i++)
+            {
+                await publisher.Enqueue(new EmptyRequest());
+            }
+
+            await publisher.SaveChangesAsync();
+            remaining -= count;
+        }
+
+        await _fixture.WaitForCompletion();
+    }
+}

--- a/src/benchmarks/Jobly.ServerBenchmarks/Benchmarks/DispatcherModeBenchmark.cs
+++ b/src/benchmarks/Jobly.ServerBenchmarks/Benchmarks/DispatcherModeBenchmark.cs
@@ -1,0 +1,77 @@
+using BenchmarkDotNet.Attributes;
+using Jobly.Core;
+using Jobly.Core.Handlers;
+using Jobly.ServerBenchmarks.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jobly.ServerBenchmarks.Benchmarks;
+
+/// <summary>
+/// Head-to-head between the two worker modes end-to-end:
+/// <list type="bullet">
+///   <item><description><c>UseDispatcher = false</c> — each <c>JoblyWorkerService</c> independently fetches + processes + commits per job (pre-dispatcher behaviour).</description></item>
+///   <item><description><c>UseDispatcher = true</c> — single <c>JoblyDispatcher</c> batch-fetches jobs and hands them to <c>JoblyDispatcherWorker</c> instances that buffer completions (<c>CompletionBatchSize = 50</c>, default).</description></item>
+/// </list>
+/// Same workload, same worker count, same handler.
+/// </summary>
+[Config(typeof(ServerBenchmarkConfig))]
+public class DispatcherModeBenchmark
+{
+    private PostgresServerFixture _fixture = null!;
+
+    [Params(10_000)]
+    public int JobCount { get; set; }
+
+    [Params(false, true)]
+    public bool UseDispatcher { get; set; }
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        _fixture = new PostgresServerFixture();
+        await _fixture.InitializeAsync(workerCount: 10, useDispatcher: UseDispatcher);
+
+        var publisher = _fixture.CreatePublisher();
+        for (var i = 0; i < 100; i++)
+        {
+            await publisher.Enqueue(new EmptyRequest());
+        }
+
+        await publisher.SaveChangesAsync();
+        await _fixture.WaitForCompletion();
+        await _fixture.CleanJobTables();
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await _fixture.DisposeAsync();
+    }
+
+    [IterationCleanup]
+    public void AfterIteration()
+    {
+        _fixture.CleanJobTables().GetAwaiter().GetResult();
+    }
+
+    [Benchmark]
+    public async Task ProcessJobs()
+    {
+        const int batchSize = 1000;
+        var remaining = JobCount;
+        while (remaining > 0)
+        {
+            var publisher = _fixture.CreatePublisher();
+            var count = Math.Min(batchSize, remaining);
+            for (var i = 0; i < count; i++)
+            {
+                await publisher.Enqueue(new EmptyRequest());
+            }
+
+            await publisher.SaveChangesAsync();
+            remaining -= count;
+        }
+
+        await _fixture.WaitForCompletion();
+    }
+}

--- a/src/benchmarks/Jobly.ServerBenchmarks/Infrastructure/PostgresServerFixture.cs
+++ b/src/benchmarks/Jobly.ServerBenchmarks/Infrastructure/PostgresServerFixture.cs
@@ -32,7 +32,7 @@ public class PostgresServerFixture : IAsyncDisposable
     /// <summary>
     /// Boots the full server: container, schema, host with workers + background tasks.
     /// </summary>
-    public async Task InitializeAsync(int workerCount = 5)
+    public async Task InitializeAsync(int workerCount = 5, bool useDispatcher = false, int completionBatchSize = 50, TimeSpan? completionFlushInterval = null)
     {
         await _container.StartAsync();
         _connectionString = _container.GetConnectionString();
@@ -58,7 +58,9 @@ public class PostgresServerFixture : IAsyncDisposable
                     config.OrchestrationInterval = TimeSpan.FromMilliseconds(100);
                     config.MessageRoutingInterval = TimeSpan.FromMilliseconds(500);
                     config.HealthCheckInterval = TimeSpan.FromMilliseconds(200);
-                    config.UseDispatcher = false;
+                    config.UseDispatcher = useDispatcher;
+                    config.CompletionBatchSize = completionBatchSize;
+                    config.CompletionFlushInterval = completionFlushInterval ?? TimeSpan.FromMilliseconds(100);
                 });
             })
             .Build();

--- a/src/core/Jobly.Tests/Fixtures/PostgreSqlBatchedCompletionFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/PostgreSqlBatchedCompletionFixture.cs
@@ -1,0 +1,70 @@
+using Jobly.Core.Interceptors;
+using Jobly.Tests.Integration;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Respawn;
+using Testcontainers.PostgreSql;
+
+namespace Jobly.Tests.Fixtures;
+
+public class PostgreSqlBatchedCompletionFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:latest")
+        .Build();
+
+    private Respawner _respawner = null!;
+    private string _connectionString = null!;
+
+    public JoblyTestServer TestServer { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+        _connectionString = _container.GetConnectionString();
+
+        await using var context = CreateContext();
+        await context.Database.EnsureCreatedAsync();
+
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.Postgres,
+            TablesToIgnore = FixtureHelper.GetServerTablesToIgnore(context),
+        });
+
+        TestServer = await JoblyTestServer.StartAsync(this, config =>
+        {
+            config.UseDispatcher = true;
+            config.WorkerCount = 5;
+            config.CompletionBatchSize = 10;
+            config.CompletionFlushInterval = TimeSpan.FromMilliseconds(50);
+        });
+    }
+
+    public async Task ResetAsync()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await _respawner.ResetAsync(conn);
+    }
+
+    public TestContext CreateContext()
+    {
+        return new TestContext(new DbContextOptionsBuilder<TestContext>()
+            .UseNpgsql(_connectionString)
+            .UseSnakeCaseNamingConvention()
+            .AddInterceptors(new PostgresRowLockInterceptor(), new SaveChangesConcurrencyTokenInterceptor())
+            .Options);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await TestServer.DisposeAsync();
+        await _container.DisposeAsync();
+    }
+}
+
+[CollectionDefinition]
+public class PostgreSqlBatchedCompletionCollection : ICollectionFixture<PostgreSqlBatchedCompletionFixture>;

--- a/src/core/Jobly.Tests/Fixtures/SqlServerBatchedCompletionFixture.cs
+++ b/src/core/Jobly.Tests/Fixtures/SqlServerBatchedCompletionFixture.cs
@@ -1,0 +1,69 @@
+using Jobly.Core.Interceptors;
+using Jobly.Tests.Integration;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Respawn;
+using Testcontainers.MsSql;
+
+namespace Jobly.Tests.Fixtures;
+
+public class SqlServerBatchedCompletionFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder()
+        .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        .Build();
+
+    private Respawner _respawner = null!;
+    private string _connectionString = null!;
+
+    public JoblyTestServer TestServer { get; private set; } = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+        _connectionString = _container.GetConnectionString() + ";Encrypt=False;";
+
+        await using var context = CreateContext();
+        await context.Database.EnsureCreatedAsync();
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.SqlServer,
+            TablesToIgnore = FixtureHelper.GetServerTablesToIgnore(context),
+        });
+
+        TestServer = await JoblyTestServer.StartAsync(this, config =>
+        {
+            config.UseDispatcher = true;
+            config.WorkerCount = 5;
+            config.CompletionBatchSize = 10;
+            config.CompletionFlushInterval = TimeSpan.FromMilliseconds(50);
+        });
+    }
+
+    public async Task ResetAsync()
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await _respawner.ResetAsync(conn);
+    }
+
+    public TestContext CreateContext()
+    {
+        return new TestContext(new DbContextOptionsBuilder<TestContext>()
+            .UseSqlServer(_connectionString)
+            .AddInterceptors(new SqlServerRowLockInterceptor(), new SaveChangesConcurrencyTokenInterceptor())
+            .Options);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await TestServer.DisposeAsync();
+        await _container.DisposeAsync();
+    }
+}
+
+[CollectionDefinition]
+public class SqlServerBatchedCompletionCollection : ICollectionFixture<SqlServerBatchedCompletionFixture>;

--- a/src/core/Jobly.Tests/Integration/BatchedCompletionIntegrationTests.cs
+++ b/src/core/Jobly.Tests/Integration/BatchedCompletionIntegrationTests.cs
@@ -1,0 +1,263 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Tests.Fixtures;
+using Jobly.Tests.TestData.Handlers;
+using Jobly.Worker;
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+
+namespace Jobly.Tests.Integration;
+
+public abstract class BatchedCompletionIntegrationTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+
+    protected BatchedCompletionIntegrationTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    protected JoblyTestServer Server => _fixture.TestServer!;
+
+    public async ValueTask InitializeAsync()
+    {
+        try
+        {
+            await _fixture.ResetAsync();
+        }
+        catch
+        {
+            await Task.Delay(100);
+            await _fixture.ResetAsync();
+        }
+
+        await Server.ReRegisterServer();
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [TimedFact(timeout: 60_000)]
+    public async Task GivenManyShortJobs_WhenProcessed_ThenAllReachCompletedState()
+    {
+        // Arrange
+        var publisher = Server.CreatePublisher();
+        const int jobCount = 200;
+        for (var i = 0; i < jobCount; i++)
+        {
+            await publisher.Enqueue(new UnitRequest());
+        }
+
+        await publisher.SaveChangesAsync();
+
+        // Act
+        await Server.WaitForCompletion(TimeSpan.FromSeconds(45));
+
+        // Assert — all jobs reach Completed, and one Completed JobLog exists per job
+        var ctx = Server.CreateContext();
+        var completedCount = await ctx.Set<Job>()
+            .Where(j => j.Kind == JobKind.Job && j.CurrentState == State.Completed)
+            .CountAsync();
+        completedCount.ShouldBe(jobCount);
+
+        var completedLogs = await ctx.Set<JobLog>()
+            .Where(l => l.EventType == "Completed")
+            .CountAsync();
+        completedLogs.ShouldBe(jobCount);
+    }
+
+    [TimedFact(timeout: 60_000)]
+    public async Task GivenMixedOutcomes_WhenProcessed_ThenStatesMatch()
+    {
+        // Arrange
+        var publisher = Server.CreatePublisher();
+        var successType = typeof(UnitRequest).AssemblyQualifiedName;
+        var failType = typeof(ThrowExceptionRequest).AssemblyQualifiedName;
+
+        const int successCount = 25;
+        const int failCount = 15;
+        for (var i = 0; i < successCount; i++)
+        {
+            await publisher.Enqueue(new UnitRequest());
+        }
+
+        for (var i = 0; i < failCount; i++)
+        {
+            await publisher.Enqueue(new ThrowExceptionRequest());
+        }
+
+        await publisher.SaveChangesAsync();
+
+        // Act
+        await Server.WaitForCompletion(TimeSpan.FromSeconds(45));
+
+        // Assert
+        var ctx = Server.CreateContext();
+        var completed = await ctx.Set<Job>()
+            .CountAsync(j => j.Type == successType && j.CurrentState == State.Completed);
+        completed.ShouldBe(successCount);
+
+        var failed = await ctx.Set<Job>()
+            .CountAsync(j => j.Type == failType && j.CurrentState == State.Failed);
+        failed.ShouldBe(failCount);
+    }
+
+    [TimedFact(timeout: 60_000)]
+    public async Task GivenIdleWorker_WhenFewJobsBelowBatchSize_ThenBufferIsDrainedByIdleTrigger()
+    {
+        // Arrange — fixture's CompletionBatchSize is 10; publishing 3 jobs never hits the size threshold.
+        // Idle drain should flush them before workers suspend on the channel.
+        var publisher = Server.CreatePublisher();
+        for (var i = 0; i < 3; i++)
+        {
+            await publisher.Enqueue(new UnitRequest());
+        }
+
+        await publisher.SaveChangesAsync();
+
+        // Act
+        await Server.WaitForCompletion(TimeSpan.FromSeconds(15));
+
+        // Assert
+        var ctx = Server.CreateContext();
+        var completed = await ctx.Set<Job>()
+            .CountAsync(j => j.Kind == JobKind.Job && j.CurrentState == State.Completed);
+        completed.ShouldBe(3);
+    }
+
+    [TimedFact(timeout: 60_000)]
+    public async Task GivenShutdown_WhenServerStops_ThenPendingCompletionsAreFlushed()
+    {
+        // Arrange — spin up a test-local server on an isolated queue so the fixture server doesn't race us.
+        // A long flush interval ensures completions stay buffered until StopAsync drains them.
+        const string isolatedQueue = "batch-shutdown-flush";
+        var server = await JoblyTestServer.StartAsync(_fixture, config =>
+        {
+            config.UseDispatcher = true;
+            config.WorkerCount = 2;
+            config.Queues = [isolatedQueue];
+            config.CompletionBatchSize = 50;
+            config.CompletionFlushInterval = TimeSpan.FromSeconds(30);
+        });
+
+        try
+        {
+            var publisher = server.CreatePublisher();
+            for (var i = 0; i < 5; i++)
+            {
+                await publisher.Enqueue(new UnitRequest(), queue: isolatedQueue);
+            }
+
+            await publisher.SaveChangesAsync();
+
+            // Wait for handlers to run (empty handlers complete ~instantly).
+            // Completions are buffered; the long flush interval means they won't auto-flush.
+            await server.WaitForJobsToLeaveEnqueued(isolatedQueue, 5, TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            // StopAsync override should drain the buffered completions.
+            await server.DisposeAsync();
+        }
+
+        // Assert — after shutdown, all jobs must be persisted as Completed.
+        var ctx = _fixture.CreateContext();
+        var jobs = await ctx.Set<Job>()
+            .Where(j => j.Queue == isolatedQueue)
+            .AsNoTracking()
+            .ToListAsync();
+        jobs.Count.ShouldBe(5);
+        jobs.ShouldAllBe(j => j.CurrentState == State.Completed);
+    }
+
+    [TimedFact(timeout: 60_000)]
+    public async Task GivenProcessingJob_WhenCancelledInDispatcherMode_ThenFlushesAsDeletedWithHourlyCounter()
+    {
+        // Arrange — fixture server runs in dispatcher mode. Enqueue a handler that blocks on cancellation.
+        var publisher = Server.CreatePublisher();
+        var jobId = await publisher.Enqueue(new CancellableRequest());
+        await publisher.SaveChangesAsync();
+
+        await Server.WaitForJobState(jobId, State.Processing);
+
+        // Act — cancel while in-flight; worker's handler token is cancelled, the catch path builds a
+        // PendingCompletion with State.Deleted and the batch flushes.
+        var cmd = Server.CreateCommandService();
+        await cmd.DeleteJob(jobId);
+
+        await Server.WaitForJobState(jobId, State.Deleted, TimeSpan.FromSeconds(15));
+
+        // Assert — terminal state + Cancelled log.
+        var job = await Server.GetJob(jobId);
+        job.CurrentState.ShouldBe(State.Deleted);
+        job.CancellationMode.ShouldBe(CancellationMode.None);
+        job.CurrentWorkerId.ShouldBeNull();
+        job.ExpireAt.ShouldNotBeNull();
+
+        var logs = await Server.GetJobLogs(jobId);
+        logs.ShouldContain(l => l.EventType == "Cancelled");
+
+        // W2 — both the aggregate and hourly counters must be written, matching non-dispatcher mode.
+        var ctx = Server.CreateContext();
+        var hourSuffix = DateTime.UtcNow.ToString("yyyy-MM-dd-HH", System.Globalization.CultureInfo.InvariantCulture);
+        var aggregateSum = await ctx.Set<Counter>()
+            .Where(c => c.Key == "stats:deleted")
+            .SumAsync(c => c.Value);
+        aggregateSum.ShouldBeGreaterThanOrEqualTo(1);
+
+        var hourlySum = await ctx.Set<Counter>()
+            .Where(c => c.Key == $"stats:deleted:{hourSuffix}")
+            .SumAsync(c => c.Value);
+        hourlySum.ShouldBeGreaterThanOrEqualTo(1);
+    }
+
+    [TimedFact(timeout: 60_000)]
+    public async Task GivenCompletionBatchSizeOne_WhenProcessed_ThenEachJobCommitsIndividually()
+    {
+        // Arrange — isolated server with batching disabled (opt-out path).
+        const string isolatedQueue = "batch-size-one";
+        await using var server = await JoblyTestServer.StartAsync(_fixture, config =>
+        {
+            config.UseDispatcher = true;
+            config.WorkerCount = 2;
+            config.Queues = [isolatedQueue];
+            config.CompletionBatchSize = 1;
+            config.CompletionFlushInterval = TimeSpan.FromSeconds(30);
+        });
+
+        var publisher = server.CreatePublisher();
+        for (var i = 0; i < 8; i++)
+        {
+            await publisher.Enqueue(new UnitRequest(), queue: isolatedQueue);
+        }
+
+        await publisher.SaveChangesAsync();
+
+        // Act
+        await server.WaitForCompletion(TimeSpan.FromSeconds(30));
+
+        // Assert
+        var ctx = _fixture.CreateContext();
+        var jobs = await ctx.Set<Job>()
+            .Where(j => j.Queue == isolatedQueue)
+            .CountAsync(j => j.CurrentState == State.Completed);
+        jobs.ShouldBe(8);
+    }
+
+}
+
+[Collection<PostgreSqlBatchedCompletionCollection>]
+public class BatchedCompletionIntegrationTests_PostgreSql : BatchedCompletionIntegrationTestsBase
+{
+    public BatchedCompletionIntegrationTests_PostgreSql(PostgreSqlBatchedCompletionFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerBatchedCompletionCollection>]
+[Trait("Category", "SqlServer")]
+public class BatchedCompletionIntegrationTests_SqlServer : BatchedCompletionIntegrationTestsBase
+{
+    public BatchedCompletionIntegrationTests_SqlServer(SqlServerBatchedCompletionFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
+++ b/src/core/Jobly.Tests/Integration/JoblyTestServer.cs
@@ -237,6 +237,31 @@ public class JoblyTestServer : IAsyncDisposable
         throw new TimeoutException($"Job {jobId} did not get log event '{eventType}' within {timeout ?? TimeSpan.FromSeconds(10)}. Events: {eventTypes}");
     }
 
+    /// <summary>
+    /// Polls until every job on <paramref name="queue"/> has left the <see cref="State.Enqueued"/>
+    /// state (i.e. a worker has picked it up), without waiting for terminal completion.
+    /// Use this when the test wants to observe in-flight / buffered state before shutdown.
+    /// </summary>
+    public async Task WaitForJobsToLeaveEnqueued(string queue, int expectedCount, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(15));
+        while (DateTime.UtcNow < deadline)
+        {
+            var ctx = CreateContext();
+            var totalSeen = await ctx.Set<Job>().CountAsync(j => j.Queue == queue);
+            var stillEnqueued = await ctx.Set<Job>()
+                .CountAsync(j => j.Queue == queue && j.CurrentState == State.Enqueued);
+            if (totalSeen >= expectedCount && stillEnqueued == 0)
+            {
+                return;
+            }
+
+            await Task.Delay(100);
+        }
+
+        throw new TimeoutException($"Jobs on queue {queue} did not leave Enqueued within {timeout ?? TimeSpan.FromSeconds(15)}");
+    }
+
     public async Task WaitForCompletion(TimeSpan? timeout = null)
     {
         var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));

--- a/src/core/Jobly.Tests/Unit/Worker/CompletionBatchTests.cs
+++ b/src/core/Jobly.Tests/Unit/Worker/CompletionBatchTests.cs
@@ -1,0 +1,334 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Jobly.Core.Enums;
+using Jobly.Tests.Fixtures;
+using Jobly.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace Jobly.Tests.Unit.Worker;
+
+public abstract class CompletionBatchTestsBase : IAsyncLifetime
+{
+    private readonly IDatabaseFixture _fixture;
+    private readonly BatchTestTimeProvider _time = new(new DateTime(2026, 4, 17, 10, 0, 0, DateTimeKind.Utc));
+
+    protected CompletionBatchTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync() => await _fixture.ResetAsync();
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private IServiceScopeFactory CreateScopeFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<TestContext>(_ => _fixture.CreateContext());
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    private async Task<Job> InsertProcessingJob()
+    {
+        var ctx = _fixture.CreateContext();
+        var job = new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            Type = "test",
+            Message = "{}",
+            CreateTime = _time.GetUtcNow().UtcDateTime,
+            ScheduleTime = _time.GetUtcNow().UtcDateTime,
+            Queue = "default",
+            CurrentWorkerId = Guid.NewGuid(),
+            LastKeepAlive = _time.GetUtcNow().UtcDateTime,
+        };
+        ctx.Set<Job>().Add(job);
+        await ctx.SaveChangesAsync();
+        return job;
+    }
+
+    private static PendingCompletion MakeEntry(Job job)
+    {
+        job.CurrentState = State.Completed;
+        job.CurrentWorkerId = null;
+        job.LastKeepAlive = null;
+        job.ExpireAt = DateTime.UtcNow.AddHours(1);
+
+        var counters = new List<Counter>
+        {
+            new() { Key = "stats:succeeded", Value = 1 },
+            new() { Key = "stats:succeeded:2026-04-17-10", Value = 1 },
+        };
+        var logs = new List<JobLog>
+        {
+            new()
+            {
+                JobId = job.Id,
+                EventType = "Completed",
+                Timestamp = DateTime.UtcNow,
+                Level = "Information",
+                Message = $"Job {job.Id} completed",
+            },
+        };
+        return new PendingCompletion(job, counters, logs);
+    }
+
+    [TimedFact]
+    public async Task FlushAsync_PersistsAllBufferedCompletions_WhenSizeReached()
+    {
+        // Arrange
+        var scopeFactory = CreateScopeFactory();
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 3, flushInterval: TimeSpan.FromSeconds(10));
+
+        var job1 = await InsertProcessingJob();
+        var job2 = await InsertProcessingJob();
+        var job3 = await InsertProcessingJob();
+
+        batch.Add(MakeEntry(job1));
+        batch.Add(MakeEntry(job2));
+        batch.Add(MakeEntry(job3));
+
+        batch.IsFull.ShouldBeTrue();
+
+        // Act
+        await batch.FlushAsync(CancellationToken.None);
+
+        // Assert
+        var ctx = _fixture.CreateContext();
+        var jobs = await ctx.Set<Job>()
+            .Where(x => x.Id == job1.Id || x.Id == job2.Id || x.Id == job3.Id)
+            .OrderBy(x => x.Id)
+            .AsNoTracking()
+            .ToListAsync();
+        jobs.Count.ShouldBe(3);
+        foreach (var job in jobs)
+        {
+            job.CurrentState.ShouldBe(State.Completed);
+            job.CurrentWorkerId.ShouldBeNull();
+            job.LastKeepAlive.ShouldBeNull();
+        }
+
+        var counters = await ctx.Set<Counter>().CountAsync();
+        counters.ShouldBe(6);
+
+        var logs = await ctx.Set<JobLog>()
+            .Where(x => x.EventType == "Completed")
+            .CountAsync();
+        logs.ShouldBe(3);
+
+        batch.Count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task FlushAsync_WhenEmpty_IsNoOp()
+    {
+        // Arrange
+        var scopeFactory = CreateScopeFactory();
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 10, flushInterval: TimeSpan.FromSeconds(1));
+
+        // Act
+        await batch.FlushAsync(CancellationToken.None);
+
+        // Assert
+        var ctx = _fixture.CreateContext();
+        (await ctx.Set<Counter>().CountAsync()).ShouldBe(0);
+        (await ctx.Set<JobLog>().CountAsync()).ShouldBe(0);
+        batch.Count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task FlushAsync_WhenCalledTwice_SecondIsNoOp()
+    {
+        // Arrange
+        var scopeFactory = CreateScopeFactory();
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 10, flushInterval: TimeSpan.FromSeconds(10));
+
+        var job = await InsertProcessingJob();
+        batch.Add(MakeEntry(job));
+
+        // Act
+        await batch.FlushAsync(CancellationToken.None);
+        var countersAfterFirst = await _fixture.CreateContext().Set<Counter>().CountAsync();
+
+        await batch.FlushAsync(CancellationToken.None);
+
+        // Assert
+        var countersAfterSecond = await _fixture.CreateContext().Set<Counter>().CountAsync();
+        countersAfterSecond.ShouldBe(countersAfterFirst);
+        batch.Count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task IsTimeElapsed_OnlyReturnsTrueAfterInterval()
+    {
+        // Arrange
+        var scopeFactory = CreateScopeFactory();
+        var flushInterval = TimeSpan.FromMilliseconds(100);
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 100, flushInterval: flushInterval);
+
+        // Assert empty — no timestamp yet
+        batch.IsTimeElapsed.ShouldBeFalse();
+
+        var job = await InsertProcessingJob();
+        batch.Add(MakeEntry(job));
+
+        // Just after add — not elapsed
+        batch.IsTimeElapsed.ShouldBeFalse();
+
+        // Advance time past interval
+        _time.Advance(flushInterval + TimeSpan.FromMilliseconds(1));
+        batch.IsTimeElapsed.ShouldBeTrue();
+
+        // Act — flush resets the timestamp
+        await batch.FlushAsync(CancellationToken.None);
+
+        // Assert — empty buffer, no timestamp
+        batch.IsTimeElapsed.ShouldBeFalse();
+    }
+
+    [TimedFact]
+    public async Task FlushAsync_WithPoisonEntry_DropsPoisonAndCommitsGoodEntries()
+    {
+        // Arrange — one real job and one phantom. A full-batch UPDATE hits 0 rows for the phantom
+        // and EF raises DbUpdateConcurrencyException. FlushAsync must split on failure, isolate
+        // the poison entry, commit the good one, and return without surfacing the exception.
+        var scopeFactory = CreateScopeFactory();
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 10, flushInterval: TimeSpan.FromSeconds(10));
+
+        var realJob = await InsertProcessingJob();
+        batch.Add(MakeEntry(realJob));
+
+        var phantomJob = new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            Type = "test",
+            Message = "{}",
+            CreateTime = _time.GetUtcNow().UtcDateTime,
+            ScheduleTime = _time.GetUtcNow().UtcDateTime,
+            Queue = "default",
+        };
+        batch.Add(new PendingCompletion(
+            phantomJob,
+            [new Counter { Key = "stats:succeeded", Value = 1 }],
+            [new JobLog { JobId = phantomJob.Id, EventType = "Completed", Timestamp = DateTime.UtcNow, Level = "Information", Message = "phantom" }]));
+
+        // Act
+        await batch.FlushAsync(CancellationToken.None);
+
+        // Assert — real job committed, phantom dropped, buffer drained.
+        var ctx = _fixture.CreateContext();
+        var persisted = await ctx.Set<Job>().FirstAsync(x => x.Id == realJob.Id);
+        persisted.CurrentState.ShouldBe(State.Completed);
+        persisted.CurrentWorkerId.ShouldBeNull();
+
+        (await ctx.Set<Job>().AnyAsync(x => x.Id == phantomJob.Id)).ShouldBeFalse();
+
+        var counters = await ctx.Set<Counter>().ToListAsync();
+        counters.Count(c => c.Key == "stats:succeeded").ShouldBe(1);
+        counters.ShouldNotContain(c => c.Value == 1 && c.Key == "stats:succeeded" && c.Id == 0 && string.Equals(c.Key, "phantom", StringComparison.Ordinal));
+
+        batch.Count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task FlushAsync_WithSinglePoisonInLargerBatch_CommitsAllGoodEntries()
+    {
+        // Arrange — four good jobs and one poison in the middle. Split-on-failure must isolate
+        // the single bad entry (via recursive halving) without dropping the neighbours.
+        var scopeFactory = CreateScopeFactory();
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 10, flushInterval: TimeSpan.FromSeconds(10));
+
+        var good1 = await InsertProcessingJob();
+        var good2 = await InsertProcessingJob();
+        var good3 = await InsertProcessingJob();
+        var good4 = await InsertProcessingJob();
+
+        batch.Add(MakeEntry(good1));
+        batch.Add(MakeEntry(good2));
+
+        var phantom = new Job
+        {
+            Id = Guid.NewGuid(),
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            Type = "test",
+            Message = "{}",
+            CreateTime = _time.GetUtcNow().UtcDateTime,
+            ScheduleTime = _time.GetUtcNow().UtcDateTime,
+            Queue = "default",
+        };
+        batch.Add(new PendingCompletion(phantom, [], []));
+
+        batch.Add(MakeEntry(good3));
+        batch.Add(MakeEntry(good4));
+
+        // Act
+        await batch.FlushAsync(CancellationToken.None);
+
+        // Assert — all four real jobs commit as Completed; phantom is gone.
+        var ctx = _fixture.CreateContext();
+        var committed = await ctx.Set<Job>()
+            .Where(x => x.Id == good1.Id || x.Id == good2.Id || x.Id == good3.Id || x.Id == good4.Id)
+            .CountAsync(x => x.CurrentState == State.Completed);
+        committed.ShouldBe(4);
+
+        (await ctx.Set<Job>().AnyAsync(x => x.Id == phantom.Id)).ShouldBeFalse();
+
+        batch.Count.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task Add_WhenBatchSizeIsOne_MarksFullImmediately()
+    {
+        // Arrange
+        var scopeFactory = CreateScopeFactory();
+        var batch = new CompletionBatch<TestContext>(scopeFactory, _time, NullLogger.Instance, batchSize: 1, flushInterval: TimeSpan.FromSeconds(10));
+
+        var job = await InsertProcessingJob();
+
+        // Act
+        batch.Add(MakeEntry(job));
+
+        // Assert
+        batch.IsFull.ShouldBeTrue();
+        batch.Count.ShouldBe(1);
+
+        // Flush commits the single entry
+        await batch.FlushAsync(CancellationToken.None);
+        var persisted = await _fixture.CreateContext().Set<Job>().FirstAsync(x => x.Id == job.Id);
+        persisted.CurrentState.ShouldBe(State.Completed);
+    }
+}
+
+internal sealed class BatchTestTimeProvider(DateTime start) : TimeProvider
+{
+    private DateTime _now = DateTime.SpecifyKind(start, DateTimeKind.Utc);
+
+    public override DateTimeOffset GetUtcNow() => new(_now, TimeSpan.Zero);
+
+    public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+}
+
+[Collection<PostgreSqlCollection>]
+public class CompletionBatchTests_PostgreSql : CompletionBatchTestsBase
+{
+    public CompletionBatchTests_PostgreSql(PostgreSqlFixture fixture)
+        : base(fixture)
+    {
+    }
+}
+
+[Collection<SqlServerCollection>]
+[Trait("Category", "SqlServer")]
+public class CompletionBatchTests_SqlServer : CompletionBatchTestsBase
+{
+    public CompletionBatchTests_SqlServer(SqlServerFixture fixture)
+        : base(fixture)
+    {
+    }
+}

--- a/src/core/Jobly.Worker/CompletionBatch.cs
+++ b/src/core/Jobly.Worker/CompletionBatch.cs
@@ -1,0 +1,142 @@
+using Jobly.Core.Data.Entities;
+using Jobly.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Jobly.Worker;
+
+/// <summary>
+/// A single job completion waiting to be persisted: the mutated <see cref="Job"/> entity,
+/// the counters to insert, and the log entries to insert (final state log + any drained handler logs).
+/// </summary>
+internal readonly record struct PendingCompletion(
+    Job Job,
+    IReadOnlyList<Counter> Counters,
+    IReadOnlyList<JobLog> Logs);
+
+/// <summary>
+/// Per-worker buffer of pending completions for dispatcher mode. Flushes all buffered entries
+/// in a single transaction when the size or time threshold is reached, when the worker is about
+/// to suspend for more work, or on shutdown.
+/// <para>
+/// On <see cref="DbUpdateException"/> (concurrency mismatch, phantom row, etc.) the flush
+/// recursively splits the batch in half to isolate the failing entries. A single-entry partition
+/// that still fails is logged and dropped — <c>StaleJobRecoveryTask</c> will recover the underlying
+/// <c>Processing</c> row. Non-<see cref="DbUpdateException"/> failures propagate to the caller.
+/// </para>
+/// </summary>
+internal sealed class CompletionBatch<TContext>
+    where TContext : DbContext
+{
+    private readonly List<PendingCompletion> _buffer;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger _logger;
+    private readonly int _batchSize;
+    private readonly TimeSpan _flushInterval;
+    private DateTimeOffset? _firstEntryTimestamp;
+
+    public CompletionBatch(
+        IServiceScopeFactory scopeFactory,
+        TimeProvider timeProvider,
+        ILogger logger,
+        int batchSize,
+        TimeSpan flushInterval)
+    {
+        _scopeFactory = scopeFactory;
+        _timeProvider = timeProvider;
+        _logger = logger;
+        _batchSize = batchSize <= 0 ? 1 : batchSize;
+        _flushInterval = flushInterval;
+        _buffer = new List<PendingCompletion>(_batchSize);
+    }
+
+    public int Count => _buffer.Count;
+
+    public bool IsFull => _buffer.Count >= _batchSize;
+
+    public bool IsTimeElapsed =>
+        _firstEntryTimestamp is { } first
+        && _timeProvider.GetUtcNow() - first >= _flushInterval;
+
+    public void Add(PendingCompletion entry)
+    {
+        if (_buffer.Count == 0)
+        {
+            _firstEntryTimestamp = _timeProvider.GetUtcNow();
+        }
+
+        _buffer.Add(entry);
+    }
+
+    /// <summary>
+    /// Persists the buffered completions. On success (including poison-drops isolated via split)
+    /// the buffer is cleared. On transient failure (non-<see cref="DbUpdateException"/>) the buffer
+    /// is already drained — the exception propagates and the orphaned <c>Processing</c> rows are
+    /// recovered by <c>StaleJobRecoveryTask</c>.
+    /// </summary>
+    public async Task FlushAsync(CancellationToken cancellationToken)
+    {
+        if (_buffer.Count == 0)
+        {
+            return;
+        }
+
+        var pending = _buffer.ToArray();
+        _buffer.Clear();
+        _firstEntryTimestamp = null;
+
+        await FlushRangeAsync(pending, 0, pending.Length, cancellationToken);
+    }
+
+    private async Task FlushRangeAsync(PendingCompletion[] entries, int start, int count, CancellationToken cancellationToken)
+    {
+        if (count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<TContext>();
+
+            await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+
+            for (var i = start; i < start + count; i++)
+            {
+                var entry = entries[i];
+                context.Entry(entry.Job).State = EntityState.Modified;
+
+                if (entry.Counters.Count > 0)
+                {
+                    context.Set<Counter>().AddRange(entry.Counters);
+                }
+
+                if (entry.Logs.Count > 0)
+                {
+                    context.Set<JobLog>().AddRange(entry.Logs);
+                }
+            }
+
+            await context.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex)
+        {
+            if (count == 1)
+            {
+                _logger.LogError(
+                    ex,
+                    "Dropping poison completion for job {jobId}; StaleJobRecoveryTask will recover the underlying Processing row",
+                    entries[start].Job.Id);
+                return;
+            }
+
+            var mid = count / 2;
+            await FlushRangeAsync(entries, start, mid, cancellationToken);
+            await FlushRangeAsync(entries, start + mid, count - mid, cancellationToken);
+        }
+    }
+}

--- a/src/core/Jobly.Worker/Configuration.cs
+++ b/src/core/Jobly.Worker/Configuration.cs
@@ -92,6 +92,30 @@ public class JoblyWorkerConfiguration : JoblyConfiguration
     /// </summary>
     public bool UseDispatcher { get; set; }
 
+    /// <summary>
+    /// Dispatcher-mode only. Maximum number of job completions each worker buffers in memory
+    /// before flushing them to the database in a single transaction. Defaults to 50.
+    /// Set to 1 to disable batching (every completion commits in its own transaction).
+    /// <para>
+    /// Trade-off: batching widens the at-least-once duplicate-execution window. If a worker
+    /// crashes with buffered completions that have not yet been flushed, those jobs stay in
+    /// <c>Processing</c> and <c>StaleJobRecoveryTask</c> will requeue them per the
+    /// <c>[NoRestart]</c> setting. Handlers with side effects should be idempotent or marked
+    /// <c>[NoRestart]</c>.
+    /// </para>
+    /// </summary>
+    public int CompletionBatchSize { get; set; } = 50;
+
+    /// <summary>
+    /// Dispatcher-mode only. Maximum time a buffered completion may wait before being flushed.
+    /// The timer starts when the first entry is added to an empty buffer. Defaults to 100ms.
+    /// <para>
+    /// A longer interval batches more completions (lower DB overhead) but widens the duplicate-execution
+    /// window on worker crash. See <see cref="CompletionBatchSize"/> for the crash-safety trade-off.
+    /// </para>
+    /// </summary>
+    public TimeSpan CompletionFlushInterval { get; set; } = TimeSpan.FromMilliseconds(100);
+
     internal List<WorkerGroupConfiguration> ExplicitWorkerGroups { get; } = [];
 
     /// <summary>

--- a/src/core/Jobly.Worker/Jobly.Worker.csproj
+++ b/src/core/Jobly.Worker/Jobly.Worker.csproj
@@ -15,6 +15,10 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Jobly.Tests" />
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(Configuration)'!='Debug'">
 		<PackageReference Include="Moberg.Jobly.Core" Version="$(PackageVersion)" />
 	</ItemGroup>

--- a/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
+++ b/src/core/Jobly.Worker/JoblyDispatcherWorker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Text.Json;
 using System.Threading.Channels;
 using Jobly.Core;
@@ -19,6 +20,8 @@ namespace Jobly.Worker;
 /// <summary>
 /// Worker that receives pre-fetched jobs from a dispatcher channel.
 /// Pure executor — handles execution and completion only. Orchestration handled by OrchestrationTask.
+/// Completions are buffered in a per-worker <see cref="CompletionBatch{TContext}"/> and flushed
+/// as a single multi-row transaction when any of: size threshold, time threshold, idle, or shutdown fires.
 /// </summary>
 public class JoblyDispatcherWorker<TContext> : BackgroundService
     where TContext : DbContext
@@ -29,6 +32,7 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
     private readonly ILogger<JoblyDispatcherWorker<TContext>> _logger;
     private readonly JoblyWorkerConfiguration _configuration;
     private readonly TimeProvider _timeProvider;
+    private readonly CompletionBatch<TContext> _batch;
 
     public JoblyDispatcherWorker(
         Guid workerId,
@@ -44,24 +48,85 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
         _logger = logger;
         _configuration = configuration.Value;
         _timeProvider = timeProvider;
+        _batch = new CompletionBatch<TContext>(
+            scopeFactory,
+            timeProvider,
+            logger,
+            _configuration.CompletionBatchSize,
+            _configuration.CompletionFlushInterval);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await foreach (var job in _jobReader.ReadAllAsync(stoppingToken))
+        try
         {
-            try
+            while (await _jobReader.WaitToReadAsync(stoppingToken).ConfigureAwait(false))
             {
-                await ProcessJob(job, stoppingToken);
+                while (_jobReader.TryRead(out var job))
+                {
+                    try
+                    {
+                        await ProcessJob(job, stoppingToken);
+                    }
+                    catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Dispatcher worker failed on job {id}", job.Id);
+                    }
+
+                    if (_batch.IsFull || _batch.IsTimeElapsed)
+                    {
+                        await FlushBatchSafely(stoppingToken);
+                    }
+                }
+
+                // Idle — drain any buffered completions before suspending on WaitToReadAsync
+                await FlushBatchSafely(stoppingToken);
             }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Dispatcher worker failed on job {id}", job.Id);
-            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Graceful stop — StopAsync handles the final flush
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await base.StopAsync(cancellationToken);
+
+        try
+        {
+            await _batch.FlushAsync(CancellationToken.None);
+            OrchestrationTask<TContext>.SignalOrchestrator();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Final batch flush on shutdown failed");
+        }
+    }
+
+    private async Task FlushBatchSafely(CancellationToken cancellationToken)
+    {
+        if (_batch.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await _batch.FlushAsync(cancellationToken);
+            OrchestrationTask<TContext>.SignalOrchestrator();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to flush completion batch");
         }
     }
 
@@ -69,16 +134,10 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
     {
         PerfTrace.Begin();
 
-        // Worker scope — owns Jobly state (Job, JobLog, Counter). Isolated from handler's DbContext.
-        using var workerScope = _scopeFactory.CreateScope();
-        var workerContext = workerScope.ServiceProvider.GetRequiredService<TContext>();
-
-        var trackedJob = await workerContext.Set<Job>().FindAsync([job.Id], cancellationToken)
-            ?? throw new InvalidOperationException($"Job {job.Id} not found");
-        trackedJob.CurrentWorkerId = _workerId;
-        trackedJob.HandlerType = job.HandlerType;
-        await workerContext.SaveChangesAsync(cancellationToken);
-        job = trackedJob;
+        // Operational observability — Dashboard/incident response needs to see "worker X holds job Y"
+        // while it runs. Single UPDATE (no SELECT, no change tracker). Scope disposes when the helper returns.
+        await MarkWorkerOwnership(job, cancellationToken);
+        job.CurrentWorkerId = _workerId;
 
         var logCollector = new JobLogCollector { JobId = job.Id, TimeProvider = _timeProvider, WorkerId = _workerId };
 
@@ -168,9 +227,6 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             await jobCts.CancelAsync();
             await monitorTask;
 
-            PerfTrace.Mark(PerfTrace.BeginTransaction2);
-            await using var endTransaction = await workerContext.Database.BeginTransactionAsync(default);
-
             if (successOutcome != null)
             {
                 job.CurrentState = successOutcome.State;
@@ -189,17 +245,9 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
                 job.CurrentState = State.Completed;
             }
 
-            FinalizeJobState(workerContext, job, null, handlerStopwatch.Elapsed.TotalMilliseconds, successOutcome);
-            if (_configuration.EnableHandlerLogging)
-            {
-                await SaveJobLogs(workerContext, logCollector);
-            }
-
-            PerfTrace.Mark(PerfTrace.SaveCompleted);
-            await workerContext.SaveChangesAsync(default);
-
-            PerfTrace.Mark(PerfTrace.CommitTransaction2);
-            await endTransaction.CommitAsync(default);
+            var (counters, finalLog) = BuildFinalization(job, null, durationMs, successOutcome);
+            var logs = CollectLogs(finalLog, logCollector).ToArray();
+            _batch.Add(new PendingCompletion(job, counters, logs));
         }
         catch (OperationCanceledException) when (jobCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
@@ -217,14 +265,21 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             await monitorTask;
 
             var cancelNow = _timeProvider.GetUtcNow().UtcDateTime;
-            await using var endTransaction = await workerContext.Database.BeginTransactionAsync(default);
             job.CurrentState = State.Deleted;
             job.ExpireAt = cancelNow.Add(_configuration.JobExpirationTimeout);
             job.CancellationMode = CancellationMode.None;
             job.CurrentWorkerId = null;
             job.LastKeepAlive = null;
-            workerContext.Set<Counter>().Add(new Counter { Key = "stats:deleted", Value = 1 });
-            workerContext.Set<JobLog>().Add(new JobLog
+
+            // Match BuildFinalization: emit both the aggregate and per-hour counters so cancellations
+            // show up in the dashboard's hourly graph alongside other terminal states.
+            var hourSuffix = cancelNow.ToString("yyyy-MM-dd-HH", CultureInfo.InvariantCulture);
+            IReadOnlyList<Counter> cancelCounters =
+            [
+                new() { Key = "stats:deleted", Value = 1 },
+                new() { Key = $"stats:deleted:{hourSuffix}", Value = 1 },
+            ];
+            var cancelLog = new JobLog
             {
                 JobId = job.Id,
                 EventType = "Cancelled",
@@ -233,14 +288,9 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
                 Message = "Job was cancelled by user",
                 DurationMs = handlerStopwatch?.Elapsed.TotalMilliseconds,
                 WorkerId = _workerId,
-            });
-            if (_configuration.EnableHandlerLogging)
-            {
-                await SaveJobLogs(workerContext, logCollector);
-            }
-
-            await workerContext.SaveChangesAsync(default);
-            await endTransaction.CommitAsync(default);
+            };
+            var logs = CollectLogs(cancelLog, logCollector).ToArray();
+            _batch.Add(new PendingCompletion(job, cancelCounters, logs));
         }
         catch (Exception e)
         {
@@ -298,15 +348,9 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             await jobCts.CancelAsync();
             await monitorTask;
 
-            await using var endTransaction = await workerContext.Database.BeginTransactionAsync(default);
-            FinalizeJobState(workerContext, job, e, errorDurationMs, outcome);
-            if (_configuration.EnableHandlerLogging)
-            {
-                await SaveJobLogs(workerContext, logCollector);
-            }
-
-            await workerContext.SaveChangesAsync(default);
-            await endTransaction.CommitAsync(default);
+            var (counters, finalLog) = BuildFinalization(job, e, errorDurationMs, outcome);
+            var logs = CollectLogs(finalLog, logCollector).ToArray();
+            _batch.Add(new PendingCompletion(job, counters, logs));
         }
         finally
         {
@@ -318,10 +362,22 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             JobExecutionContext.Current = null;
         }
 
-        OrchestrationTask<TContext>.SignalOrchestrator();
-
         PerfTrace.Mark(PerfTrace.Done);
         PerfTrace.End();
+    }
+
+    private async Task MarkWorkerOwnership(Job job, CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        var handlerTypeToSet = job.HandlerType;
+        await context.Set<Job>()
+            .Where(x => x.Id == job.Id)
+            .ExecuteUpdateAsync(
+                x => x
+                    .SetProperty(p => p.CurrentWorkerId, _workerId)
+                    .SetProperty(p => p.HandlerType, handlerTypeToSet),
+                cancellationToken);
     }
 
     private static async Task ExecuteJob(Job job, IServiceProvider provider, CancellationToken cancellationToken)
@@ -428,10 +484,10 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
     }
 
     /// <summary>
-    /// Finalizes job state: clears worker fields, adds counters and log entry.
+    /// Clears worker-owned fields on the job and produces the completion counters + final state log.
     /// State must be set on the job before calling this method.
     /// </summary>
-    private void FinalizeJobState(TContext context, Job job, Exception? error, double? durationMs, JobOutcome? outcome = null)
+    private (List<Counter> Counters, JobLog FinalLog) BuildFinalization(Job job, Exception? error, double? durationMs, JobOutcome? outcome)
     {
         var state = job.CurrentState;
         job.CancellationMode = CancellationMode.None;
@@ -440,19 +496,23 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
 
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var hourSuffix = now.ToString("yyyy-MM-dd-HH");
+        var counters = new List<Counter>();
         if (state == State.Completed)
         {
             job.ExpireAt = now.Add(_configuration.JobExpirationTimeout);
-            AddCounters(context, "stats:succeeded", $"stats:succeeded:{hourSuffix}");
+            counters.Add(new Counter { Key = "stats:succeeded", Value = 1 });
+            counters.Add(new Counter { Key = $"stats:succeeded:{hourSuffix}", Value = 1 });
         }
         else if (state == State.Failed)
         {
-            AddCounters(context, "stats:failed", $"stats:failed:{hourSuffix}");
+            counters.Add(new Counter { Key = "stats:failed", Value = 1 });
+            counters.Add(new Counter { Key = $"stats:failed:{hourSuffix}", Value = 1 });
         }
         else if (state == State.Deleted)
         {
             job.ExpireAt = now.Add(_configuration.JobExpirationTimeout);
-            AddCounters(context, "stats:deleted", $"stats:deleted:{hourSuffix}");
+            counters.Add(new Counter { Key = "stats:deleted", Value = 1 });
+            counters.Add(new Counter { Key = $"stats:deleted:{hourSuffix}", Value = 1 });
         }
 
         var logMessage = outcome?.LogMessage
@@ -468,7 +528,7 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             _ => state.ToString(),
         };
 
-        context.Set<JobLog>().Add(new JobLog
+        var finalLog = new JobLog
         {
             JobId = job.Id,
             EventType = eventType,
@@ -478,24 +538,24 @@ public class JoblyDispatcherWorker<TContext> : BackgroundService
             Exception = logException,
             DurationMs = durationMs,
             WorkerId = _workerId,
-        });
+        };
+
+        return (counters, finalLog);
     }
 
-    private static async Task SaveJobLogs(TContext context, JobLogCollector collector)
+    private IEnumerable<JobLog> CollectLogs(JobLog finalLog, JobLogCollector collector)
     {
-        var entries = collector.Drain();
-        if (entries.Count == 0)
+        yield return finalLog;
+
+        if (!_configuration.EnableHandlerLogging)
         {
-            return;
+            yield break;
         }
 
-        await context.Set<JobLog>().AddRangeAsync(entries);
-    }
-
-    private static void AddCounters(TContext context, string totalKey, string hourlyKey)
-    {
-        context.Set<Counter>().Add(new Counter { Key = totalKey, Value = 1 });
-        context.Set<Counter>().Add(new Counter { Key = hourlyKey, Value = 1 });
+        foreach (var drained in collector.Drain())
+        {
+            yield return drained;
+        }
     }
 
     private static string Truncate(string value, int maxLength)


### PR DESCRIPTION
## Summary
- `JoblyDispatcherWorker` now buffers job completions (Job state update + Counter rows + JobLog rows) in a per-worker `CompletionBatch` and flushes them in a single multi-row transaction.
- Flush triggers: size threshold, time threshold, idle-before-`WaitToReadAsync`, and `StopAsync`. Poison entries (`DbUpdateException`) are isolated via recursive halving, logged, and dropped — `StaleJobRecoveryTask` recovers their underlying `Processing` rows.
- Non-dispatcher `JoblyWorkerService` is untouched.

## Config (on `JoblyWorkerConfiguration`)
- `CompletionBatchSize` — default **50**. Set to `1` to opt out (per-job commits).
- `CompletionFlushInterval` — default **100 ms**. Time-based fallback when the buffer is below size.

## Trade-off
Batching widens the at-least-once duplicate-execution window. A worker crash with buffered completions leaves jobs in `Processing`; pair non-idempotent handlers with `[NoRestart]`. Documented in the XML docs on the new config fields.

## Tests
- **Unit** (`CompletionBatchTests`, PG + SQL Server): size trigger, empty flush no-op, double-flush no-op, `IsTimeElapsed`, `Add_WhenBatchSizeIsOne`, poison-entry drop, multi-entry poison with recursive split.
- **Integration** (`BatchedCompletionIntegrationTests`, PG + SQL Server): 200-job throughput, mixed success/failure outcomes, idle drain, shutdown flush on isolated queue, size=1 opt-out, graceful cancellation through the batch (state + logs + both aggregate & hourly `stats:deleted` counters).
- **No regressions:** full PG suite 467/467 green (one pre-existing flaky test `CrashRecoveryTests.CleanUpServers_HeartbeatAtExactTimeout_NotCleaned` fails on `main` too — unrelated).

## Benchmarks
BenchmarkDotNet in `Jobly.ServerBenchmarks` (Debug build; `Moberg.Jobly.Core` NuGet blocks Release per the existing `ServerBenchmarkConfig` pattern):

**`CompletionBatchBenchmark`** — batching within dispatcher mode, 10 000 no-op jobs, 10 workers:
| `CompletionBatchSize` | Mean | StdDev |
|---|---|---|
| 1 (baseline) | 26.20 s | 2.91 s |
| 50 (batched) | 21.81 s | 0.23 s |

**`DispatcherModeBenchmark`** — dispatcher vs direct, 10 000 no-op jobs, 10 workers:
| Mode | Mean | StdDev | Allocated/op |
|---|---|---|---|
| `UseDispatcher = false` (direct) | 19.72 s | 1.61 s | 3.47 GB |
| `UseDispatcher = true` (+ batching size 50) | 24.78 s | 6.59 s | 4.59 GB |

**Caveats:** Debug build, localhost Docker Postgres (sub-ms round trips negate the main payoff of batching), empty handler, 3 iterations with wide variance. Batching helps *within* dispatcher mode but doesn't make dispatcher mode beat direct workers on localhost. Real-world payoff requires networked DB latency; a followup to unstick the Release build is worth doing.

## Test plan
- [x] PG unit tests green
- [x] PG integration tests green
- [x] SQL Server unit tests green (CompletionBatchTests_SqlServer)
- [x] SQL Server integration tests green (BatchedCompletionIntegrationTests_SqlServer)
- [x] Benchmarks discoverable & runnable via `dotnet run --project benchmarks/Jobly.ServerBenchmarks -- --filter "*CompletionBatch*"` and `*DispatcherMode*`
- [x] Non-dispatcher path (`JoblyWorkerService`) untouched
- [x] Zero warnings on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)