### PR TITLE
docs: mark 0.8.0 as released

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 ## 0.8.0
 
-*Unreleased*
+*2026-04-19*
 
 ### New Features
 


### PR DESCRIPTION
## Summary
- Flip 0.8.0 header from *Unreleased* to 2026-04-19 in `website/docs/releases.md`, prior to cutting the GitHub release.

## Test plan
- [x] No code changes; docs-only.