### PR TITLE
Drop "It gets the job done" tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Warp
 
-> It gets the job done.
-
 A distributed job processing, message queue, and in-memory mediator library for .NET 10. Four patterns, one unified pipeline, a real-time dashboard.
 
 [![NuGet](https://img.shields.io/nuget/v/Moberg.Warp.Core?label=Warp.Core)](https://www.nuget.org/packages/Moberg.Warp.Core)

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -8,9 +8,6 @@ function Hero() {
     <header style={{padding: '4rem 0', textAlign: 'center'}}>
       <div className="container">
         <h1 style={{fontSize: '3rem'}}>{siteConfig.title}</h1>
-        <p style={{fontSize: '1.25rem', fontStyle: 'italic', color: 'var(--ifm-color-secondary-darkest)'}}>
-          It gets the job done.
-        </p>
         <p style={{fontSize: '1.1rem', color: 'var(--ifm-color-secondary-darkest)'}}>
           {siteConfig.tagline}
         </p>


### PR DESCRIPTION
## Summary
- Pun no longer fits post-rename
- Removed from `README.md` and the docusaurus landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)