### PR TITLE
fix: bump GivenWorkInProgress timeout for SQL Server CI

### DIFF
--- a/src/tests/Warp.Tests/Worker/DispatcherShutdownIntegrationTests.cs
+++ b/src/tests/Warp.Tests/Worker/DispatcherShutdownIntegrationTests.cs
@@ -39,7 +39,11 @@ public abstract class DispatcherShutdownIntegrationTestsBase : IAsyncLifetime
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-    [TimedFact(30_000)]
+    // 60s budget: locally ~20s, but two server bring-ups + Service Broker setup on shared
+    // SQL Server CI runners regularly push past 30s. WaitForCompletion below caps the actual
+    // job-completion wait at 20s, so this only widens the outer test envelope, not the
+    // assertion window.
+    [TimedFact(60_000)]
     public async Task GivenWorkInProgress_WhenServerReplaced_ThenAllJobsEventuallyComplete()
     {
         // Server A takes work, gets disposed mid-flight. Server B starts on the same queue.


### PR DESCRIPTION
## Summary
\`GivenWorkInProgress_WhenServerReplaced_ThenAllJobsEventuallyComplete\` was hitting the 30s \`[TimedFact]\` cap on shared SQL Server CI. Locally the test runs ~20s; on CI the two server bring-ups + Service Broker setup overhead pushes it past 30s.

The inner \`WaitForCompletion(timeout: 20s)\` is unchanged — this only widens the outer envelope from 30s to 60s so CI variance doesn't mask the actual job-completion behavior.

## Test plan
- [x] Local SQL Server: passes in ~21s
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)