### PR TITLE
fix: deflake SQL Server integration tests

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -107,9 +107,20 @@ public class WarpTestServer : IAsyncDisposable
         Action<IServiceCollection>? configureServices)
     {
         var tempCtx = fixture.CreateContext();
-        var connectionString = tempCtx.Database.GetConnectionString()!;
+        var baseConnectionString = tempCtx.Database.GetConnectionString()!;
         var isPostgres = tempCtx.Database.ProviderName?.Contains("Npgsql", StringComparison.Ordinal) == true;
         await tempCtx.DisposeAsync();
+
+        // For SQL Server only: give each test-server instance its own ADO.NET connection pool by
+        // appending a unique Application Name (which Microsoft.Data.SqlClient includes in the pool
+        // key). This mirrors production pod-restart (new process = new pool) so that one disposed
+        // server's cancelled-mid-flight SqlConnections — left in 'attention-sent' state — don't
+        // poison the pool that a replacement server then borrows from. Npgsql doesn't have the
+        // same session-on-cancel pathology, and per-server pools blow past PostgreSQL's
+        // max_connections under parallel test load, so we skip it there.
+        var connectionString = isPostgres
+            ? baseConnectionString
+            : $"{baseConnectionString};Application Name=warp-test-{Guid.NewGuid():N}";
 
         var host = Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>
@@ -178,6 +189,12 @@ public class WarpTestServer : IAsyncDisposable
                     // sweep tight so retry loops don't stall waiting for the 5s default.
                     config.ScheduledActivationInterval = TimeSpan.FromMilliseconds(250);
                     config.UseDispatcher = false;
+
+                    // Turn off the auto Counter→Statistic aggregator. No test relies on it
+                    // firing automatically — tests that need aggregation invoke
+                    // TestTasks.CreateCounterAggregator(...).AggregateCountersAsync(...) directly.
+                    // Leaving it on creates a 5s race against any test that reads Counter rows.
+                    config.CounterAggregationInterval = null;
 
                     configure?.Invoke(config);
 


### PR DESCRIPTION
## Summary

Two independent flakes, both reproduced locally under parallel-suite load, both fixed in `WarpTestServer.StartAsync`:

### 1. Per-server SqlConnection pool isolation (SQL Server only)

When a `WarpTestServer` is disposed mid-flight, the host's `stoppingToken` cancels in-flight queries. Microsoft.Data.SqlClient leaves the cancelled `SqlConnection` in 'attention-sent' state; it returns to the pool dirty. The next caller — typically a replacement server in the same test, or the next test in the same collection — borrows the dirty connection and sees `SqlException 596: batch aborted / session busy`. Background tasks (`Orchestration`, `ScheduledJobActivation`, etc.) abort outright on that error, stranding jobs and tripping `[TimedFact]` timeouts on shutdown durability tests like `DispatcherShutdownIntegrationTests` and `BatchedCompletionIntegrationTests`.

Production never hits this: pod-restart = new process = new pool. The two-Host-instances-against-one-connection-string shape is purely a test setup artifact.

**Fix:** append a unique `Application Name=warp-test-{guid}` per `WarpTestServer` for SQL Server only. Microsoft.Data.SqlClient includes Application Name in the pool key, so each test server gets its own pool, mirroring production pod-restart. Skipped on Npgsql because (a) it doesn't have the same session-on-cancel pathology and (b) per-server pools quickly exhaust PostgreSQL's `max_connections=100` under parallel load.

### 2. CounterAggregator races test assertions

The aggregator runs every 5s by default (production setting), folding `Counter` rows into `Statistic` and deleting the originals. `ScopeIsolationIntegrationTests.GivenHandlerThatAddsEntitySavesAndThrows_WhenProcessed_ThenEntityPersisted` writes a `Counter` row as a "did the handler commit before throwing?" canary; if the auto-sweep fires between the handler's `SaveChanges` and the test's assertion, the canary disappears.

No test relies on the auto-sweep — every test that needs aggregation invokes `TestTasks.CreateCounterAggregator(...).AggregateCountersAsync(...)` directly.

**Fix:** set `CounterAggregationInterval = null` in `WarpTestServer`'s defaults so the timer never fires under tests.

## Repro / verification

Before:
- Full SQL Server suite under parallel load: ~25–50% flake rate (DispatcherShutdown / BatchedCompletion timeouts at 30s)
- `ScopeIsolationIntegrationTests` run alone: ~60% flake rate (Counter race)

After:
- 6/6 full SQL Server runs green (~1m 30s each)
- 3/3 full PG+NoDb runs green (~1m 09s each)

## Test plan
- [ ] CI green on this PR (PostgreSQL + SQL Server + NoDb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)