### PR TITLE
fix: deflake MultiHandlerMessage integration test, add failure dump

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/IntegrationTestBase.cs
+++ b/src/tests/Warp.Tests/Fixtures/IntegrationTestBase.cs
@@ -26,5 +26,32 @@ public abstract class IntegrationTestBase : IAsyncLifetime
         }
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public async ValueTask DisposeAsync()
+    {
+        // On any non-passing result, dump test-server state to stderr so a flake
+        // in CI is diagnosable instead of opaque. WaitForCompletion's own timeout
+        // path can't fire here — xunit's [TimedFact] cancels the polling token
+        // before WaitForCompletion's deadline branch is reached, so the test
+        // exits via OperationCanceledException, not TimeoutException. This hook
+        // catches that path (and any other failure) using a fresh CancellationToken
+        // since xunit's is already cancelled.
+        var testState = Xunit.TestContext.Current.TestState;
+        if (testState == null || testState.Result == Xunit.TestResult.Passed)
+        {
+            return;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var dump = await Server.DumpDiagnosticsAsync(
+                $"Test failed ({testState.Result}). Server-state diagnostics:",
+                cts.Token);
+            await Console.Error.WriteLineAsync(dump);
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"Diagnostic dump failed: {ex.Message}");
+        }
+    }
 }

--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -168,7 +169,7 @@ public class WarpTestServer : IAsyncDisposable
                     config.PollingInterval = TimeSpan.FromMilliseconds(100);
                     config.CancellationCheckInterval = TimeSpan.FromSeconds(1);
                     config.OrchestrationInterval = TimeSpan.FromMilliseconds(100);
-                    config.MessageRoutingInterval = TimeSpan.FromMilliseconds(500);
+                    config.MessageRoutingInterval = TimeSpan.FromMilliseconds(100);
                     config.InvisibilityTimeout = TimeSpan.FromMinutes(1);
                     config.HealthCheckInterval = TimeSpan.FromMilliseconds(200);
                     config.LogFlushInterval = TimeSpan.FromMilliseconds(100);
@@ -368,15 +369,84 @@ public class WarpTestServer : IAsyncDisposable
             await Task.Delay(200, Xunit.TestContext.Current.CancellationToken);
         }
 
-        var debugCtx = CreateContext();
-        var stuck = await debugCtx.Set<Job>()
-            .Where(j => j.CurrentState == State.Enqueued || j.CurrentState == State.Processing || j.CurrentState == State.Awaiting)
-            .Select(j => new { j.Id, j.Kind, j.CurrentState, j.ParentJobId })
-            .Take(10)
-            .ToListAsync(Xunit.TestContext.Current.CancellationToken);
-        var stuckInfo = string.Join(", ", stuck.Select(s => $"{s.Kind}:{s.CurrentState}(parent={s.ParentJobId})"));
+        throw new TimeoutException(await DumpDiagnosticsAsync(
+            $"Not all jobs completed within {(timeout ?? TimeSpan.FromSeconds(30)).TotalSeconds:0.#}s.",
+            Xunit.TestContext.Current.CancellationToken));
+    }
 
-        throw new TimeoutException($"Not all jobs completed within timeout. Stuck: {stuckInfo}");
+    /// <summary>
+    /// Builds a multi-line diagnostic dump of test-server state — stuck Job rows with their
+    /// JobLog tail, every ServerTask row's last run, and the most recent ServerLog entries.
+    /// Used both by <see cref="WaitForCompletion"/> timeouts (own-cancellation path) and by
+    /// <see cref="IntegrationTestBase.DisposeAsync"/> on test failure (xunit-cancellation path).
+    /// Caller passes its own <paramref name="ct"/> so the failure-path call can use a fresh
+    /// token instead of xunit's already-cancelled one.
+    /// </summary>
+    public async Task<string> DumpDiagnosticsAsync(string header, CancellationToken ct)
+    {
+        var debugCtx = CreateContext();
+
+        var stuckJobs = await debugCtx.Set<Job>()
+            .AsNoTracking()
+            .Where(j => j.CurrentState == State.Enqueued || j.CurrentState == State.Processing
+                || j.CurrentState == State.Awaiting || j.CurrentState == State.Scheduled)
+            .OrderBy(j => j.CreateTime)
+            .Select(j => new { j.Id, j.Kind, j.CurrentState, j.ParentJobId, j.Queue, j.ScheduleTime, j.CurrentWorkerId, j.LastKeepAlive })
+            .Take(20)
+            .ToListAsync(ct);
+
+        var stuckIds = stuckJobs.ConvertAll(j => j.Id);
+        var stuckLogs = stuckIds.Count == 0
+            ? []
+            : await debugCtx.Set<JobLog>()
+                .AsNoTracking()
+                .Where(l => stuckIds.Contains(l.JobId))
+                .OrderBy(l => l.Timestamp)
+                .Select(l => new { l.JobId, l.Timestamp, l.EventType, l.Level, l.Message })
+                .ToListAsync(ct);
+
+        var serverTasks = await debugCtx.Set<ServerTask>()
+            .AsNoTracking()
+            .OrderBy(t => t.TaskName)
+            .Select(t => new { t.TaskName, t.IntervalSeconds, t.LastRun, t.LastStatus, t.LastMessage, t.LastDurationMs })
+            .ToListAsync(ct);
+
+        var serverLogs = await debugCtx.Set<ServerLog>()
+            .AsNoTracking()
+            .OrderByDescending(l => l.Timestamp)
+            .Take(30)
+            .Select(l => new { l.Timestamp, l.Status, l.Message, l.DurationMs, TaskName = l.ServerTask != null ? l.ServerTask.TaskName : null })
+            .ToListAsync(ct);
+
+        var sb = new StringBuilder();
+        sb.AppendLine(header);
+
+        sb.AppendLine();
+        sb.AppendLine($"Stuck jobs ({stuckJobs.Count}):");
+        foreach (var j in stuckJobs)
+        {
+            sb.AppendLine($"  {j.Id} kind={j.Kind} state={j.CurrentState} queue={j.Queue} parent={j.ParentJobId} scheduleTime={j.ScheduleTime:HH:mm:ss.fff} worker={j.CurrentWorkerId} keepAlive={j.LastKeepAlive:HH:mm:ss.fff}");
+            foreach (var l in stuckLogs.Where(x => x.JobId == j.Id))
+            {
+                sb.AppendLine($"    [{l.Timestamp:HH:mm:ss.fff}] {l.Level} {l.EventType} — {l.Message}");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"ServerTask rows ({serverTasks.Count}):");
+        foreach (var t in serverTasks)
+        {
+            sb.AppendLine($"  {t.TaskName} interval={t.IntervalSeconds}s lastRun={t.LastRun:HH:mm:ss.fff} status={t.LastStatus} duration={t.LastDurationMs:0.#}ms message={t.LastMessage}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Recent ServerLog entries ({serverLogs.Count}, newest first):");
+        foreach (var l in serverLogs)
+        {
+            sb.AppendLine($"  [{l.Timestamp:HH:mm:ss.fff}] {l.TaskName ?? "<no-task>"} {l.Status} {l.DurationMs:0.#}ms — {l.Message}");
+        }
+
+        return sb.ToString();
     }
 
     public async Task<List<JobLog>> GetJobLogs(Guid jobId)


### PR DESCRIPTION
## Summary

Addresses CI flake in `MessageIntegrationTests_PostgreSql.GivenMultiHandlerMessage_WhenPublished_ThenBothHandlersExecuteAndMessageCompletes` (run `24995946782`, 10s 001ms — exactly the `[TimedFact]` ceiling, i.e. xunit aborted the polling loop). Two changes that work together:

- **Drop `MessageRoutingInterval` from 500ms to 100ms** in the test fixture (matches `OrchestrationInterval`). Production defaults unchanged — only the test harness.
- **Server-state diagnostic dump on test failure.** `WaitForCompletion`'s existing `TimeoutException` branch never ran for `[TimedFact]` timeouts: xunit cancels the polling token first, so the loop exits via `OperationCanceledException` before the deadline check. Hooked the dump into `IntegrationTestBase.DisposeAsync` via `TestContext.Current.TestState.Result` instead, with a fresh 10s `CancellationToken` (xunit's is already cancelled at this point), output to `Console.Error` so it lands in the CI log.

The dump captures:
- Stuck `Job` rows (Enqueued/Processing/Awaiting/Scheduled) with their `JobLog` tail
- Every `ServerTask` row's `LastRun` / `LastStatus` / `LastMessage` / duration — answers "did MessageRouter / Orchestrator actually tick?"
- 30 most-recent `ServerLog` entries with task names attached

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] Target test passes 20/20 in isolation locally
- [x] Full PG suite (~80s) passes 5/5 locally
- [x] Wrote a deliberate-fail throwaway test, confirmed the dump appears under `Error output:` in the test report — populated `ServerTask` rows (`MessageRouting interval=0.1s lastRun=… status=Skipped`) and `ServerLog` entries (`MessageRouting Completed 144ms — Routed 1 messages`). Then deleted the throwaway.
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)