### PR TITLE
docs: add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Moberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -519,3 +519,7 @@ cd src/ui && npm run dev                                         # Dashboard on 
 ```
 
 Requires Docker for tests (Testcontainers + Respawn).
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Add top-level `LICENSE` file (MIT, "Copyright (c) 2026 Moberg" — matches `Copyright` in `src/Directory.Build.props`)
- Add License section to README pointing to `LICENSE`

The csproj metadata already declared `<PackageLicenseExpression>MIT</PackageLicenseExpression>`, so this just makes the repo itself match: GitHub now recognizes the license, and visitors get a clear pointer.

## Test plan
- [x] GitHub renders the LICENSE and shows "MIT" in the repo sidebar
- [x] README License section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)