### PR TITLE
test: dump server-state diagnostics on every integration-test failure

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/FixtureDiagnostics.cs
+++ b/src/tests/Warp.Tests/Fixtures/FixtureDiagnostics.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Warp.Core.Data.Entities;
+using Warp.Core.Entities;
+using Warp.Core.Enums;
+
+namespace Warp.Tests.Fixtures;
+
+/// <summary>
+/// Builds a multi-line diagnostic dump of test-server state — stuck Job rows with their
+/// JobLog tail, every ServerTask row's last run, and the most recent ServerLog entries.
+/// Lives on the fixture (not WarpTestServer) because it's a pure DB read; it doesn't matter
+/// which server published the rows. Callers pass their own <paramref name="ct"/> so the
+/// failure-path call can use a fresh token instead of xunit's already-cancelled one.
+/// </summary>
+public static class FixtureDiagnostics
+{
+    public static Task<string> DumpDiagnosticsAsync(this IDatabaseFixture fixture, string header, CancellationToken ct)
+        => DumpAsync(fixture.CreateContext(), header, ct);
+
+    public static Task<string> DumpDiagnosticsAsync(this IMultiServerDatabaseFixture fixture, string header, CancellationToken ct)
+        => DumpAsync(fixture.CreateContext(), header, ct);
+
+    /// <summary>
+    /// Shared failure-dump tail for integration test bases. On any non-passing test result,
+    /// invokes <paramref name="dumper"/> with a fresh CancellationToken (xunit's is already
+    /// cancelled) and writes the result to stderr so flakes are diagnosable in CI.
+    /// </summary>
+    public static async ValueTask DumpOnFailureAsync(Func<string, CancellationToken, Task<string>> dumper)
+    {
+        var testState = Xunit.TestContext.Current.TestState;
+        if (testState == null || testState.Result == Xunit.TestResult.Passed)
+        {
+            return;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var dump = await dumper(
+                $"Test failed ({testState.Result}). Server-state diagnostics:",
+                cts.Token);
+            await Console.Error.WriteLineAsync(dump);
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync($"Diagnostic dump failed: {ex.Message}");
+        }
+    }
+
+    private static async Task<string> DumpAsync(TestContext debugCtx, string header, CancellationToken ct)
+    {
+        var stuckJobs = await debugCtx.Set<Job>()
+            .AsNoTracking()
+            .Where(j => j.CurrentState == State.Enqueued || j.CurrentState == State.Processing
+                || j.CurrentState == State.Awaiting || j.CurrentState == State.Scheduled)
+            .OrderBy(j => j.CreateTime)
+            .Select(j =>
+                new { j.Id, j.Kind, j.CurrentState, j.ParentJobId, j.Queue, j.ScheduleTime, j.CurrentWorkerId, j.LastKeepAlive })
+            .Take(20)
+            .ToListAsync(ct);
+
+        var stuckIds = stuckJobs.ConvertAll(j => j.Id);
+        var stuckLogs = stuckIds.Count == 0
+            ? []
+            : await debugCtx.Set<JobLog>()
+                .AsNoTracking()
+                .Where(l => stuckIds.Contains(l.JobId))
+                .OrderBy(l => l.Timestamp)
+                .Select(l =>
+                    new { l.JobId, l.Timestamp, l.EventType, l.Level, l.Message })
+                .ToListAsync(ct);
+
+        var serverTasks = await debugCtx.Set<ServerTask>()
+            .AsNoTracking()
+            .OrderBy(t => t.TaskName)
+            .Select(t =>
+                new { t.TaskName, t.IntervalSeconds, t.LastRun, t.LastStatus, t.LastMessage, t.LastDurationMs })
+            .ToListAsync(ct);
+
+        var serverLogs = await debugCtx.Set<ServerLog>()
+            .AsNoTracking()
+            .OrderByDescending(l => l.Timestamp)
+            .Take(30)
+            .Select(l =>
+                new { l.Timestamp, l.Status, l.Message, l.DurationMs, TaskName = l.ServerTask != null ? l.ServerTask.TaskName : null })
+            .ToListAsync(ct);
+
+        var sb = new StringBuilder();
+        sb.AppendLine(header);
+
+        sb.AppendLine();
+        sb.AppendLine($"Stuck jobs ({stuckJobs.Count}):");
+        foreach (var j in stuckJobs)
+        {
+            sb.AppendLine($"  {j.Id} kind={j.Kind} state={j.CurrentState} queue={j.Queue} parent={j.ParentJobId} scheduleTime={j.ScheduleTime:HH:mm:ss.fff} worker={j.CurrentWorkerId} keepAlive={j.LastKeepAlive:HH:mm:ss.fff}");
+            foreach (var l in stuckLogs.Where(x => x.JobId == j.Id))
+            {
+                sb.AppendLine($"    [{l.Timestamp:HH:mm:ss.fff}] {l.Level} {l.EventType} — {l.Message}");
+            }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"ServerTask rows ({serverTasks.Count}):");
+        foreach (var t in serverTasks)
+        {
+            sb.AppendLine($"  {t.TaskName} interval={t.IntervalSeconds}s lastRun={t.LastRun:HH:mm:ss.fff} status={t.LastStatus} duration={t.LastDurationMs:0.#}ms message={t.LastMessage}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Recent ServerLog entries ({serverLogs.Count}, newest first):");
+        foreach (var l in serverLogs)
+        {
+            sb.AppendLine($"  [{l.Timestamp:HH:mm:ss.fff}] {l.TaskName ?? "<no-task>"} {l.Status} {l.DurationMs:0.#}ms — {l.Message}");
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/tests/Warp.Tests/Fixtures/IntegrationTestBase.cs
+++ b/src/tests/Warp.Tests/Fixtures/IntegrationTestBase.cs
@@ -4,54 +4,28 @@ namespace Warp.Tests.Fixtures;
 
 public abstract class IntegrationTestBase : IAsyncLifetime
 {
-    private readonly IDatabaseFixture _fixture;
-
     protected IntegrationTestBase(IDatabaseFixture fixture)
     {
-        _fixture = fixture;
+        Fixture = fixture;
     }
 
-    protected WarpTestServer Server => _fixture.TestServer!;
+    protected IDatabaseFixture Fixture { get; }
 
-    public async ValueTask InitializeAsync()
+    protected WarpTestServer Server => Fixture.TestServer!;
+
+    public virtual async ValueTask InitializeAsync()
     {
         try
         {
-            await _fixture.ResetAsync();
+            await Fixture.ResetAsync();
         }
         catch
         {
             await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            await _fixture.ResetAsync();
+            await Fixture.ResetAsync();
         }
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        // On any non-passing result, dump test-server state to stderr so a flake
-        // in CI is diagnosable instead of opaque. WaitForCompletion's own timeout
-        // path can't fire here — xunit's [TimedFact] cancels the polling token
-        // before WaitForCompletion's deadline branch is reached, so the test
-        // exits via OperationCanceledException, not TimeoutException. This hook
-        // catches that path (and any other failure) using a fresh CancellationToken
-        // since xunit's is already cancelled.
-        var testState = Xunit.TestContext.Current.TestState;
-        if (testState == null || testState.Result == Xunit.TestResult.Passed)
-        {
-            return;
-        }
-
-        try
-        {
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            var dump = await Server.DumpDiagnosticsAsync(
-                $"Test failed ({testState.Result}). Server-state diagnostics:",
-                cts.Token);
-            await Console.Error.WriteLineAsync(dump);
-        }
-        catch (Exception ex)
-        {
-            await Console.Error.WriteLineAsync($"Diagnostic dump failed: {ex.Message}");
-        }
-    }
+    public virtual ValueTask DisposeAsync()
+        => FixtureDiagnostics.DumpOnFailureAsync(Fixture.DumpDiagnosticsAsync);
 }

--- a/src/tests/Warp.Tests/Fixtures/MultiServerIntegrationTestBase.cs
+++ b/src/tests/Warp.Tests/Fixtures/MultiServerIntegrationTestBase.cs
@@ -4,31 +4,32 @@ namespace Warp.Tests.Fixtures;
 
 public abstract class MultiServerIntegrationTestBase : IAsyncLifetime
 {
-    private readonly IMultiServerDatabaseFixture _fixture;
-
     protected MultiServerIntegrationTestBase(IMultiServerDatabaseFixture fixture)
     {
-        _fixture = fixture;
+        Fixture = fixture;
     }
 
-    protected WarpTestServer Server1 => _fixture.Server1;
+    protected IMultiServerDatabaseFixture Fixture { get; }
 
-    protected WarpTestServer Server2 => _fixture.Server2;
+    protected WarpTestServer Server1 => Fixture.Server1;
 
-    protected TestContext CreateContext() => _fixture.CreateContext();
+    protected WarpTestServer Server2 => Fixture.Server2;
 
-    public async ValueTask InitializeAsync()
+    protected TestContext CreateContext() => Fixture.CreateContext();
+
+    public virtual async ValueTask InitializeAsync()
     {
         try
         {
-            await _fixture.ResetAsync();
+            await Fixture.ResetAsync();
         }
         catch
         {
             await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            await _fixture.ResetAsync();
+            await Fixture.ResetAsync();
         }
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public virtual ValueTask DisposeAsync()
+        => FixtureDiagnostics.DumpOnFailureAsync(Fixture.DumpDiagnosticsAsync);
 }

--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -369,84 +368,9 @@ public class WarpTestServer : IAsyncDisposable
             await Task.Delay(200, Xunit.TestContext.Current.CancellationToken);
         }
 
-        throw new TimeoutException(await DumpDiagnosticsAsync(
+        throw new TimeoutException(await _fixture.DumpDiagnosticsAsync(
             $"Not all jobs completed within {(timeout ?? TimeSpan.FromSeconds(30)).TotalSeconds:0.#}s.",
             Xunit.TestContext.Current.CancellationToken));
-    }
-
-    /// <summary>
-    /// Builds a multi-line diagnostic dump of test-server state — stuck Job rows with their
-    /// JobLog tail, every ServerTask row's last run, and the most recent ServerLog entries.
-    /// Used both by <see cref="WaitForCompletion"/> timeouts (own-cancellation path) and by
-    /// <see cref="IntegrationTestBase.DisposeAsync"/> on test failure (xunit-cancellation path).
-    /// Caller passes its own <paramref name="ct"/> so the failure-path call can use a fresh
-    /// token instead of xunit's already-cancelled one.
-    /// </summary>
-    public async Task<string> DumpDiagnosticsAsync(string header, CancellationToken ct)
-    {
-        var debugCtx = CreateContext();
-
-        var stuckJobs = await debugCtx.Set<Job>()
-            .AsNoTracking()
-            .Where(j => j.CurrentState == State.Enqueued || j.CurrentState == State.Processing
-                || j.CurrentState == State.Awaiting || j.CurrentState == State.Scheduled)
-            .OrderBy(j => j.CreateTime)
-            .Select(j => new { j.Id, j.Kind, j.CurrentState, j.ParentJobId, j.Queue, j.ScheduleTime, j.CurrentWorkerId, j.LastKeepAlive })
-            .Take(20)
-            .ToListAsync(ct);
-
-        var stuckIds = stuckJobs.ConvertAll(j => j.Id);
-        var stuckLogs = stuckIds.Count == 0
-            ? []
-            : await debugCtx.Set<JobLog>()
-                .AsNoTracking()
-                .Where(l => stuckIds.Contains(l.JobId))
-                .OrderBy(l => l.Timestamp)
-                .Select(l => new { l.JobId, l.Timestamp, l.EventType, l.Level, l.Message })
-                .ToListAsync(ct);
-
-        var serverTasks = await debugCtx.Set<ServerTask>()
-            .AsNoTracking()
-            .OrderBy(t => t.TaskName)
-            .Select(t => new { t.TaskName, t.IntervalSeconds, t.LastRun, t.LastStatus, t.LastMessage, t.LastDurationMs })
-            .ToListAsync(ct);
-
-        var serverLogs = await debugCtx.Set<ServerLog>()
-            .AsNoTracking()
-            .OrderByDescending(l => l.Timestamp)
-            .Take(30)
-            .Select(l => new { l.Timestamp, l.Status, l.Message, l.DurationMs, TaskName = l.ServerTask != null ? l.ServerTask.TaskName : null })
-            .ToListAsync(ct);
-
-        var sb = new StringBuilder();
-        sb.AppendLine(header);
-
-        sb.AppendLine();
-        sb.AppendLine($"Stuck jobs ({stuckJobs.Count}):");
-        foreach (var j in stuckJobs)
-        {
-            sb.AppendLine($"  {j.Id} kind={j.Kind} state={j.CurrentState} queue={j.Queue} parent={j.ParentJobId} scheduleTime={j.ScheduleTime:HH:mm:ss.fff} worker={j.CurrentWorkerId} keepAlive={j.LastKeepAlive:HH:mm:ss.fff}");
-            foreach (var l in stuckLogs.Where(x => x.JobId == j.Id))
-            {
-                sb.AppendLine($"    [{l.Timestamp:HH:mm:ss.fff}] {l.Level} {l.EventType} — {l.Message}");
-            }
-        }
-
-        sb.AppendLine();
-        sb.AppendLine($"ServerTask rows ({serverTasks.Count}):");
-        foreach (var t in serverTasks)
-        {
-            sb.AppendLine($"  {t.TaskName} interval={t.IntervalSeconds}s lastRun={t.LastRun:HH:mm:ss.fff} status={t.LastStatus} duration={t.LastDurationMs:0.#}ms message={t.LastMessage}");
-        }
-
-        sb.AppendLine();
-        sb.AppendLine($"Recent ServerLog entries ({serverLogs.Count}, newest first):");
-        foreach (var l in serverLogs)
-        {
-            sb.AppendLine($"  [{l.Timestamp:HH:mm:ss.fff}] {l.TaskName ?? "<no-task>"} {l.Status} {l.DurationMs:0.#}ms — {l.Message}");
-        }
-
-        return sb.ToString();
     }
 
     public async Task<List<JobLog>> GetJobLogs(Guid jobId)

--- a/src/tests/Warp.Tests/Notifications/ListenerReconnectDrainTests.cs
+++ b/src/tests/Warp.Tests/Notifications/ListenerReconnectDrainTests.cs
@@ -17,28 +17,18 @@ namespace Warp.Tests.Notifications;
 // up whatever was enqueued during the listener's offline window. Without this, a single
 // transport hiccup would strand every job that arrived during the gap until the next slow poll.
 [GenerateDatabaseTests(FixtureKind.Integration)]
-public abstract class ListenerReconnectDrainTestsBase : IAsyncLifetime
+public abstract class ListenerReconnectDrainTestsBase : IntegrationTestBase
 {
-    private readonly IDatabaseFixture _fixture;
-
-    protected ListenerReconnectDrainTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
-
-    public async ValueTask InitializeAsync()
+    protected ListenerReconnectDrainTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
     {
-        try
-        {
-            await _fixture.ResetAsync();
-        }
-        catch
-        {
-            await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            await _fixture.ResetAsync();
-        }
-
-        await _fixture.TestServer!.ReRegisterServer();
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Server.ReRegisterServer();
+    }
 
     [TimedFact]
     public async Task GivenListenerAlwaysFails_WhenJobEnqueued_ThenReconnectDrainStillDelivers()
@@ -53,7 +43,7 @@ public abstract class ListenerReconnectDrainTestsBase : IAsyncLifetime
         var transport = new ListenFailingTransport();
 
         await using var server = await WarpTestServer.StartAsync(
-            _fixture,
+            Fixture,
             configure: cfg =>
             {
                 cfg.UseDispatcher = true;

--- a/src/tests/Warp.Tests/Notifications/PushFailurePollingBackstopTests.cs
+++ b/src/tests/Warp.Tests/Notifications/PushFailurePollingBackstopTests.cs
@@ -17,28 +17,18 @@ namespace Warp.Tests.Notifications;
 // If this property regresses, any deploy that ships with a broken transport becomes a silent
 // job-loss incident.
 [GenerateDatabaseTests(FixtureKind.Integration)]
-public abstract class PushFailurePollingBackstopTestsBase : IAsyncLifetime
+public abstract class PushFailurePollingBackstopTestsBase : IntegrationTestBase
 {
-    private readonly IDatabaseFixture _fixture;
-
-    protected PushFailurePollingBackstopTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
-
-    public async ValueTask InitializeAsync()
+    protected PushFailurePollingBackstopTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
     {
-        try
-        {
-            await _fixture.ResetAsync();
-        }
-        catch
-        {
-            await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            await _fixture.ResetAsync();
-        }
-
-        await _fixture.TestServer!.ReRegisterServer();
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Server.ReRegisterServer();
+    }
 
     [TimedFact]
     public async Task GivenPushEnabledButTransportBroken_WhenJobEnqueued_ThenPollingStillPicksItUp()
@@ -53,7 +43,7 @@ public abstract class PushFailurePollingBackstopTestsBase : IAsyncLifetime
         var failingTransport = new FailingTransport();
 
         await using var server = await WarpTestServer.StartAsync(
-            _fixture,
+            Fixture,
             configure: cfg =>
             {
                 cfg.UseDispatcher = true;

--- a/src/tests/Warp.Tests/Worker/BatchedCompletionIntegrationTests.cs
+++ b/src/tests/Warp.Tests/Worker/BatchedCompletionIntegrationTests.cs
@@ -10,30 +10,18 @@ using Warp.Worker;
 namespace Warp.Tests.Worker;
 
 [GenerateDatabaseTests(FixtureKind.BatchedCompletion)]
-public abstract class BatchedCompletionIntegrationTestsBase : IAsyncLifetime
+public abstract class BatchedCompletionIntegrationTestsBase : IntegrationTestBase
 {
-    private readonly IDatabaseFixture _fixture;
-
-    protected BatchedCompletionIntegrationTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
-
-    protected WarpTestServer Server => _fixture.TestServer!;
-
-    public async ValueTask InitializeAsync()
+    protected BatchedCompletionIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
     {
-        try
-        {
-            await _fixture.ResetAsync();
-        }
-        catch
-        {
-            await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            await _fixture.ResetAsync();
-        }
-
-        await Server.ReRegisterServer();
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Server.ReRegisterServer();
+    }
 
     [TimedFact(timeout: 60_000)]
     public async Task GivenManyShortJobs_WhenProcessed_ThenAllReachCompletedState()
@@ -140,7 +128,7 @@ public abstract class BatchedCompletionIntegrationTestsBase : IAsyncLifetime
         // Arrange — spin up a test-local server on an isolated queue so the fixture server doesn't race us.
         // A long flush interval ensures completions stay buffered until StopAsync drains them.
         const string isolatedQueue = "batch-shutdown-flush";
-        var server = await WarpTestServer.StartAsync(_fixture, config =>
+        var server = await WarpTestServer.StartAsync(Fixture, config =>
         {
             config.UseDispatcher = true;
             config.WorkerCount = 2;
@@ -170,7 +158,7 @@ public abstract class BatchedCompletionIntegrationTestsBase : IAsyncLifetime
         }
 
         // Assert — after shutdown, all jobs must be persisted as Completed.
-        var ctx = _fixture.CreateContext();
+        var ctx = Fixture.CreateContext();
         var jobs = await ctx.Set<Job>()
             .Where(j => j.Queue == isolatedQueue)
             .AsNoTracking()
@@ -225,7 +213,7 @@ public abstract class BatchedCompletionIntegrationTestsBase : IAsyncLifetime
     {
         // Arrange — isolated server with batching disabled (opt-out path).
         const string isolatedQueue = "batch-size-one";
-        await using var server = await WarpTestServer.StartAsync(_fixture, config =>
+        await using var server = await WarpTestServer.StartAsync(Fixture, config =>
         {
             config.UseDispatcher = true;
             config.WorkerCount = 2;
@@ -246,7 +234,7 @@ public abstract class BatchedCompletionIntegrationTestsBase : IAsyncLifetime
         await server.WaitForCompletion(TimeSpan.FromSeconds(30));
 
         // Assert
-        var ctx = _fixture.CreateContext();
+        var ctx = Fixture.CreateContext();
         var jobs = await ctx.Set<Job>()
             .Where(j => j.Queue == isolatedQueue)
             .CountAsync(j => j.CurrentState == State.Completed, Xunit.TestContext.Current.CancellationToken);

--- a/src/tests/Warp.Tests/Worker/DispatcherShutdownIntegrationTests.cs
+++ b/src/tests/Warp.Tests/Worker/DispatcherShutdownIntegrationTests.cs
@@ -16,28 +16,18 @@ namespace Warp.Tests.Worker;
 //   * StaleJobRecovery — any Processing orphans the first two paths miss are reclaimed
 //     after InvisibilityTimeout
 [GenerateDatabaseTests(FixtureKind.Integration)]
-public abstract class DispatcherShutdownIntegrationTestsBase : IAsyncLifetime
+public abstract class DispatcherShutdownIntegrationTestsBase : IntegrationTestBase
 {
-    private readonly IDatabaseFixture _fixture;
-
-    protected DispatcherShutdownIntegrationTestsBase(IDatabaseFixture fixture) => _fixture = fixture;
-
-    public async ValueTask InitializeAsync()
+    protected DispatcherShutdownIntegrationTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
     {
-        try
-        {
-            await _fixture.ResetAsync();
-        }
-        catch
-        {
-            await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            await _fixture.ResetAsync();
-        }
-
-        await _fixture.TestServer!.ReRegisterServer();
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public override async ValueTask InitializeAsync()
+    {
+        await base.InitializeAsync();
+        await Server.ReRegisterServer();
+    }
 
     [TimedFact(30_000)]
     public async Task GivenWorkInProgress_WhenServerReplaced_ThenAllJobsEventuallyComplete()
@@ -49,7 +39,7 @@ public abstract class DispatcherShutdownIntegrationTestsBase : IAsyncLifetime
         const string queue = "dispatcher-shutdown-baton";
         var invisibilityTimeout = TimeSpan.FromSeconds(2);
 
-        var serverA = await WarpTestServer.StartAsync(_fixture, cfg =>
+        var serverA = await WarpTestServer.StartAsync(Fixture, cfg =>
         {
             cfg.UseDispatcher = true;
             cfg.WorkerCount = 2;
@@ -74,7 +64,7 @@ public abstract class DispatcherShutdownIntegrationTestsBase : IAsyncLifetime
         // A leaves the DB in, B drives every job to Completed.
         await serverA.DisposeAsync();
 
-        await using var serverB = await WarpTestServer.StartAsync(_fixture, cfg =>
+        await using var serverB = await WarpTestServer.StartAsync(Fixture, cfg =>
         {
             cfg.UseDispatcher = true;
             cfg.WorkerCount = 2;
@@ -88,7 +78,7 @@ public abstract class DispatcherShutdownIntegrationTestsBase : IAsyncLifetime
         // one recovery sweep (~0.5s) + handler time. 20s leaves comfortable CI headroom.
         await serverB.WaitForCompletion(timeout: TimeSpan.FromSeconds(20));
 
-        var ctx = _fixture.CreateContext();
+        var ctx = Fixture.CreateContext();
         var jobs = await ctx.Set<Job>()
             .Where(j => j.Queue == queue)
             .AsNoTracking()


### PR DESCRIPTION
## Summary
- Move `DumpDiagnosticsAsync` off `WarpTestServer` onto `IDatabaseFixture` / `IMultiServerDatabaseFixture` extensions in a new `FixtureDiagnostics` class — it's a pure DB read, doesn't belong on the server type.
- Extract the failure-dump `DisposeAsync` body into `FixtureDiagnostics.DumpOnFailureAsync` so `IntegrationTestBase` and `MultiServerIntegrationTestBase` share one one-liner instead of duplicating the body.
- Migrate `BatchedCompletion`, `DispatcherShutdown`, `ListenerReconnectDrain`, and `PushFailurePollingBackstop` bases to inherit from `IntegrationTestBase`. They were duplicating the `IAsyncLifetime` boilerplate just to call `Server.ReRegisterServer()` after reset — now they override `InitializeAsync`. As a side effect, every integration test base now writes a stuck-job + JobLog + ServerTask + ServerLog dump to stderr on any non-passing result.
- `MultiServerIntegrationTestBase` had no failure-dump hook at all before this; now it does.

Motivation: `DispatcherShutdownIntegrationTests_SqlServer.GivenWorkInProgress_WhenServerReplaced_ThenAllJobsEventuallyComplete` flaked in CI on PR #150 with only a `TimeoutException` and EF noise — no diagnostic info — because the test bypassed `IntegrationTestBase`. Next flake will include the actual stuck-state dump.

## Test plan
- [x] `dotnet build Warp.slnx` — 0 warnings, 0 errors
- [x] `dotnet test --project tests/Warp.Tests/Warp.Tests.csproj` — 1025/1025 passed (1m 43s, both PG + SQL Server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)