### PR TITLE
docs: readable anchors for version headings via remark plugin

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,8 +4,6 @@ sidebar_position: 6
 
 # Releases
 
-<a id="v0-12-0"></a>
-
 ## 0.12.0
 
 *2026-05-07*
@@ -186,8 +184,6 @@ Full docs at [features/http](features/http). Shipped in [#154](https://github.co
 
 - **HTTP request-isolation suite** — five concurrency tests bombard the in-memory test app with 200 parallel requests (50 for streaming) and assert per-request DI scope (N requests → N distinct `ScopeProbe` constructions), no `AsyncLocal<T>` bleed between handlers, no request-payload crossover, pipeline behaviors observe per-request inputs, and concurrent `IStreamRequest` endpoints emit only their own block of items.
 
-<a id="v0-11-0"></a>
-
 ## 0.11.0
 
 *2026-05-06*
@@ -222,8 +218,6 @@ Stability release. No breaking API changes. Several latent product bugs surfaced
 - **Enterprise landing page redesign** — new home page with a Moberg-aligned enterprise aesthetic, replacing the prior tagline-driven layout ([#148](https://github.com/moberghr/warp/pull/148), [#150](https://github.com/moberghr/warp/pull/150)).
 
 ---
-
-<a id="v0-10-0"></a>
 
 ## 0.10.0
 
@@ -295,8 +289,6 @@ Breaking release because of both the rename and the removal of reflection-based 
 
 ---
 
-<a id="v0-9-1"></a>
-
 ## 0.9.1
 
 *2026-04-21*
@@ -311,8 +303,6 @@ Breaking release because of both the rename and the removal of reflection-based 
 - **Docs site dependencies** — Docusaurus 3.9.2 → 3.10.0, added `@docusaurus/faster` (required by 3.10 with `future.v4`), and pinned `serialize-javascript ^7.0.5` via `overrides` to close [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) — the build-chain DoS that Docusaurus's bundler transitively pulled in. `npm audit` now reports 0 vulnerabilities on both frontends.
 
 ---
-
-<a id="v0-9-0"></a>
 
 ## 0.9.0
 
@@ -366,8 +356,6 @@ Breaking release because of the provider package split and the DI lambda API.
 
 ---
 
-<a id="v0-8-0"></a>
-
 ## 0.8.0
 
 *2026-04-19*
@@ -403,8 +391,6 @@ Breaking release because of the provider package split and the DI lambda API.
 - **`StaleJobRecoveryTask.RequeueStaleJobs` removed** — Replaced by `RecoverStaleJobs` returning `StaleJobRecoveryResult` (includes `Requeued`, `Failed`, `Deleted` counts). No `[Obsolete]` bridge; callers must migrate to the new signature.
 
 ---
-
-<a id="v0-7-0"></a>
 
 ## 0.7.0
 
@@ -453,8 +439,6 @@ This is a large release with several breaking changes. Plan the upgrade accordin
 
 ---
 
-<a id="v0-6-1"></a>
-
 ## 0.6.1
 
 *2026-04-13*
@@ -468,8 +452,6 @@ This is a large release with several breaking changes. Plan the upgrade accordin
 - **Fix all 401 build warnings** — Zero warnings across the entire solution. Fixes include: regex DoS hardening (NonBacktracking), collection expression simplification, constructor formatting, CancellationToken propagation, string.Equals usage, and async call consistency. All rule suppressions via `.editorconfig` — no `#pragma` or `[SuppressMessage]` attributes.
 
 ---
-
-<a id="v0-6-0"></a>
 
 ## 0.6.0
 
@@ -508,8 +490,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 
 ---
 
-<a id="v0-5-0"></a>
-
 ## 0.5.0
 
 *2026-04-09*
@@ -538,8 +518,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 
 ---
 
-<a id="v0-4-0"></a>
-
 ## 0.4.0
 
 *2026-04-08*
@@ -553,8 +531,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 - [GitHub Release](https://github.com/moberghr/warp/releases/tag/0.4.0)
 
 ---
-
-<a id="v0-3-0"></a>
 
 ## 0.3.0
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,6 +1,37 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import {visit} from 'unist-util-visit';
+
+// Maps a top-level version-pattern heading (e.g. `## 0.12.0`) to an explicit
+// id like `v0-12-0`. Without this, Docusaurus's slugifier would strip the
+// dots and produce unreadable anchors like `#0120`. We can't use the
+// `## 0.12.0 {#v0-12-0}` syntax because Docusaurus 3.10's stricter MDX
+// expression parser rejects `{#...}` before the heading-id remark plugin
+// sees it (acorn refuses `#v0-12-0` as a JS expression).
+const versionAnchorPlugin = () => {
+  return (tree: any) => {
+    visit(tree, 'heading', (node: any) => {
+      if (node.depth !== 2 || !node.children?.length) {
+        return;
+      }
+      const text = node.children
+        .filter((c: any) => c.type === 'text')
+        .map((c: any) => c.value)
+        .join('');
+      const match = /^(\d+\.\d+(?:\.\d+)?)$/.exec(text.trim());
+      if (!match) {
+        return;
+      }
+      const id = 'v' + match[1].replace(/\./g, '-');
+      node.data = node.data || {};
+      node.data.hProperties = node.data.hProperties || {};
+      node.data.hProperties.id = id;
+      // Keep `id` on the AST itself so docusaurus's TOC extractor uses it.
+      node.data.id = id;
+    });
+  };
+};
 
 const config: Config = {
   title: 'Warp',
@@ -52,6 +83,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/moberghr/warp/tree/main/website/',
+          beforeDefaultRemarkPlugins: [versionAnchorPlugin],
         },
         blog: false,
         theme: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.0",

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.0",


### PR DESCRIPTION
## Summary
The earlier fix shipped `<a id="v0-12-0"></a>` as a *secondary* anchor before each heading, but the heading itself still had Docusaurus's auto-generated id (`0120` from `## 0.12.0`). The right-side TOC and the # permalink icon linked to the auto id, so the readable URL never actually appeared.

This PR adds a tiny inline remark plugin that detects version-pattern h2 headings (`X.Y` / `X.Y.Z`) and rewrites their id to `v0-12-0` form. Markdown heading is preserved (TOC extractor still sees it), only the emitted id changes.

Why we can't use Docusaurus's documented `{#id}` syntax: in 3.10, the stricter MDX expression parser hands `{#v0-12-0}` to acorn before the heading-id remark plugin can intercept it, and acorn rejects `#` at expression start. `format: md` frontmatter doesn't disable this — that flag only governs HTML→JSX coercion.

## Verified locally
- `<h2 id="v0-12-0">0.12.0</h2>` with `.anchor` / `.hash-link` classes intact.
- Right-side TOC links use `#v0-12-0`, `#v0-11-0`, etc.
- Build clean against the locked Docusaurus 3.10.0.

## Test plan
- [ ] After merge, deploy-docs workflow republishes; visit `https://moberghr.github.io/warp/docs/releases` and confirm `#v0-12-0` URL appears in the address bar when clicking version headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)