### PR TITLE
Lower default test retry count; dump every Warp table on failure

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/FixtureDiagnostics.cs
+++ b/src/tests/Warp.Tests/Fixtures/FixtureDiagnostics.cs
@@ -2,16 +2,21 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Warp.Core.Data.Entities;
 using Warp.Core.Entities;
-using Warp.Core.Enums;
+using EFWorker = Warp.Core.Data.Entities.Worker;
+using EFWorkerGroup = Warp.Core.Data.Entities.WorkerGroup;
 
 namespace Warp.Tests.Fixtures;
 
 /// <summary>
-/// Builds a multi-line diagnostic dump of test-server state — stuck Job rows with their
-/// JobLog tail, every ServerTask row's last run, and the most recent ServerLog entries.
-/// Lives on the fixture (not WarpTestServer) because it's a pure DB read; it doesn't matter
-/// which server published the rows. Callers pass their own <paramref name="ct"/> so the
-/// failure-path call can use a fresh token instead of xunit's already-cancelled one.
+/// Builds a multi-line diagnostic dump of test-server state — every Job row with its full JobLog
+/// history, every ServerTask row's last run, and every ServerLog entry. Lives on the fixture
+/// (not WarpTestServer) because it's a pure DB read; it doesn't matter which server published the
+/// rows. Callers pass their own <paramref name="ct"/> so the failure-path call can use a fresh
+/// token instead of xunit's already-cancelled one.
+/// <para>
+/// Runs only on test failure, so size is not the constraint — completeness is. A future-debugger
+/// reading a CI flake should not have to wonder whether a missing job was filtered out.
+/// </para>
 /// </summary>
 public static class FixtureDiagnostics
 {
@@ -47,26 +52,78 @@ public static class FixtureDiagnostics
 
     private static async Task<string> DumpAsync(TestContext debugCtx, string header, CancellationToken ct)
     {
-        var stuckJobs = await debugCtx.Set<Job>()
+        var stateHistogram = await debugCtx.Set<Job>()
             .AsNoTracking()
-            .Where(j => j.CurrentState == State.Enqueued || j.CurrentState == State.Processing
-                || j.CurrentState == State.Awaiting || j.CurrentState == State.Scheduled)
-            .OrderBy(j => j.CreateTime)
-            .Select(j =>
-                new { j.Id, j.Kind, j.CurrentState, j.ParentJobId, j.Queue, j.ScheduleTime, j.CurrentWorkerId, j.LastKeepAlive })
-            .Take(20)
+            .GroupBy(j => new { j.Type, j.CurrentState })
+            .Select(g => new { g.Key.Type, g.Key.CurrentState, Count = g.Count() })
             .ToListAsync(ct);
 
-        var stuckIds = stuckJobs.ConvertAll(j => j.Id);
-        var stuckLogs = stuckIds.Count == 0
-            ? []
-            : await debugCtx.Set<JobLog>()
-                .AsNoTracking()
-                .Where(l => stuckIds.Contains(l.JobId))
-                .OrderBy(l => l.Timestamp)
-                .Select(l =>
-                    new { l.JobId, l.Timestamp, l.EventType, l.Level, l.Message })
-                .ToListAsync(ct);
+        var allJobs = await debugCtx.Set<Job>()
+            .AsNoTracking()
+            .OrderBy(j => j.CreateTime)
+            .Select(j => new
+            {
+                j.Id,
+                j.Kind,
+                j.Type,
+                j.CurrentState,
+                j.ParentJobId,
+                j.Queue,
+                j.CreateTime,
+                j.ScheduleTime,
+                j.CurrentWorkerId,
+                j.LastKeepAlive,
+                j.ExpireAt,
+                j.CancellationMode,
+                j.Metadata,
+            })
+            .ToListAsync(ct);
+
+        var allLogs = await debugCtx.Set<JobLog>()
+            .AsNoTracking()
+            .OrderBy(l => l.Timestamp)
+            .Select(l => new { l.JobId, l.Timestamp, l.EventType, l.Level, l.Message, l.Exception, l.WorkerId, l.DurationMs })
+            .ToListAsync(ct);
+
+        var servers = await debugCtx.Set<Server>()
+            .AsNoTracking()
+            .OrderBy(s => s.StartedTime)
+            .ToListAsync(ct);
+
+        var workers = await debugCtx.Set<EFWorker>()
+            .AsNoTracking()
+            .OrderBy(w => w.StartedTime)
+            .ToListAsync(ct);
+
+        var workerGroups = await debugCtx.Set<EFWorkerGroup>()
+            .AsNoTracking()
+            .OrderBy(g => g.ServerId)
+            .ToListAsync(ct);
+
+        var recurringJobs = await debugCtx.Set<RecurringJob>()
+            .AsNoTracking()
+            .OrderBy(r => r.Name)
+            .ToListAsync(ct);
+
+        var recurringJobLogs = await debugCtx.Set<RecurringJobLog>()
+            .AsNoTracking()
+            .OrderBy(l => l.CreatedAt)
+            .ToListAsync(ct);
+
+        var counters = await debugCtx.Set<Counter>()
+            .AsNoTracking()
+            .OrderBy(c => c.Key)
+            .ToListAsync(ct);
+
+        var statistics = await debugCtx.Set<Statistic>()
+            .AsNoTracking()
+            .OrderBy(s => s.Key)
+            .ToListAsync(ct);
+
+        var circuitStates = await debugCtx.Set<CircuitBreakerState>()
+            .AsNoTracking()
+            .OrderBy(s => s.GroupKey)
+            .ToListAsync(ct);
 
         var serverTasks = await debugCtx.Set<ServerTask>()
             .AsNoTracking()
@@ -77,13 +134,14 @@ public static class FixtureDiagnostics
 
         var serverLogs = await debugCtx.Set<ServerLog>()
             .AsNoTracking()
-            .OrderByDescending(l => l.Timestamp)
-            .Take(30)
+            .OrderBy(l => l.Timestamp)
             .Select(l =>
                 new { l.Timestamp, l.Status, l.Message, l.DurationMs, TaskName = l.ServerTask != null ? l.ServerTask.TaskName : null })
             .ToListAsync(ct);
 
         var lifecycleEvents = ServerLifecycleTrace.Drain();
+
+        var logsByJob = allLogs.GroupBy(l => l.JobId).ToDictionary(g => g.Key, g => g.ToList());
 
         var sb = new StringBuilder();
         sb.AppendLine(header);
@@ -100,14 +158,88 @@ public static class FixtureDiagnostics
         }
 
         sb.AppendLine();
-        sb.AppendLine($"Stuck jobs ({stuckJobs.Count}):");
-        foreach (var j in stuckJobs)
+        sb.AppendLine($"Job state histogram ({stateHistogram.Count} groups):");
+        foreach (var g in stateHistogram.OrderBy(x => x.Type).ThenBy(x => x.CurrentState))
         {
-            sb.AppendLine($"  {j.Id} kind={j.Kind} state={j.CurrentState} queue={j.Queue} parent={j.ParentJobId} scheduleTime={j.ScheduleTime:HH:mm:ss.fff} worker={j.CurrentWorkerId} keepAlive={j.LastKeepAlive:HH:mm:ss.fff}");
-            foreach (var l in stuckLogs.Where(x => x.JobId == j.Id))
+            sb.AppendLine($"  {ShortTypeName(g.Type)} {g.CurrentState} = {g.Count}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"All jobs ({allJobs.Count}):");
+        foreach (var j in allJobs)
+        {
+            sb.AppendLine(
+                $"  {j.Id} kind={j.Kind} type={ShortTypeName(j.Type)} state={j.CurrentState} queue={j.Queue} " +
+                $"parent={j.ParentJobId} createTime={j.CreateTime:HH:mm:ss.fff} scheduleTime={j.ScheduleTime:HH:mm:ss.fff} " +
+                $"worker={j.CurrentWorkerId} keepAlive={j.LastKeepAlive:HH:mm:ss.fff} expireAt={j.ExpireAt:HH:mm:ss.fff} " +
+                $"cancel={j.CancellationMode} metadata={j.Metadata}");
+            if (logsByJob.TryGetValue(j.Id, out var logs))
             {
-                sb.AppendLine($"    [{l.Timestamp:HH:mm:ss.fff}] {l.Level} {l.EventType} — {l.Message}");
+                foreach (var l in logs)
+                {
+                    sb.AppendLine($"    [{l.Timestamp:HH:mm:ss.fff}] {l.Level} {l.EventType} worker={l.WorkerId} duration={l.DurationMs:0.#}ms — {l.Message}");
+                    if (!string.IsNullOrEmpty(l.Exception))
+                    {
+                        sb.AppendLine($"      {IndentLines(l.Exception)}");
+                    }
+                }
             }
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Servers ({servers.Count}):");
+        foreach (var s in servers)
+        {
+            sb.AppendLine($"  {s.Id} name={s.ServerName} started={s.StartedTime:HH:mm:ss.fff} lastHeartbeat={s.LastHeartbeatTime:HH:mm:ss.fff} services={s.ServiceCount} pausedAt={s.PausedAt:HH:mm:ss.fff}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"WorkerGroups ({workerGroups.Count}):");
+        foreach (var g in workerGroups)
+        {
+            sb.AppendLine($"  {g.Id} server={g.ServerId} workers={g.WorkerCount} queues={g.Queues} pollMs={g.PollingIntervalMs} pausedAt={g.PausedAt:HH:mm:ss.fff}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Workers ({workers.Count}):");
+        foreach (var w in workers)
+        {
+            sb.AppendLine($"  {w.Id} server={w.ServerId} group={w.WorkerGroupId} started={w.StartedTime:HH:mm:ss.fff} lastHeartbeat={w.LastHeartbeatTime:HH:mm:ss.fff}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"RecurringJobs ({recurringJobs.Count}):");
+        foreach (var r in recurringJobs)
+        {
+            sb.AppendLine($"  {r.Id} name={r.Name} type={ShortTypeName(r.Type)} cron={r.Cron} queue={r.Queue} next={r.NextExecution:HH:mm:ss.fff} last={r.LastExecution:HH:mm:ss.fff} disabled={r.DisabledAt:HH:mm:ss.fff}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"RecurringJobLog ({recurringJobLogs.Count}):");
+        foreach (var l in recurringJobLogs)
+        {
+            sb.AppendLine($"  [{l.CreatedAt:HH:mm:ss.fff}] recurring={l.RecurringJobId} job={l.JobId} skipped={l.Skipped}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Counters ({counters.Count}):");
+        foreach (var c in counters)
+        {
+            sb.AppendLine($"  {c.Key} = {c.Value}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"Statistics ({statistics.Count}):");
+        foreach (var s in statistics)
+        {
+            sb.AppendLine($"  {s.Key} = {s.Value}");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"CircuitBreakerState ({circuitStates.Count}):");
+        foreach (var s in circuitStates)
+        {
+            sb.AppendLine($"  {s.GroupKey} state={s.State} failures={s.FailureCount} openUntil={s.OpenUntil:HH:mm:ss.fff} lastFailure={s.LastFailureAt:HH:mm:ss.fff}");
         }
 
         sb.AppendLine();
@@ -118,7 +250,7 @@ public static class FixtureDiagnostics
         }
 
         sb.AppendLine();
-        sb.AppendLine($"Recent ServerLog entries ({serverLogs.Count}, newest first):");
+        sb.AppendLine($"ServerLog entries ({serverLogs.Count}, oldest first):");
         foreach (var l in serverLogs)
         {
             sb.AppendLine($"  [{l.Timestamp:HH:mm:ss.fff}] {l.TaskName ?? "<no-task>"} {l.Status} {l.DurationMs:0.#}ms — {l.Message}");
@@ -126,4 +258,21 @@ public static class FixtureDiagnostics
 
         return sb.ToString();
     }
+
+    private static string ShortTypeName(string? assemblyQualifiedName)
+    {
+        if (string.IsNullOrEmpty(assemblyQualifiedName))
+        {
+            return "<null>";
+        }
+
+        var commaIdx = assemblyQualifiedName.IndexOf(',', StringComparison.Ordinal);
+        var fullName = commaIdx > 0 ? assemblyQualifiedName[..commaIdx] : assemblyQualifiedName;
+        var dotIdx = fullName.LastIndexOf('.');
+
+        return dotIdx > 0 ? fullName[(dotIdx + 1)..] : fullName;
+    }
+
+    private static string IndentLines(string text)
+        => text.Replace("\n", "\n      ", StringComparison.Ordinal);
 }

--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -221,7 +221,7 @@ public class WarpTestServer : IAsyncDisposable
 
                     config.AddRetry(o =>
                     {
-                        o.MaxRetries = 3;
+                        o.MaxRetries = 1;
                         o.Delays = [1];
                     });
                     config.AddMutex();


### PR DESCRIPTION
## Summary

- Default `MaxRetries: 3 → 1` in `WarpTestServer` to halve retry-loop wall time and shrink the dispatcher/shutdown race window that produced the recent BatchedCompletion `GivenMixedOutcomes` flake.
- Removed all caps from the failure-dump; every Warp table is now read (`Job`, `JobLog`, `Server`, `Worker`, `WorkerGroup`, `RecurringJob`, `RecurringJobLog`, `Counter`, `Statistic`, `CircuitBreakerState`, `ServerTask`, `ServerLog`) plus a `(Type, CurrentState)` histogram for triage.

## Background

CI flake on https://github.com/moberghr/warp/actions/runs/25484443774 — `BatchedCompletionIntegrationTests_SqlServer.GivenMixedOutcomes_WhenProcessed_ThenStatesMatch` failed with `failed.ShouldBe(15)` actual `2`. Diagnostic dump showed 3 jobs stuck at `Enqueued` (signature of `WarpDispatcher.UnclaimUndelivered` firing on shutdown). Could not reproduce locally in isolation; needs the concurrent class-parallel load.

The dump's `Take(20)` cap on stuck jobs and exclusion of terminal states meant 10 of the 15 failing-type jobs were unaccounted for — we couldn't tell whether the retry pipeline misfired, the worker batch dropped them, or something else.

## Changes

**`WarpTestServer.cs:224`** — `MaxRetries: 3 → 1`. No test depends on the default count specifically; every retry-sensitive test sets its own value via `Configure<IRetryMetadata>` per-job or in its `configure` callback.

**`FixtureDiagnostics.cs`** — caps removed, every table dumped. JobLog now includes `Exception`, `WorkerId`, `DurationMs`. New `(Type, CurrentState)` histogram up top.

## Test plan

- [x] SQL Server suite 7× 444/444
- [x] PostgreSQL suite 1× 445/445
- [x] Build clean, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)