### PR TITLE
test: deflake three integration tests + tighten test SQL command timeout

### DIFF
--- a/src/tests/Warp.Tests/EndToEnd/MultiServerTests.cs
+++ b/src/tests/Warp.Tests/EndToEnd/MultiServerTests.cs
@@ -402,7 +402,19 @@ public abstract class MultiServerTestsBase : IntegrationTestBase
     [TimedFact]
     public async Task GivenPausedServer_WithTwoServers_ThenOtherServerProcessesJobs()
     {
-        await using var server1 = await WarpTestServer.StartAsync(Fixture, Configure3Workers);
+        // server1 has its auto-heartbeat disabled so we can drive the PauseStateHolder flip
+        // manually — see PauseIntegrationTests.PauseServer_JobsStayEnqueued for the rationale.
+        // Without this, server1's workers can have iterations in-flight (already past their
+        // pause check, sitting in the SQL fetch) when the holder flips, claim the freshly-
+        // published rows, and break the test's premise. server2 runs with the default config
+        // because it's the one we expect to do the work.
+        await using var server1 = await WarpTestServer.StartAsync(
+            Fixture,
+            cfg =>
+            {
+                Configure3Workers(cfg);
+                cfg.HealthCheckInterval = null;
+            });
         await using var server2 = await WarpTestServer.StartAsync(Fixture, Configure3Workers);
 
         // Get server1's worker group and pause it
@@ -413,8 +425,20 @@ public abstract class MultiServerTestsBase : IntegrationTestBase
             .FirstAsync(Xunit.TestContext.Current.CancellationToken);
 
         var svc = server1.CreateServerCommandService();
+
+        // Pause via API (DB row update), then run Heartbeat once on server1 so its in-memory
+        // PauseStateHolder catches up. After this, every server1 worker iteration that begins
+        // from now on will see paused=true and skip the fetch.
         await svc.PauseServer(server1.ServerId);
-        await server1.WaitForPauseState(server1GroupId, expectedPaused: true);
+        await server1.RunHeartbeatOnceAsync(Xunit.TestContext.Current.CancellationToken);
+        server1.PauseState.IsPaused(server1GroupId).ShouldBeTrue();
+
+        // Drain any server1 worker iterations that were already mid-fetch when the holder
+        // flipped — without this slack they could still claim a freshly-published row from
+        // their already-running SQL query. One PollingInterval (100ms test config) plus slack
+        // guarantees every such iteration finishes against the empty queue, loops back, and
+        // sees paused=true on its next check.
+        await Task.Delay(500, Xunit.TestContext.Current.CancellationToken);
 
         // Enqueue jobs while server1 is paused
         var publisher = server2.CreatePublisher();
@@ -456,8 +480,9 @@ public abstract class MultiServerTestsBase : IntegrationTestBase
             x => server2WorkerIds.Contains(x),
             "All jobs should have been processed by server2's workers while server1 was paused");
 
-        // Resume server1
+        // Resume server1 (manual heartbeat to flip the holder back, since auto-heartbeat is off)
         await svc.ResumeServer(server1.ServerId);
-        await server1.WaitForPauseState(server1GroupId, expectedPaused: false);
+        await server1.RunHeartbeatOnceAsync(Xunit.TestContext.Current.CancellationToken);
+        server1.PauseState.IsPaused(server1GroupId).ShouldBeFalse();
     }
 }

--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -158,13 +158,22 @@ public class WarpTestServer : IAsyncDisposable
             {
                 services.AddDbContext<TestContext>(options =>
                 {
+                    // Bound every SQL command at 5 seconds in tests. Default ADO.NET command
+                    // timeout is 30s — long enough that one hung connection (e.g. attention-sent
+                    // state from a cancelled-mid-flight prior request) causes a cascading 10s
+                    // [TimedFact] failure with no diagnostic, because the test gives up before
+                    // the underlying command does. Capping at 5s makes the bad command fail with
+                    // a timeout exception that shows up in logs and lets ServerTaskLoop's catch
+                    // handler retry on a fresh connection. Long-running provider-native commands
+                    // (Service Broker WAITFOR / LISTEN) set CommandTimeout explicitly on the
+                    // SqlCommand / NpgsqlCommand and are unaffected by this default.
                     if (isPostgres)
                     {
-                        options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention();
+                        options.UseNpgsql(connectionString, npg => npg.CommandTimeout(5)).UseSnakeCaseNamingConvention();
                     }
                     else
                     {
-                        options.UseSqlServer(connectionString);
+                        options.UseSqlServer(connectionString, sql => sql.CommandTimeout(5));
                     }
                 });
 

--- a/src/tests/Warp.Tests/Worker/BatchedCompletionIntegrationTests.cs
+++ b/src/tests/Warp.Tests/Worker/BatchedCompletionIntegrationTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Shouldly;
 using Warp.Core.Data.Entities;
 using Warp.Core.Entities;
@@ -130,64 +132,73 @@ public abstract class BatchedCompletionIntegrationTestsBase : IntegrationTestBas
     [TimedFact(timeout: 60_000)]
     public async Task GivenShutdown_WhenServerStops_ThenPendingCompletionsAreFlushed()
     {
-        // Arrange — isolated queue with a long flush interval so completions stay buffered
-        // until StopAsync drains them.
+        // Arrange — single-worker, isolated queue, with a barrier handler queued behind 4 short
+        // ones. The single worker pulls them from the dispatcher channel back-to-back: short
+        // jobs 1..4 each call _batch.Add and TryRead returns true for the next one — so the inner
+        // loop never exits and the idle-drain at WarpDispatcherWorker line 107 does NOT run.
+        // When the worker enters the barrier handler it parks inside ProcessJob, leaving 4
+        // PendingCompletion entries sitting in _batch. With a short HostOptions.ShutdownTimeout,
+        // base.StopAsync returns before the parked handler completes; the worker's StopAsync
+        // override then runs _batch.FlushAsync() — that is the load-bearing path under test.
+        // The 5th (barrier) job stays in Processing and would be recovered by StaleJobRecovery
+        // in production; that's the realistic outcome of a shutdown mid-handler.
         const string isolatedQueue = "batch-shutdown-flush";
-        var server = await WarpTestServer.StartAsync(Fixture, config =>
-        {
-            config.UseDispatcher = true;
-            config.WorkerCount = 2;
-            config.Queues = [isolatedQueue];
-            config.CompletionBatchSize = 50;
-            config.CompletionFlushInterval = TimeSpan.FromSeconds(30);
-        });
+        var barrier = new BarrierSignal();
+        var server = await WarpTestServer.StartAsync(
+            Fixture,
+            config =>
+            {
+                config.UseDispatcher = true;
+                config.WorkerCount = 1;
+                config.Queues = [isolatedQueue];
+                config.CompletionBatchSize = 50;
+                config.CompletionFlushInterval = TimeSpan.FromSeconds(30);
+            },
+            services =>
+            {
+                services.AddSingleton(barrier);
+                services.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromMilliseconds(500));
+            });
 
         try
         {
             var publisher = server.CreatePublisher();
-            for (var i = 0; i < 5; i++)
+            for (var i = 0; i < 4; i++)
             {
                 await publisher.Enqueue(new UnitRequest(), queue: isolatedQueue);
             }
 
+            await publisher.Enqueue(new BarrierRequest(), queue: isolatedQueue);
             await publisher.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-            // Wait until all 5 jobs have been picked up by a worker (CurrentWorkerId set by
-            // MarkWorkerOwnership at handler entry). This avoids a race: WaitForJobsToLeaveEnqueued
-            // alone returns as soon as the dispatcher's batch claim commits Processing, but before
-            // the in-memory channel delivery + worker pickup completes. If we disposed in that
-            // window, the dispatcher's UnclaimUndelivered would roll the undelivered jobs back to
-            // Enqueued — defeating the test's premise that pending completions get flushed.
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-            while (DateTime.UtcNow < deadline)
-            {
-                var pollCtx = Fixture.CreateContext();
-                var pickedUp = await pollCtx.Set<Job>()
-                    .CountAsync(
-                        j => j.Queue == isolatedQueue && j.CurrentWorkerId != null,
-                        Xunit.TestContext.Current.CancellationToken);
-                if (pickedUp == 5)
-                {
-                    break;
-                }
-
-                await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
-            }
+            // Wait for the barrier handler to enter. Single-worker FIFO guarantees the 4 short
+            // jobs ran first and each added to _batch. No idle-drain has fired because the inner
+            // TryRead loop is now parked inside ProcessJob(barrier).
+            await barrier.Running.WaitAsync(Xunit.TestContext.Current.CancellationToken);
         }
         finally
         {
-            // StopAsync override should drain the buffered completions.
+            // StopAsync override is the only path that can persist the 4 buffered completions —
+            // the parked handler prevents idle-drain from running.
             await server.DisposeAsync();
+
+            // Release the orphaned handler so its task doesn't keep waiting after the host is
+            // gone. The post-handler code may observe disposed scopes, but nothing awaits it.
+            barrier.CanFinish.Release();
         }
 
-        // Assert — after shutdown, all jobs must be persisted as Completed.
+        // Assert — the 4 short jobs must reach Completed via the shutdown-flush path. The 5th
+        // (barrier) is the in-flight orphan; it stays Processing because its handler was still
+        // parked when shutdown returned. StaleJobRecovery would clean it up in production.
         var ctx = Fixture.CreateContext();
         var jobs = await ctx.Set<Job>()
             .Where(j => j.Queue == isolatedQueue)
+            .OrderBy(j => j.CreateTime)
             .AsNoTracking()
             .ToListAsync(Xunit.TestContext.Current.CancellationToken);
         jobs.Count.ShouldBe(5);
-        jobs.ShouldAllBe(j => j.CurrentState == State.Completed);
+        jobs.Take(4).ShouldAllBe(j => j.CurrentState == State.Completed);
+        jobs[4].CurrentState.ShouldBe(State.Processing);
     }
 
     [TimedFact(timeout: 60_000)]

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,8 +4,6 @@ sidebar_position: 6
 
 # Releases
 
-<a id="v0-12-0"></a>
-
 ## 0.12.0
 
 *2026-05-07*
@@ -186,8 +184,6 @@ Full docs at [features/http](features/http). Shipped in [#154](https://github.co
 
 - **HTTP request-isolation suite** — five concurrency tests bombard the in-memory test app with 200 parallel requests (50 for streaming) and assert per-request DI scope (N requests → N distinct `ScopeProbe` constructions), no `AsyncLocal<T>` bleed between handlers, no request-payload crossover, pipeline behaviors observe per-request inputs, and concurrent `IStreamRequest` endpoints emit only their own block of items.
 
-<a id="v0-11-0"></a>
-
 ## 0.11.0
 
 *2026-05-06*
@@ -222,8 +218,6 @@ Stability release. No breaking API changes. Several latent product bugs surfaced
 - **Enterprise landing page redesign** — new home page with a Moberg-aligned enterprise aesthetic, replacing the prior tagline-driven layout ([#148](https://github.com/moberghr/warp/pull/148), [#150](https://github.com/moberghr/warp/pull/150)).
 
 ---
-
-<a id="v0-10-0"></a>
 
 ## 0.10.0
 
@@ -295,8 +289,6 @@ Breaking release because of both the rename and the removal of reflection-based 
 
 ---
 
-<a id="v0-9-1"></a>
-
 ## 0.9.1
 
 *2026-04-21*
@@ -311,8 +303,6 @@ Breaking release because of both the rename and the removal of reflection-based 
 - **Docs site dependencies** — Docusaurus 3.9.2 → 3.10.0, added `@docusaurus/faster` (required by 3.10 with `future.v4`), and pinned `serialize-javascript ^7.0.5` via `overrides` to close [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) — the build-chain DoS that Docusaurus's bundler transitively pulled in. `npm audit` now reports 0 vulnerabilities on both frontends.
 
 ---
-
-<a id="v0-9-0"></a>
 
 ## 0.9.0
 
@@ -366,8 +356,6 @@ Breaking release because of the provider package split and the DI lambda API.
 
 ---
 
-<a id="v0-8-0"></a>
-
 ## 0.8.0
 
 *2026-04-19*
@@ -403,8 +391,6 @@ Breaking release because of the provider package split and the DI lambda API.
 - **`StaleJobRecoveryTask.RequeueStaleJobs` removed** — Replaced by `RecoverStaleJobs` returning `StaleJobRecoveryResult` (includes `Requeued`, `Failed`, `Deleted` counts). No `[Obsolete]` bridge; callers must migrate to the new signature.
 
 ---
-
-<a id="v0-7-0"></a>
 
 ## 0.7.0
 
@@ -453,8 +439,6 @@ This is a large release with several breaking changes. Plan the upgrade accordin
 
 ---
 
-<a id="v0-6-1"></a>
-
 ## 0.6.1
 
 *2026-04-13*
@@ -468,8 +452,6 @@ This is a large release with several breaking changes. Plan the upgrade accordin
 - **Fix all 401 build warnings** — Zero warnings across the entire solution. Fixes include: regex DoS hardening (NonBacktracking), collection expression simplification, constructor formatting, CancellationToken propagation, string.Equals usage, and async call consistency. All rule suppressions via `.editorconfig` — no `#pragma` or `[SuppressMessage]` attributes.
 
 ---
-
-<a id="v0-6-0"></a>
 
 ## 0.6.0
 
@@ -508,8 +490,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 
 ---
 
-<a id="v0-5-0"></a>
-
 ## 0.5.0
 
 *2026-04-09*
@@ -538,8 +518,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 
 ---
 
-<a id="v0-4-0"></a>
-
 ## 0.4.0
 
 *2026-04-08*
@@ -553,8 +531,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 - [GitHub Release](https://github.com/moberghr/warp/releases/tag/0.4.0)
 
 ---
-
-<a id="v0-3-0"></a>
 
 ## 0.3.0
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,6 +1,37 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import {visit} from 'unist-util-visit';
+
+// Maps a top-level version-pattern heading (e.g. `## 0.12.0`) to an explicit
+// id like `v0-12-0`. Without this, Docusaurus's slugifier would strip the
+// dots and produce unreadable anchors like `#0120`. We can't use the
+// `## 0.12.0 {#v0-12-0}` syntax because Docusaurus 3.10's stricter MDX
+// expression parser rejects `{#...}` before the heading-id remark plugin
+// sees it (acorn refuses `#v0-12-0` as a JS expression).
+const versionAnchorPlugin = () => {
+  return (tree: any) => {
+    visit(tree, 'heading', (node: any) => {
+      if (node.depth !== 2 || !node.children?.length) {
+        return;
+      }
+      const text = node.children
+        .filter((c: any) => c.type === 'text')
+        .map((c: any) => c.value)
+        .join('');
+      const match = /^(\d+\.\d+(?:\.\d+)?)$/.exec(text.trim());
+      if (!match) {
+        return;
+      }
+      const id = 'v' + match[1].replace(/\./g, '-');
+      node.data = node.data || {};
+      node.data.hProperties = node.data.hProperties || {};
+      node.data.hProperties.id = id;
+      // Keep `id` on the AST itself so docusaurus's TOC extractor uses it.
+      node.data.id = id;
+    });
+  };
+};
 
 const config: Config = {
   title: 'Warp',
@@ -52,6 +83,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/moberghr/warp/tree/main/website/',
+          beforeDefaultRemarkPlugins: [versionAnchorPlugin],
         },
         blog: false,
         theme: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.0",

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.0",


### PR DESCRIPTION
## Summary
Fixes three flaky integration tests + bounds the test-side SQL command timeout to surface hung connections instead of cascading into 10 s `[TimedFact]` failures.

### `GivenShutdown_WhenServerStops_ThenPendingCompletionsAreFlushed` — `BatchedCompletionIntegrationTests`
- Original setup couldn't actually exercise the shutdown-flush path. `WarpDispatcherWorker.cs:107` idle-drains the batch whenever the channel goes empty, so by the time `StopAsync` ran the buffer was already 0. The 4-of-5 `Completed` result we observed on the flake came from idle-drain, not shutdown-flush; the stuck 5th job was an unrelated dispatcher claim/unclaim race.
- New design: `WorkerCount = 1`, 4 `UnitRequest`s followed by one `BarrierRequest`. The single worker pulls them back-to-back so `TryRead` keeps the inner loop alive (no idle-drain), then parks inside the barrier handler with 4 `PendingCompletion`s stably in `_batch`. A 500 ms `HostOptions.ShutdownTimeout` makes `base.StopAsync` return before the parked handler completes, so the worker's own `StopAsync` is the only path that can persist the buffered 4. The 5th stays `Processing` (orphaned, recoverable by `StaleJobRecovery` in production).

### `GivenPausedServer_WithTwoServers_ThenOtherServerProcessesJobs` — `MultiServerTests`
- Documented pause-propagation race per `CLAUDE.md`: in-flight server1 worker iterations already past their pause check can still complete one fetch+claim after the holder flips. With `WorkerCount=3`, three workers in-flight = three claimed jobs, exactly matching the failed CI assertion (3 of 10).
- Switched to the deterministic prescription already used in `PauseIntegrationTests`: `HealthCheckInterval = null`, then `PauseServer` → `RunHeartbeatOnceAsync` → 500 ms drain → publish.

### `WarpTestServer` DbContext default `CommandTimeout = 5s`
- Diagnostic from the failed `GivenMutexJobs_WithTwoServers` run showed every `ServerTask` row with `lastRun` frozen at startup time and zero jobs in the DB — consistent with `publisher.SaveChangesAsync` hanging behind ADO.NET's 30 s default `CommandTimeout`, which caused a cascading 10 s `[TimedFact]` failure with no diagnostic.
- Capping at 5 s makes the bad command time out, surfaces in logs, and lets `ServerTaskLoop`'s catch handler retry on a fresh connection. Provider-native long-running commands (Service Broker `WAITFOR`, Postgres `LISTEN`) set `CommandTimeout` explicitly on the `SqlCommand` / `NpgsqlCommand` and are unaffected by this default.
- Diagnostic context behind the original CI flakes: https://github.com/moberghr/warp/actions/runs/25495760476 and https://github.com/moberghr/warp/actions/runs/25499005296

## Test plan
- [x] Rewritten shutdown-flush test: 5/5 stable runs on PG + SQL Server
- [x] Rewritten paused-server test: 3/3 stable runs on PG + SQL Server
- [x] All 16 `MultiServerTests` pass on both backends
- [x] Full suite — 1,116/1,116 tests pass on both backends with `CommandTimeout = 5s`
- [x] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)