### PR TITLE
test: capture pre-host setup timing in failure diagnostics

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/FixtureDiagnostics.cs
+++ b/src/tests/Warp.Tests/Fixtures/FixtureDiagnostics.cs
@@ -83,10 +83,22 @@ public static class FixtureDiagnostics
                 new { l.Timestamp, l.Status, l.Message, l.DurationMs, TaskName = l.ServerTask != null ? l.ServerTask.TaskName : null })
             .ToListAsync(ct);
 
+        var testEvents = TestLifecycleTrace.Drain();
         var lifecycleEvents = ServerLifecycleTrace.Drain();
 
         var sb = new StringBuilder();
         sb.AppendLine(header);
+
+        sb.AppendLine();
+        sb.AppendLine($"Test lifecycle ({testEvents.Count} events):");
+        foreach (var grouped in testEvents.GroupBy(e => e.TestName))
+        {
+            sb.AppendLine($"  Test {grouped.Key}:");
+            foreach (var e in grouped.OrderBy(x => x.Timestamp))
+            {
+                sb.AppendLine($"    [{e.Timestamp:HH:mm:ss.fff}] {e.Event}");
+            }
+        }
 
         sb.AppendLine();
         sb.AppendLine($"Server lifecycle ({lifecycleEvents.Count} events):");

--- a/src/tests/Warp.Tests/Fixtures/IntegrationTestBase.cs
+++ b/src/tests/Warp.Tests/Fixtures/IntegrationTestBase.cs
@@ -13,15 +13,22 @@ public abstract class IntegrationTestBase : IAsyncLifetime
 
     public virtual async ValueTask InitializeAsync()
     {
+        TestLifecycleTrace.Record("IntegrationTestBase.InitializeAsync starting");
         try
         {
+            TestLifecycleTrace.Record("Fixture.ResetAsync starting");
             await Fixture.ResetAsync();
+            TestLifecycleTrace.Record("Fixture.ResetAsync returned");
         }
         catch
         {
+            TestLifecycleTrace.Record("Fixture.ResetAsync threw, retrying");
             await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
             await Fixture.ResetAsync();
+            TestLifecycleTrace.Record("Fixture.ResetAsync returned (retry)");
         }
+
+        TestLifecycleTrace.Record("IntegrationTestBase.InitializeAsync returned");
     }
 
     public virtual ValueTask DisposeAsync()

--- a/src/tests/Warp.Tests/Fixtures/PostgreSqlClassFixture.cs
+++ b/src/tests/Warp.Tests/Fixtures/PostgreSqlClassFixture.cs
@@ -20,20 +20,28 @@ public class PostgreSqlClassFixture : IAsyncLifetime, IDatabaseFixture
 
     public async ValueTask InitializeAsync()
     {
+        TestLifecycleTrace.Record("PostgreSqlClassFixture.InitializeAsync starting");
         var databaseName = $"warp_t_{Guid.NewGuid():N}";
+
+        TestLifecycleTrace.Record("SharedPostgreSqlContainer.CreateDatabaseAsync starting");
         _connectionString = await SharedPostgreSqlContainer.CreateDatabaseAsync(
             databaseName,
             Xunit.TestContext.Current.CancellationToken);
+        TestLifecycleTrace.Record("SharedPostgreSqlContainer.CreateDatabaseAsync returned");
 
+        TestLifecycleTrace.Record("EnsureCreatedAsync starting");
         await using var context = CreateContext();
         await context.Database.EnsureCreatedAsync(Xunit.TestContext.Current.CancellationToken);
+        TestLifecycleTrace.Record("EnsureCreatedAsync returned");
 
+        TestLifecycleTrace.Record("Respawner.CreateAsync starting");
         await using var conn = new NpgsqlConnection(_connectionString);
         await conn.OpenAsync(Xunit.TestContext.Current.CancellationToken);
         _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
         {
             DbAdapter = DbAdapter.Postgres,
         });
+        TestLifecycleTrace.Record("Respawner.CreateAsync returned");
     }
 
     public async Task ResetAsync()

--- a/src/tests/Warp.Tests/Fixtures/SqlServerClassFixture.cs
+++ b/src/tests/Warp.Tests/Fixtures/SqlServerClassFixture.cs
@@ -27,21 +27,29 @@ public class SqlServerClassFixture : IAsyncLifetime, IDatabaseFixture
 
     public async ValueTask InitializeAsync()
     {
+        TestLifecycleTrace.Record("SqlServerClassFixture.InitializeAsync starting");
         var databaseName = $"warp_t_{Guid.NewGuid():N}";
+
+        TestLifecycleTrace.Record("SharedSqlServerContainer.CreateDatabaseAsync starting");
         _connectionString = await SharedSqlServerContainer.CreateDatabaseAsync(
             databaseName,
             EnableServiceBroker,
             Xunit.TestContext.Current.CancellationToken);
+        TestLifecycleTrace.Record("SharedSqlServerContainer.CreateDatabaseAsync returned");
 
+        TestLifecycleTrace.Record("EnsureCreatedAsync starting");
         await using var context = CreateContext();
         await context.Database.EnsureCreatedAsync(Xunit.TestContext.Current.CancellationToken);
+        TestLifecycleTrace.Record("EnsureCreatedAsync returned");
 
+        TestLifecycleTrace.Record("Respawner.CreateAsync starting");
         await using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(Xunit.TestContext.Current.CancellationToken);
         _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
         {
             DbAdapter = DbAdapter.SqlServer,
         });
+        TestLifecycleTrace.Record("Respawner.CreateAsync returned");
     }
 
     public async Task ResetAsync()

--- a/src/tests/Warp.Tests/Fixtures/TestLifecycleTrace.cs
+++ b/src/tests/Warp.Tests/Fixtures/TestLifecycleTrace.cs
@@ -1,0 +1,29 @@
+using System.Collections.Concurrent;
+
+namespace Warp.Tests.Fixtures;
+
+/// <summary>
+/// Captures pre-host setup events (class-fixture InitializeAsync, IntegrationTestBase
+/// InitializeAsync, Fixture.ResetAsync, WarpTestServer.StartAsync prep) so the failure-path
+/// diagnostic dump can show where the budget went before <see cref="ServerLifecycleTrace"/>'s
+/// IHost.StartAsync entries pick up. Same drain-on-dump semantics as ServerLifecycleTrace.
+/// </summary>
+internal static class TestLifecycleTrace
+{
+    private static readonly ConcurrentQueue<TraceEvent> _events = new();
+
+    public static void Record(string @event)
+    {
+        var testName = Xunit.TestContext.Current?.Test?.TestDisplayName ?? "<no-test>";
+        _events.Enqueue(new TraceEvent(testName, @event, DateTime.UtcNow));
+    }
+
+    public static IReadOnlyList<TraceEvent> Drain()
+    {
+        var snapshot = _events.ToArray();
+        _events.Clear();
+        return snapshot;
+    }
+
+    public sealed record TraceEvent(string TestName, string Event, DateTime Timestamp);
+}

--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -127,10 +127,14 @@ public class WarpTestServer : IAsyncDisposable
         Action<WarpWorkerBuilder<TestContext>>? configure,
         Action<IServiceCollection>? configureServices)
     {
+        TestLifecycleTrace.Record("WarpTestServer.StartAsync starting");
+
+        TestLifecycleTrace.Record("Fixture.CreateContext (probe) starting");
         var tempCtx = fixture.CreateContext();
         var baseConnectionString = tempCtx.Database.GetConnectionString()!;
         var isPostgres = tempCtx.Database.ProviderName?.Contains("Npgsql", StringComparison.Ordinal) == true;
         await tempCtx.DisposeAsync();
+        TestLifecycleTrace.Record("Fixture.CreateContext (probe) returned");
 
         // For SQL Server only: give each test-server instance its own ADO.NET connection pool by
         // appending a unique Application Name (which Microsoft.Data.SqlClient includes in the pool
@@ -143,6 +147,7 @@ public class WarpTestServer : IAsyncDisposable
             ? baseConnectionString
             : $"{baseConnectionString};Application Name=warp-test-{Guid.NewGuid():N}";
 
+        TestLifecycleTrace.Record("Host.Build starting");
         var host = Host.CreateDefaultBuilder()
             .ConfigureLogging(logging =>
             {
@@ -237,11 +242,13 @@ public class WarpTestServer : IAsyncDisposable
                 configureServices?.Invoke(services);
             })
             .Build();
+        TestLifecycleTrace.Record("Host.Build returned");
 
         var serverId = host.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<WarpWorkerConfiguration>>().Value.ServerId;
         ServerLifecycleTrace.Record(serverId, "IHost.StartAsync starting");
         await host.StartAsync(Xunit.TestContext.Current.CancellationToken);
         ServerLifecycleTrace.Record(serverId, "IHost.StartAsync returned");
+        TestLifecycleTrace.Record($"WarpTestServer.StartAsync returned (server={serverId})");
 
         return new WarpTestServer(host, fixture);
     }

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,8 +4,6 @@ sidebar_position: 6
 
 # Releases
 
-<a id="v0-12-0"></a>
-
 ## 0.12.0
 
 *2026-05-07*
@@ -186,8 +184,6 @@ Full docs at [features/http](features/http). Shipped in [#154](https://github.co
 
 - **HTTP request-isolation suite** — five concurrency tests bombard the in-memory test app with 200 parallel requests (50 for streaming) and assert per-request DI scope (N requests → N distinct `ScopeProbe` constructions), no `AsyncLocal<T>` bleed between handlers, no request-payload crossover, pipeline behaviors observe per-request inputs, and concurrent `IStreamRequest` endpoints emit only their own block of items.
 
-<a id="v0-11-0"></a>
-
 ## 0.11.0
 
 *2026-05-06*
@@ -222,8 +218,6 @@ Stability release. No breaking API changes. Several latent product bugs surfaced
 - **Enterprise landing page redesign** — new home page with a Moberg-aligned enterprise aesthetic, replacing the prior tagline-driven layout ([#148](https://github.com/moberghr/warp/pull/148), [#150](https://github.com/moberghr/warp/pull/150)).
 
 ---
-
-<a id="v0-10-0"></a>
 
 ## 0.10.0
 
@@ -295,8 +289,6 @@ Breaking release because of both the rename and the removal of reflection-based 
 
 ---
 
-<a id="v0-9-1"></a>
-
 ## 0.9.1
 
 *2026-04-21*
@@ -311,8 +303,6 @@ Breaking release because of both the rename and the removal of reflection-based 
 - **Docs site dependencies** — Docusaurus 3.9.2 → 3.10.0, added `@docusaurus/faster` (required by 3.10 with `future.v4`), and pinned `serialize-javascript ^7.0.5` via `overrides` to close [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) — the build-chain DoS that Docusaurus's bundler transitively pulled in. `npm audit` now reports 0 vulnerabilities on both frontends.
 
 ---
-
-<a id="v0-9-0"></a>
 
 ## 0.9.0
 
@@ -366,8 +356,6 @@ Breaking release because of the provider package split and the DI lambda API.
 
 ---
 
-<a id="v0-8-0"></a>
-
 ## 0.8.0
 
 *2026-04-19*
@@ -403,8 +391,6 @@ Breaking release because of the provider package split and the DI lambda API.
 - **`StaleJobRecoveryTask.RequeueStaleJobs` removed** — Replaced by `RecoverStaleJobs` returning `StaleJobRecoveryResult` (includes `Requeued`, `Failed`, `Deleted` counts). No `[Obsolete]` bridge; callers must migrate to the new signature.
 
 ---
-
-<a id="v0-7-0"></a>
 
 ## 0.7.0
 
@@ -453,8 +439,6 @@ This is a large release with several breaking changes. Plan the upgrade accordin
 
 ---
 
-<a id="v0-6-1"></a>
-
 ## 0.6.1
 
 *2026-04-13*
@@ -468,8 +452,6 @@ This is a large release with several breaking changes. Plan the upgrade accordin
 - **Fix all 401 build warnings** — Zero warnings across the entire solution. Fixes include: regex DoS hardening (NonBacktracking), collection expression simplification, constructor formatting, CancellationToken propagation, string.Equals usage, and async call consistency. All rule suppressions via `.editorconfig` — no `#pragma` or `[SuppressMessage]` attributes.
 
 ---
-
-<a id="v0-6-0"></a>
 
 ## 0.6.0
 
@@ -508,8 +490,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 
 ---
 
-<a id="v0-5-0"></a>
-
 ## 0.5.0
 
 *2026-04-09*
@@ -538,8 +518,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 
 ---
 
-<a id="v0-4-0"></a>
-
 ## 0.4.0
 
 *2026-04-08*
@@ -553,8 +531,6 @@ This release adds a new nullable `ParentSpanId` column to the Job table. Run an 
 - [GitHub Release](https://github.com/moberghr/warp/releases/tag/0.4.0)
 
 ---
-
-<a id="v0-3-0"></a>
 
 ## 0.3.0
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,6 +1,37 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import {visit} from 'unist-util-visit';
+
+// Maps a top-level version-pattern heading (e.g. `## 0.12.0`) to an explicit
+// id like `v0-12-0`. Without this, Docusaurus's slugifier would strip the
+// dots and produce unreadable anchors like `#0120`. We can't use the
+// `## 0.12.0 {#v0-12-0}` syntax because Docusaurus 3.10's stricter MDX
+// expression parser rejects `{#...}` before the heading-id remark plugin
+// sees it (acorn refuses `#v0-12-0` as a JS expression).
+const versionAnchorPlugin = () => {
+  return (tree: any) => {
+    visit(tree, 'heading', (node: any) => {
+      if (node.depth !== 2 || !node.children?.length) {
+        return;
+      }
+      const text = node.children
+        .filter((c: any) => c.type === 'text')
+        .map((c: any) => c.value)
+        .join('');
+      const match = /^(\d+\.\d+(?:\.\d+)?)$/.exec(text.trim());
+      if (!match) {
+        return;
+      }
+      const id = 'v' + match[1].replace(/\./g, '-');
+      node.data = node.data || {};
+      node.data.hProperties = node.data.hProperties || {};
+      node.data.hProperties.id = id;
+      // Keep `id` on the AST itself so docusaurus's TOC extractor uses it.
+      node.data.id = id;
+    });
+  };
+};
 
 const config: Config = {
   title: 'Warp',
@@ -52,6 +83,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/moberghr/warp/tree/main/website/',
+          beforeDefaultRemarkPlugins: [versionAnchorPlugin],
         },
         blog: false,
         theme: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,7 +15,8 @@
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.0",

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.0",


### PR DESCRIPTION
## Summary

When an integration test times out at the `[TimedFact]` 10 s default, the existing dump only shows `IHost.StartAsync` timing — but the budget can be eaten earlier (Respawn reset, class-fixture init, host build) and the dump gives no visibility into that window. CI run [25501370833](https://github.com/moberghr/warp/actions/runs/25501370833/job/74835412074) is the motivating case: the failed test's `IHost.StartAsync` only began ~5 ms before the 10 s timeout fired, so the entire 10 s went somewhere we couldn't see.

Adds `TestLifecycleTrace` (sibling of `ServerLifecycleTrace`) keyed by xunit test display name, and instruments the four blind spots:

- `IntegrationTestBase.InitializeAsync` — `Fixture.ResetAsync` (including the retry branch)
- `SqlServerClassFixture` / `PostgreSqlClassFixture.InitializeAsync` — `CreateDatabaseAsync`, `EnsureCreatedAsync`, `Respawner.CreateAsync`
- `WarpTestServer.StartAsync` — the fixture probe context, `Host.Build`, and a bridge entry into the existing `IHost.StartAsync` events

The dump renders a new "Test lifecycle" section above "Server lifecycle". Same drain-on-dump semantics as `ServerLifecycleTrace` — process-wide queue, cleared each failure dump, so a failing test's dump includes its own events plus any class-fixture / earlier-passed-test events accumulated since the last drain. Noisier, but more useful when a flake is influenced by what ran before it.

Class-fixture events show up under `<no-test>` because `TestContext.Current.Test` isn't populated during `IClassFixture.InitializeAsync`; the grouping still makes the timeline readable.

## Verification

Forced one test to fail (`TraceIntegrationTests_PostgreSql.GivenTwoSeparateJobs…` via `ShouldNotBe` → `ShouldBe`), reverted after capturing the dump:

```
Test lifecycle (17 events):
  Test <no-test>:
    [14:52:03.144] PostgreSqlClassFixture.InitializeAsync starting
    [14:52:03.144] SharedPostgreSqlContainer.CreateDatabaseAsync starting
    [14:52:07.471] SharedPostgreSqlContainer.CreateDatabaseAsync returned   ← 4.3 s cold container
    [14:52:07.471] EnsureCreatedAsync starting
    [14:52:08.605] EnsureCreatedAsync returned                              ← 1.13 s schema
    [14:52:08.605] Respawner.CreateAsync starting
    [14:52:08.627] Respawner.CreateAsync returned                           ← 22 ms
  Test …TraceIntegrationTests_PostgreSql.GivenTwoSeparateJobs…:
    [14:52:08.671] IntegrationTestBase.InitializeAsync starting
    [14:52:08.671] Fixture.ResetAsync starting
    [14:52:08.686] Fixture.ResetAsync returned                              ← 15 ms reset
    [14:52:08.686] IntegrationTestBase.InitializeAsync returned
    [14:52:08.911] WarpTestServer.StartAsync starting
    [14:52:08.911] Fixture.CreateContext (probe) starting
    [14:52:08.930] Fixture.CreateContext (probe) returned                   ← 19 ms
    [14:52:08.930] Host.Build starting
    [14:52:09.137] Host.Build returned                                      ← 207 ms DI build
    [14:52:09.633] WarpTestServer.StartAsync returned (server=…)

Server lifecycle (4 events):
  Server af7bd997-…:
    [14:52:09.137] IHost.StartAsync starting
    [14:52:09.633] IHost.StartAsync returned                                ← 496 ms
```

## Test plan

- [x] Build green (0 warnings, 0 errors)
- [x] Forced-fail run verified the new dump section renders
- [ ] Suite still green on PostgreSQL and SQL Server in CI
- [ ] Next [TimedFact] flake's dump shows where the budget went

🤖 Generated with [Claude Code](https://claude.com/claude-code)