### PR TITLE
fix: messages nav badge counts active states only

### DIFF
--- a/src/core/Warp.Core/Services/DashboardStatsService.cs
+++ b/src/core/Warp.Core/Services/DashboardStatsService.cs
@@ -58,7 +58,11 @@ public class DashboardStatsService<TContext> : IDashboardStatsService
         var awaiting = await GetJobsCount(State.Awaiting);
         var deleted = await GetJobsCount(State.Deleted);
         var messages = await _context.Set<Job>()
-            .Where(x => x.Kind == JobKind.Message && x.CurrentState != State.Completed)
+            .Where(x => x.Kind == JobKind.Message)
+            .Where(x => x.CurrentState == State.Enqueued
+                || x.CurrentState == State.Awaiting
+                || x.CurrentState == State.Processing
+                || x.CurrentState == State.Scheduled)
             .CountAsync();
         var batches = await _context.Set<Job>()
             .Where(x => x.Kind == JobKind.Batch && x.CurrentState != State.Deleted)

--- a/src/tests/Warp.Tests/Observability/DashboardBreakdownTests.cs
+++ b/src/tests/Warp.Tests/Observability/DashboardBreakdownTests.cs
@@ -65,6 +65,62 @@ public abstract class DashboardBreakdownTestsBase : IAsyncLifetime
     }
 
     [TimedFact]
+    public async Task GetWarpStatus_Messages_CountsActiveStatesOnly()
+    {
+        // Arrange — one of every state, message kind
+        var ctx = _fixture.CreateContext();
+
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Enqueued));
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Awaiting));
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Processing));
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Scheduled));
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Completed));
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Failed));
+        ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Deleted));
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // Act
+        var svc = new DashboardStatsService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
+        var status = await svc.GetWarpStatus();
+
+        // Assert — only Enqueued + Awaiting + Processing + Scheduled (saga timeouts) count as active
+        status.Messages.ShouldBe(4);
+    }
+
+    [TimedFact]
+    public async Task GetWarpStatus_Messages_ExcludesFailedAndCompleted()
+    {
+        // Repro of issue #177: seed-sagas leaves four failed, three completed, and three
+        // scheduled message rows; only the scheduled ones should show in the navbar badge.
+        var ctx = _fixture.CreateContext();
+
+        for (var i = 0; i < 4; i++)
+        {
+            ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Failed));
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Completed));
+        }
+
+        for (var i = 0; i < 3; i++)
+        {
+            ctx.Set<Job>().Add(CreateJob(JobKind.Message, State.Scheduled));
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = new DashboardStatsService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
+        var status = await svc.GetWarpStatus();
+
+        status.Messages.ShouldBe(3);
+        status.MessagesFailed.ShouldBe(4);
+        status.MessagesCompleted.ShouldBe(3);
+    }
+
+    [TimedFact]
     public async Task GetWarpStatus_CountsBatchesByState()
     {
         // Arrange


### PR DESCRIPTION
Closes #177.

## Summary
- Dashboard navbar Messages badge was `Kind=Message && CurrentState != Completed` — which included terminal `Failed`/`Deleted` rows, so a freshly-seeded sagas demo with 4 Failed + 3 Scheduled messages showed `Messages 7 4` instead of `Messages 3 4`.
- Fixed to an explicit active-set: `Enqueued`, `Awaiting`, `Processing`, `Scheduled` (saga timeouts in `Scheduled` legitimately count as active in flight).
- Audited the other UI counters — every rendered field is already a clean single-state count or the now-fixed `messages`. `stats.batches` (also `!= Deleted`) exists in the DTO but isn't rendered anywhere, so out of scope.

## Test plan
- [x] New `GetWarpStatus_Messages_CountsActiveStatesOnly` — seeds one of every state, asserts `Messages == 4`.
- [x] New `GetWarpStatus_Messages_ExcludesFailedAndCompleted` — issue #177 repro (4 failed + 3 completed + 3 scheduled → `Messages == 3`).
- [x] Both run on Postgres + SQL Server via `[GenerateDatabaseTests]`.
- [x] `dotnet build src/Warp.slnx` clean.
- [x] PG suite (599 tests) green locally.
- [x] SQL Server suite (593 tests) green locally.
- [x] NoDb suite (391 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)