### PR TITLE
test: eliminate timing-guess Task.Delay in notification + pause tests

### DIFF
--- a/src/core/providers/Warp.Provider.PostgreSql/PostgresNotificationTransport.cs
+++ b/src/core/providers/Warp.Provider.PostgreSql/PostgresNotificationTransport.cs
@@ -8,9 +8,9 @@ namespace Warp.Provider.PostgreSql;
 
 /// <summary>
 /// PostgreSQL LISTEN/NOTIFY transport. <see cref="PublishAsync"/> opens a short-lived
-/// (pooled) connection and issues <c>SELECT pg_notify(...)</c>; <see cref="ListenAsync"/>
+/// (pooled) connection and issues <c>SELECT pg_notify(...)</c>; <see cref="ListenAsync(CancellationToken)"/>
 /// holds a dedicated long-lived connection, issues <c>LISTEN</c>, and yields each arriving
-/// notification. Reconnect is the caller's responsibility — <see cref="ListenAsync"/>
+/// notification. Reconnect is the caller's responsibility — <see cref="ListenAsync(CancellationToken)"/>
 /// terminates on connection failure or cancellation, and the hosting listener task wraps
 /// it in an outer reconnect loop.
 /// </summary>
@@ -65,7 +65,20 @@ public sealed class PostgresNotificationTransport : IWarpNotificationTransport
         }
     }
 
-    public async IAsyncEnumerable<Notification> ListenAsync([EnumeratorCancellation] CancellationToken ct)
+    public IAsyncEnumerable<Notification> ListenAsync(CancellationToken ct)
+    {
+        return ListenCoreAsync(readySignal: null, ct);
+    }
+
+    // Test hook: deterministic listener-ready signal. Fires after LISTEN has been
+    // executed on the wire, before the first WaitAsync. Lets tests await readiness
+    // instead of guessing with Task.Delay — see PostgresNotificationTransportTests.
+    internal IAsyncEnumerable<Notification> ListenAsync(TaskCompletionSource ready, CancellationToken ct)
+    {
+        return ListenCoreAsync(ready, ct);
+    }
+
+    private async IAsyncEnumerable<Notification> ListenCoreAsync(TaskCompletionSource? readySignal, [EnumeratorCancellation] CancellationToken ct)
     {
         await using var conn = await OpenConnectionAsync(ct);
 
@@ -75,6 +88,8 @@ public sealed class PostgresNotificationTransport : IWarpNotificationTransport
         {
             await cmd.ExecuteNonQueryAsync(ct);
         }
+
+        readySignal?.TrySetResult();
 
         // Npgsql fires the Notification event synchronously during WaitAsync on the same thread
         // the iterator runs on — so a plain Queue is safe, no Channel/Task.Run needed. The event

--- a/src/tests/Warp.Tests/EndToEnd/MultiServerTests.cs
+++ b/src/tests/Warp.Tests/EndToEnd/MultiServerTests.cs
@@ -444,10 +444,11 @@ public abstract class MultiServerTestsBase : IntegrationTestBase
         server1.PauseState.IsPaused(server1GroupId).ShouldBeTrue();
 
         // Drain any server1 worker iterations that were already mid-fetch when the holder
-        // flipped — without this slack they could still claim a freshly-published row from
-        // their already-running SQL query. One PollingInterval (100ms test config) plus slack
-        // guarantees every such iteration finishes against the empty queue, loops back, and
-        // sees paused=true on its next check.
+        // flipped — this models the §6.8 pause contract ("no new fetches after up to one
+        // heartbeat"), not a timing guess. Without this slack, a worker mid-fetch could still
+        // claim a freshly-published row from its already-running SQL query. One PollingInterval
+        // (100ms test config) plus 4× slack covers every such iteration. Making this
+        // deterministic would require worker-iteration observability (forbidden by §6.1).
         await Task.Delay(500, Xunit.TestContext.Current.CancellationToken);
 
         // Enqueue jobs while server1 is paused

--- a/src/tests/Warp.Tests/Features/Pause/PauseIntegrationTests.cs
+++ b/src/tests/Warp.Tests/Features/Pause/PauseIntegrationTests.cs
@@ -58,12 +58,16 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         await server.RunHeartbeatOnceAsync(Xunit.TestContext.Current.CancellationToken);
         server.PauseState.IsPaused(groupId).ShouldBeTrue();
 
-        // Drain in-flight worker iterations. A worker that read holder=false just before the
-        // manual heartbeat is now somewhere in GetAndProcessJob; if we published immediately,
-        // its already-running SQL claim could see the new row even though the holder is now
-        // paused. Waiting one full polling cycle (PollingInterval = 100ms in test config)
-        // plus slack guarantees every such iteration finishes against an empty queue, loops
-        // back, and reads paused=true on its next check.
+        // Drain in-flight worker iterations. This is NOT a timing guess — it models the §6.8
+        // pause contract: pause is "no new fetches after up to one heartbeat", deliberately
+        // non-synchronous so the worker fetch/execute hot path stays observation-free (§6.1).
+        // A worker that read holder=false just before the manual heartbeat is now somewhere
+        // in GetAndProcessJob; without this drain its already-running SQL claim could see the
+        // row we're about to publish. Waiting one full PollingInterval (100ms in test config)
+        // plus 4× slack guarantees every such iteration finishes against an empty queue, loops
+        // back, and reads paused=true on its next check. Making this deterministic would
+        // require either worker-iteration observability (forbidden by §6.1) or making pause
+        // synchronous (a contract change). The wall-clock wait is the contract.
         await Task.Delay(500, Xunit.TestContext.Current.CancellationToken);
 
         // Publish a job — by now all worker iterations are either sleeping in the pause
@@ -72,15 +76,15 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         var jobId = await publisher.Enqueue(new UnitRequest());
         await publisher.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-        // Confirm it stays Enqueued for the duration we'd reasonably expect a worker to pick
-        // it up if pause weren't honored.
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-        while (DateTime.UtcNow < deadline)
-        {
-            var job = await server.GetJob(jobId);
-            job.CurrentState.ShouldBe(State.Enqueued);
-            await Task.Delay(200, Xunit.TestContext.Current.CancellationToken);
-        }
+        // Confirm pause is honored: WaitForCompletion must time out, because the (paused)
+        // worker can't claim the only outstanding job. Expressing the negative assertion as a
+        // bounded WaitForCompletion replaces a polling-loop-with-Delay; the 2s budget is the
+        // window over which we expect no worker iteration to misbehave.
+        await Should.ThrowAsync<TimeoutException>(
+            async () => await server.WaitForCompletion(TimeSpan.FromSeconds(2)));
+
+        var jobBeforeResume = await server.GetJob(jobId);
+        jobBeforeResume.CurrentState.ShouldBe(State.Enqueued);
 
         // Resume + manual heartbeat to flip the holder back, then let workers process.
         await svc.ResumeServer(server.ServerId);
@@ -123,20 +127,20 @@ public abstract class PauseIntegrationTestsBase : IntegrationTestBase
         await server.RunHeartbeatOnceAsync(Xunit.TestContext.Current.CancellationToken);
         server.PauseState.IsPaused(groupId).ShouldBeTrue();
 
-        // Drain in-flight worker iterations — see PauseServer_JobsStayEnqueued for rationale.
+        // Drain in-flight worker iterations — see PauseServer_JobsStayEnqueued for the §6.8
+        // contract rationale and why this isn't a timing guess.
         await Task.Delay(500, Xunit.TestContext.Current.CancellationToken);
 
         var publisher = server.CreatePublisher();
         var jobId = await publisher.Enqueue(new UnitRequest());
         await publisher.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-        while (DateTime.UtcNow < deadline)
-        {
-            var job = await server.GetJob(jobId);
-            job.CurrentState.ShouldBe(State.Enqueued);
-            await Task.Delay(200, Xunit.TestContext.Current.CancellationToken);
-        }
+        // Negative-window assertion — see PauseServer_JobsStayEnqueued for rationale.
+        await Should.ThrowAsync<TimeoutException>(
+            async () => await server.WaitForCompletion(TimeSpan.FromSeconds(2)));
+
+        var jobBeforeResume = await server.GetJob(jobId);
+        jobBeforeResume.CurrentState.ShouldBe(State.Enqueued);
 
         await svc.ResumeWorkerGroup(groupId);
         await server.RunHeartbeatOnceAsync(Xunit.TestContext.Current.CancellationToken);

--- a/src/tests/Warp.Tests/Notifications/ListenerReconnectDrainTests.cs
+++ b/src/tests/Warp.Tests/Notifications/ListenerReconnectDrainTests.cs
@@ -64,10 +64,12 @@ public abstract class ListenerReconnectDrainTestsBase : IntegrationTestBase
                 services.AddSingleton<IWarpNotificationTransport>(transport);
             });
 
-        // Let the listener loop at least once so the dispatcher has seen the startup drain
-        // and settled into its 30s wait. The reconnect drain that fires after enqueue is what
-        // the test is measuring.
-        await Task.Delay(1200, Xunit.TestContext.Current.CancellationToken);
+        // Deterministic: wait until the listener has STARTED its second attempt. That proves
+        // the first attempt fully unwound (throw → log → backoff sleep → loop back), so the
+        // startup-drain has already fired and the dispatcher is no longer running a fresh poll.
+        // Any subsequent ListenAttempts increment from this point onward is a reconnect that
+        // happened AFTER our enqueue below.
+        await transport.SecondAttemptStarted.WaitAsync(Xunit.TestContext.Current.CancellationToken);
         var listenAttemptsBeforeEnqueue = transport.ListenAttempts;
 
         var publisher = server.CreatePublisher();
@@ -88,15 +90,25 @@ public abstract class ListenerReconnectDrainTestsBase : IntegrationTestBase
     // notification — so any delivery is through the reconnect-driven DrainSignals path.
     private sealed class ListenFailingTransport : IWarpNotificationTransport
     {
+        private readonly TaskCompletionSource _secondAttemptStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _listenAttempts;
 
         public int ListenAttempts => _listenAttempts;
+
+        // Fires when ListenAsync is entered for the SECOND time, i.e. after the first attempt
+        // fully unwound through the reconnect-backoff sleep and the listener task looped back.
+        public Task SecondAttemptStarted => _secondAttemptStarted.Task;
 
         public Task PublishAsync(NotificationKind kind, string? queue, CancellationToken ct) => Task.CompletedTask;
 
         public async IAsyncEnumerable<Notification> ListenAsync([EnumeratorCancellation] CancellationToken ct)
         {
-            Interlocked.Increment(ref _listenAttempts);
+            var attempt = Interlocked.Increment(ref _listenAttempts);
+            if (attempt >= 2)
+            {
+                _secondAttemptStarted.TrySetResult();
+            }
+
             await Task.Yield();
             throw new InvalidOperationException("ListenFailingTransport: listen deliberately throws to exercise reconnect-drain");
 #pragma warning disable CS0162

--- a/src/tests/Warp.Tests/Notifications/PostgresNotificationTransportTests.cs
+++ b/src/tests/Warp.Tests/Notifications/PostgresNotificationTransportTests.cs
@@ -25,13 +25,15 @@ public class PostgresNotificationTransportTests : IAsyncLifetime, IClassFixture<
             new WarpDatabasePushConfiguration { ChannelName = "warp_notify_test" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = transport.ListenAsync(ready, cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
             // Kick off MoveNextAsync first so the iterator runs OpenAsync+LISTEN before we publish.
+            // Then await the listener-ready signal — deterministic, no Task.Delay race.
             var moveTask = enumerator.MoveNextAsync();
-            await Task.Delay(TimeSpan.FromMilliseconds(300), cts.Token);
+            await ready.Task.WaitAsync(cts.Token);
 
             await transport.PublishAsync(NotificationKind.JobEnqueued, "default", cts.Token);
 
@@ -61,12 +63,13 @@ public class PostgresNotificationTransportTests : IAsyncLifetime, IClassFixture<
             new WarpDatabasePushConfiguration { ChannelName = "warp_notify_test2" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = transport.ListenAsync(ready, cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
             var firstMoveTask = enumerator.MoveNextAsync();
-            await Task.Delay(TimeSpan.FromMilliseconds(300), cts.Token);
+            await ready.Task.WaitAsync(cts.Token);
 
             await transport.PublishAsync(NotificationKind.MessageEnqueued, null, cts.Token);
             await transport.PublishAsync(NotificationKind.JobFinalized, null, cts.Token);
@@ -110,12 +113,13 @@ public class PostgresNotificationTransportTests : IAsyncLifetime, IClassFixture<
             new WarpDatabasePushConfiguration { ChannelName = "warp_notify_ds_test" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = transport.ListenAsync(ready, cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
             var moveTask = enumerator.MoveNextAsync();
-            await Task.Delay(TimeSpan.FromMilliseconds(300), cts.Token);
+            await ready.Task.WaitAsync(cts.Token);
 
             await transport.PublishAsync(NotificationKind.JobEnqueued, "default", cts.Token);
 

--- a/src/tests/Warp.Tests/Notifications/SqlServerNotificationTransportTests.cs
+++ b/src/tests/Warp.Tests/Notifications/SqlServerNotificationTransportTests.cs
@@ -29,8 +29,11 @@ public class SqlServerNotificationTransportTests : IAsyncLifetime, IClassFixture
         var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
+            // Service Broker queues are persistent: WAITFOR (RECEIVE) returns any messages
+            // already enqueued at the moment it runs. Unlike PG LISTEN/NOTIFY (where a NOTIFY
+            // fired before LISTEN is registered is lost), publish-before-listen is safe here.
+            // No timing guard needed.
             var moveTask = enumerator.MoveNextAsync();
-            await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
 
             await transport.PublishAsync(NotificationKind.JobEnqueued, "default", cts.Token);
 
@@ -62,8 +65,8 @@ public class SqlServerNotificationTransportTests : IAsyncLifetime, IClassFixture
         var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
+            // Persistent queue — see PublishListen_RoundTrip_DeliversNotification for rationale.
             var firstMoveTask = enumerator.MoveNextAsync();
-            await Task.Delay(TimeSpan.FromMilliseconds(500), cts.Token);
 
             await transport.PublishAsync(NotificationKind.MessageEnqueued, null, cts.Token);
             await transport.PublishAsync(NotificationKind.JobFinalized, null, cts.Token);


### PR DESCRIPTION
## Summary

Root-causes the `PublishListen_RoundTrip_WithDataSource_DeliversNotification` flake on CI run [25916420518](https://github.com/moberghr/warp/actions/runs/25916420518/job/76174367781) and removes the broader class of timing-guess `Task.Delay` patterns from notification + pause tests.

The PG flake was a LISTEN-vs-NOTIFY race: a cold `NpgsqlDataSource` pool occasionally lost the race during the 300ms grace window, so `pg_notify` fired before `LISTEN` was registered → message lost → 10s timeout. Reproduced locally at 0ms grace (11/100 fail); 100/100 pass with the fix.

### Changes

- **`PostgresNotificationTransport`**: internal `ListenAsync(TaskCompletionSource, CancellationToken)` overload fires after `LISTEN` returns. Tests await the signal instead of `Task.Delay(300)`.
- **`SqlServerNotificationTransportTests`**: drop `Task.Delay(500)` — Service Broker queues are persistent, no race exists (no transport change needed).
- **`ListenerReconnectDrainTests`**: `SecondAttemptStarted` TCS on `ListenFailingTransport` replaces `Task.Delay(1200)`.
- **`PauseIntegrationTests`**: negative-window polling loops → `Should.ThrowAsync<TimeoutException>(WaitForCompletion(2s))` + state check.
- **`PauseIntegrationTests` + `MultiServerTests`**: `Task.Delay(500)` drains after pause+heartbeat **kept** — these model the §6.8 pause contract (non-synchronous by design to keep the worker hot path observation-free per §6.1). Comments sharpened to call this out.

### What stayed and why

`Task.Delay(Timeout.InfiniteTimeSpan, ct)` in cancellable handler fixtures — explicitly allowed by §4.5.

`while (deadline) { check; break; Task.Delay(50–200) }` polling loops in saga/observability/rate-limit tests and `WarpTestServer.WaitFor*` helpers — these are bounded wait-for-DB-condition patterns, not timing guesses. Flake risk is bounded by the timeout, not the cadence. Converting them to interceptor-based observers (`WaitForJobLog` pattern) is a separate worthwhile refactor.

## Test plan

- [x] `dotnet build src/Warp.slnx` — clean (0 warnings, 0 errors)
- [x] Full PG suite (642 tests): green
- [x] Full SQL Server suite (636 tests): green
- [x] Full NoDb suite (481 tests): green
- [x] Standalone repro at 0ms grace: 100/100 pass with fix (vs 89/100 without)
- [x] 10× loop of impacted test classes (PG + SQL combined): all pass at ~15s/run

🤖 Generated with [Claude Code](https://claude.com/claude-code)