### PR TITLE
test: wait for saga child handler-jobs to reach Completed

### DIFF
--- a/src/tests/Warp.Tests/Features/Sagas/SagaIntegrationTests.cs
+++ b/src/tests/Warp.Tests/Features/Sagas/SagaIntegrationTests.cs
@@ -38,14 +38,14 @@ public abstract class SagaIntegrationTestsBase : IntegrationTestBase
         await WaitForSagaRemoved(server, "O-1");
 
         // All three message-routed handler jobs ended in Completed state.
+        // WaitForSagaRemoved returns when the saga row is deleted inside the handler's
+        // SaveChanges, but the worker writes State.Completed for the handler-job in a
+        // separate UPDATE after the handler returns — poll for that transition rather
+        // than snapshot, otherwise the last child can still be Processing here.
         var jobIds = new[] { placed, payment, inventory };
         foreach (var jobId in jobIds)
         {
-            var children = await server.CreateContext().Set<Warp.Core.Entities.Job>()
-                .Where(x => x.ParentJobId == jobId)
-                .ToListAsync(Xunit.TestContext.Current.CancellationToken);
-            children.ShouldNotBeEmpty();
-            children.ShouldAllBe(c => c.CurrentState == Warp.Core.Enums.State.Completed);
+            await WaitForChildrenCompleted(server, jobId);
         }
     }
 
@@ -332,6 +332,31 @@ public abstract class SagaIntegrationTestsBase : IntegrationTestBase
         }
 
         throw new TimeoutException($"Saga '{correlationKey}' did not reach expected state (paymentCaptured={paymentCaptured}, inventoryReserved={inventoryReserved})");
+    }
+
+    private static async Task WaitForChildrenCompleted(WarpTestServer server, Guid parentJobId)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        List<Warp.Core.Entities.Job> children = [];
+        while (DateTime.UtcNow < deadline)
+        {
+            children = await server.CreateContext().Set<Warp.Core.Entities.Job>()
+                .AsNoTracking()
+                .Where(x => x.ParentJobId == parentJobId)
+                .ToListAsync(Xunit.TestContext.Current.CancellationToken);
+
+            if (children.Count > 0 && children.All(c => c.CurrentState == Warp.Core.Enums.State.Completed))
+            {
+                return;
+            }
+
+            await Task.Delay(100, Xunit.TestContext.Current.CancellationToken);
+        }
+
+        var snapshot = children.Count == 0
+            ? "<no children>"
+            : string.Join(", ", children.Select(c => $"{c.Id}={c.CurrentState}"));
+        throw new TimeoutException($"Children of {parentJobId} did not all reach Completed within 10s. States: {snapshot}");
     }
 
     private static async Task WaitForSagaRemoved(WarpTestServer server, string correlationKey)


### PR DESCRIPTION
## Summary

- `SagaIntegrationTests.ThreeMessageFlow_InOrder_SagaCompletesAndRowRemoved` raced the worker's terminal `State.Completed` write. `WaitForSagaRemoved` returns the instant the saga row is deleted inside the handler's `SaveChanges` (per §8.17 delete-on-completion), but the worker writes `Completed` for the routed handler-job in a separate UPDATE after the handler returns — so the immediate snapshot `ShouldAllBe(c => c.CurrentState == Completed)` could observe the last child still `Processing`.
- Replace the snapshot with `WaitForChildrenCompleted(server, parentJobId)` (10s poll). On timeout it dumps `{Id}={State}` per child instead of throwing a stateless Shouldly mismatch, so any future failure is diagnostic.
- No production code changed; only the test was racing.

## Test plan

- [x] `dotnet build src/Warp.slnx` — analyzer-clean
- [x] `dotnet test … --filter-class "*SagaIntegrationTests_PostgreSql"` — 8/8 pass
- [x] `dotnet test … --filter-class "*SagaIntegrationTests_SqlServer"` — 8/8 pass
- [ ] CI green on the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)