### PR TITLE
chore(docs): disable system theme option, keep light/dark toggle only

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -96,7 +96,7 @@ const config: Config = {
   themeConfig: {
     image: 'img/screenshots/01-dashboard.png',
     colorMode: {
-      respectPrefersColorScheme: true,
+      respectPrefersColorScheme: false,
       disableSwitch: false,
     },
     docs: {


### PR DESCRIPTION
## Summary

- Docusaurus 3.x renders a three-state `colorMode` switch (Light / Dark / System) in the navbar when `respectPrefersColorScheme: true`. The dashboard uses a binary light/dark toggle, so the docs site now matches.
- Setting `respectPrefersColorScheme: false` collapses the toggle to two states. The OS-preference detection on first load is the trade-off; users still flip themes via the toggle.

## Test plan

- [ ] `npm run build` in `website/` succeeds (verified locally).
- [ ] Navbar toggle on the docs site shows two states only after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)