### PR TITLE
fix: pack Warp.SourceGenerator into Moberg.Warp.Core nupkg

### DIFF
--- a/src/core/Warp.Core/Warp.Core.csproj
+++ b/src/core/Warp.Core/Warp.Core.csproj
@@ -29,4 +29,13 @@
 		<ProjectReference Include="..\Warp.SourceGenerator\Warp.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 
+	<!-- Embed the source generator DLL into the NuGet package as a Roslyn analyzer.
+	     Without this, NuGet consumers of Moberg.Warp.Core get the runtime library but not
+	     the mediator/job dispatch generation — WarpGeneratedHandlerRegistry stays empty
+	     and AddWarp registers nothing. Mirrors the same block in Warp.Http.csproj. -->
+	<ItemGroup>
+		<None Include="..\Warp.SourceGenerator\bin\$(Configuration)\netstandard2.0\Warp.SourceGenerator.dll"
+		      Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false" />
+	</ItemGroup>
+
 </Project>

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,29 @@ sidebar_position: 6
 
 # Releases
 
+## 0.15.1
+
+*2026-05-18*
+
+One packaging fix to `Moberg.Warp.Core`. No public API changes.
+
+### Fixed: source generator missing from the NuGet package
+
+The mediator/job dispatch source generator (`Warp.SourceGenerator`) was wired up as a project-level analyzer in `Warp.Core.csproj` but never packed into `Moberg.Warp.Core.nupkg`. In-tree consumers (Warp's own tests, demos, benchmarks) reference Core via `<ProjectReference>` so the analyzer flowed through normally — masking the gap. Downstream NuGet consumers got the runtime DLL but no generator, so `[ModuleInitializer]`-driven `WarpGeneratedHandlerRegistry` registrations never ran. `AddWarpWorker` then registered nothing and the first `IMediator.Send(...)` threw `"No handler registered for {RequestType}"`.
+
+The bug has been present since handler auto-registration shipped in 0.10.0 (2026-04-27). It surfaced for consumers with more than a trivial number of handlers, where the manual `services.AddScoped<IRequestHandler<,>, ...>()` workaround stopped scaling.
+
+The fix is one block in `Warp.Core.csproj` mirroring what `Warp.Http.csproj` has had since day one — embed the generator DLL into `analyzers/dotnet/cs/`:
+
+```xml
+<ItemGroup>
+  <None Include="..\Warp.SourceGenerator\bin\$(Configuration)\netstandard2.0\Warp.SourceGenerator.dll"
+        Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false" />
+</ItemGroup>
+```
+
+No action required on upgrade beyond bumping the `Moberg.Warp.Core` version. Consumers that worked around the bug with reflection-based handler scanning can drop the workaround once on 0.15.1 — `AddWarpWorker` / `AddWarp` will pick handlers up automatically.
+
 ## 0.15.0
 
 *2026-05-17*


### PR DESCRIPTION
## Summary

- `Warp.SourceGenerator` was referenced as a project-level analyzer in `Warp.Core.csproj` but never embedded into the published `Moberg.Warp.Core.nupkg`. Downstream NuGet consumers got the runtime DLL but no generator, so `WarpGeneratedHandlerRegistry` stayed empty and `AddWarpWorker` registered nothing — first `IMediator.Send(...)` threw `"No handler registered for {RequestType}"`.
- In-tree consumers (Warp's own tests, demos, benchmarks) reference Core via `<ProjectReference>` so the analyzer flowed through normally — which is why CI stayed green and the bug went unnoticed.
- Fix mirrors what `Warp.Http.csproj:23-26` has had since day one — embed the generator DLL into `analyzers/dotnet/cs/`.
- Bug has been latent since handler auto-registration shipped in 0.10.0 (2026-04-27). Surfaces for consumers with more than one or two handlers, where manual `AddScoped<IRequestHandler<,>, ...>()` workarounds stop scaling. See [moberghr/inventhor#39](https://github.com/moberghr/inventhor/pull/39) for the canonical downstream symptom.
- Bumps to 0.15.1 with release-notes entry.

## Test plan

- [x] `dotnet build src/Warp.slnx` clean (0 warnings, 0 errors)
- [x] `dotnet pack src/core/Warp.Core/Warp.Core.csproj -c Release` produces a `.nupkg` containing `analyzers/dotnet/cs/Warp.SourceGenerator.dll` (verified locally)
- [ ] Post-merge: tag `0.15.1`, publish to NuGet, downstream consumer (inventhor) drops the reflection-based handler scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)