### PR TITLE
fix: BackgroundService supervisor + ExpirationCleanup robustness

### DIFF
--- a/src/core/Warp.Core/BackgroundServices/BackgroundServiceLifecycleLogger.cs
+++ b/src/core/Warp.Core/BackgroundServices/BackgroundServiceLifecycleLogger.cs
@@ -51,6 +51,21 @@ public sealed class BackgroundServiceLifecycleLogger
     }
 
     /// <summary>
+    /// Emits a <c>Lifecycle / Error</c> row: a supervisor-side operation (status write, fault
+    /// record, restart-count reset) failed. Distinct from <see cref="LogFaulted"/>, which is for
+    /// failures originating in user code. Treated by the supervisor as a faulted iteration:
+    /// backoff applies and the next iteration retries the whole cycle.
+    /// </summary>
+    public void LogSupervisorFault(Exception ex)
+    {
+        _collector.Enqueue(
+            BackgroundServiceLogSource.Lifecycle,
+            LogLevel.Error,
+            $"Supervisor faulted: {ex.GetType().Name}: {ex.Message}",
+            ex);
+    }
+
+    /// <summary>
     /// Emits a <c>Lifecycle / Warning</c> row: the supervisor is waiting
     /// <paramref name="delay"/> before the next <c>ExecuteAsync</c> invocation.
     /// </summary>

--- a/src/core/Warp.Worker/BackgroundServices/BackgroundServiceSupervisor.cs
+++ b/src/core/Warp.Worker/BackgroundServices/BackgroundServiceSupervisor.cs
@@ -121,148 +121,182 @@ internal sealed class BackgroundServiceSupervisor<TContext>
         }
 
         // Step 2: Main restart loop.
+        //
+        // Each iteration is wrapped in a supervisor-fault catch: if any of the supervisor's
+        // own DB writes (SetStatus, RecordFault, ResetRestartCount) throws, the iteration is
+        // treated as faulted — log an Error, emit a SupervisorFault lifecycle entry, advance
+        // backoff, and retry the iteration. Service execution is gated on the supervisor's
+        // ability to persist status: dashboard truthfulness is preferred over running blind.
+        // The user-fault counter (RestartCount) is NOT incremented for supervisor faults.
         var backoffIndex = 0;
         var attempt = 0;
 
         while (!hostStoppingToken.IsCancellationRequested)
         {
-            // Try to acquire execution rights (always succeeds for per-server; may return null
-            // for singleton while another server holds the lease).
-            BackgroundServiceExecutionScope? executionScope;
+            BackgroundServiceExecutionScope? executionScope = null;
             try
             {
                 executionScope = await _strategy.AcquireAsync(hostStoppingToken);
-            }
-            catch (OperationCanceledException) when (hostStoppingToken.IsCancellationRequested)
-            {
-                break;
-            }
 
-            if (executionScope == null)
-            {
-                // Singleton waiting for the lease — set Waiting status and poll.
-                await TrySetStatusAsync(_service.Name, BackgroundServiceStatus.Waiting, hostStoppingToken);
+                if (executionScope == null)
+                {
+                    // Singleton waiting for the lease — set Waiting status and poll.
+                    await SetStatusAsync(_service.Name, BackgroundServiceStatus.Waiting, hostStoppingToken);
+                    await Task.Delay(_acquirePollInterval, hostStoppingToken);
+
+                    continue;
+                }
+
+                // Acquired — set Running status and emit lifecycle log.
+                await SetStatusAsync(_service.Name, BackgroundServiceStatus.Running, hostStoppingToken);
+
+                if (_strategy.Scope == ServiceScope.Singleton)
+                {
+                    _lifecycleLogger.LogLeaseAcquired();
+                }
+                else
+                {
+                    _lifecycleLogger.LogStarted();
+                }
+
+                var startedAt = _time.GetUtcNow();
+                var faultException = default(Exception?);
+                var leaseLost = false;
+
+                WarpTelemetry.BackgroundServicesStarted.Add(1, new KeyValuePair<string, object?>("service_name", _service.Name));
+
                 try
                 {
-                    await Task.Delay(_acquirePollInterval, hostStoppingToken);
+                    await _service.InvokeExecuteAsync(executionScope.Token);
+
+                    // User code returned without cancellation — treat as fault.
+                    faultException = new InvalidOperationException(
+                        $"{_service.Name}.ExecuteAsync returned without cancellation. " +
+                        "WarpBackgroundService must run until its CancellationToken is cancelled.");
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (hostStoppingToken.IsCancellationRequested)
                 {
-                    break;
+                    // Graceful host shutdown — let it bubble to the outer catch.
+                    throw;
+                }
+                catch (OperationCanceledException) when (
+                    executionScope.Token.IsCancellationRequested
+                    && !hostStoppingToken.IsCancellationRequested)
+                {
+                    // Lease was lost (singleton: internal CTS fired). Release scope and restart.
+                    leaseLost = true;
+                }
+                catch (Exception ex)
+                {
+                    faultException = ex;
                 }
 
-                continue;
-            }
+                // Release the scope (unsubscribes signal, disposes linked CTS, releases lease).
+                // Null out the local so the iteration's finally block doesn't double-release.
+                await TryReleaseAsync(executionScope);
+                executionScope = null;
 
-            // Acquired — set Running status and emit lifecycle log.
-            await TrySetStatusAsync(_service.Name, BackgroundServiceStatus.Running, hostStoppingToken);
+                if (leaseLost)
+                {
+                    _lifecycleLogger.LogLeaseLost("lease lost between heartbeats");
 
-            if (_strategy.Scope == ServiceScope.Singleton)
-            {
-                _lifecycleLogger.LogLeaseAcquired();
-            }
-            else
-            {
-                _lifecycleLogger.LogStarted();
-            }
+                    // Emit Faulted then Waiting so the dashboard timeline shows the full
+                    // Running → Faulted → Waiting transition deterministically.
+                    // Without the Waiting write the next AcquireAsync may immediately re-acquire
+                    // and the timeline jumps from Faulted straight to Running.
+                    await SetStatusAsync(_service.Name, BackgroundServiceStatus.Faulted, hostStoppingToken);
+                    await SetStatusAsync(_service.Name, BackgroundServiceStatus.Waiting, hostStoppingToken);
 
-            var startedAt = _time.GetUtcNow();
-            var faultException = default(Exception?);
-            var leaseLost = false;
+                    // Re-enter acquire loop as a waiter — backoff resets so the lease attempt is immediate.
+                    backoffIndex = 0;
+                    attempt = 0;
+                    continue;
+                }
 
-            WarpTelemetry.BackgroundServicesStarted.Add(1, new KeyValuePair<string, object?>("service_name", _service.Name));
+                if (faultException != null)
+                {
+                    WarpTelemetry.BackgroundServicesFaulted.Add(
+                        1,
+                        new KeyValuePair<string, object?>("service_name", _service.Name),
+                        new KeyValuePair<string, object?>("exception_type", faultException.GetType().Name));
+                    _lifecycleLogger.LogFaulted(faultException);
+                    _logger.LogError(faultException, "BackgroundService {Name} faulted", _service.Name);
+                    await RecordFaultAsync(_service.Name, faultException, hostStoppingToken);
+                }
 
-            try
-            {
-                await _service.InvokeExecuteAsync(executionScope.Token);
+                // Healthy-reset check: if the service ran for ≥5 min before this fault, reset
+                // the backoff — it was a transient blip on an otherwise healthy service.
+                //
+                // ORDER CONTRACT: RecordFaultAsync (above) increments RestartCount BEFORE this
+                // block clears it. HealthyResetTests asserts RestartCount == 1 after a second
+                // fault, which only holds if the order stays Record→Reset (not Reset→Record).
+                // If you reorder these, update HealthyResetTestsBase's assertion accordingly.
+                var ranFor = _time.GetUtcNow() - startedAt;
+                if (ranFor >= BackgroundServiceSupervisorConstants.HealthyResetThreshold)
+                {
+                    await ResetRestartCountAsync(_service.Name, hostStoppingToken);
+                    backoffIndex = 0;
+                }
 
-                // User code returned without cancellation — treat as fault.
-                faultException = new InvalidOperationException(
-                    $"{_service.Name}.ExecuteAsync returned without cancellation. " +
-                    "WarpBackgroundService must run until its CancellationToken is cancelled.");
+                var backoffSequence = BackgroundServiceSupervisorConstants.BackoffSequence;
+                var backoff = backoffSequence[Math.Min(backoffIndex, backoffSequence.Length - 1)];
+                backoffIndex++;
+                attempt++;
+
+                await SetStatusAsync(_service.Name, BackgroundServiceStatus.Restarting, hostStoppingToken);
+                _lifecycleLogger.LogRestarting(attempt, backoff);
+
+                WarpTelemetry.BackgroundServicesRestarts.Add(1, new KeyValuePair<string, object?>("service_name", _service.Name));
+
+                await Task.Delay(backoff, _time, hostStoppingToken);
             }
             catch (OperationCanceledException) when (hostStoppingToken.IsCancellationRequested)
             {
-                // Graceful host shutdown — release scope and exit loop.
-                await TryReleaseAsync(executionScope);
                 _lifecycleLogger.LogStopped();
                 break;
-            }
-            catch (OperationCanceledException) when (
-                executionScope.Token.IsCancellationRequested
-                && !hostStoppingToken.IsCancellationRequested)
-            {
-                // Lease was lost (singleton: internal CTS fired). Release scope and restart.
-                leaseLost = true;
             }
             catch (Exception ex)
             {
-                faultException = ex;
-            }
+                // Supervisor-side fault — typically a DB write that failed (timeout under load,
+                // pool exhaustion, transient connection error). Log an Error, emit a
+                // SupervisorFault lifecycle entry, advance backoff, and retry the iteration.
+                // RestartCount stays untouched: it counts user-code faults, not infrastructure ones.
+                _logger.LogError(ex, "BackgroundService {Name}: supervisor iteration faulted", _service.Name);
+                _lifecycleLogger.LogSupervisorFault(ex);
 
-            // Release the scope (unsubscribes signal, disposes linked CTS, releases lease).
-            await TryReleaseAsync(executionScope);
-
-            if (leaseLost)
-            {
-                _lifecycleLogger.LogLeaseLost("lease lost between heartbeats");
-
-                // Emit Faulted then Waiting so the dashboard timeline shows the full
-                // Running → Faulted → Waiting transition deterministically.
-                // Without the Waiting write the next AcquireAsync may immediately re-acquire
-                // and the timeline jumps from Faulted straight to Running.
-                await TrySetStatusAsync(_service.Name, BackgroundServiceStatus.Faulted, hostStoppingToken);
-                await TrySetStatusAsync(_service.Name, BackgroundServiceStatus.Waiting, hostStoppingToken);
-
-                // Re-enter acquire loop as a waiter — backoff resets so the lease attempt is immediate.
-                backoffIndex = 0;
-                attempt = 0;
-                continue;
-            }
-
-            if (faultException != null)
-            {
                 WarpTelemetry.BackgroundServicesFaulted.Add(
                     1,
                     new KeyValuePair<string, object?>("service_name", _service.Name),
-                    new KeyValuePair<string, object?>("exception_type", faultException.GetType().Name));
-                _lifecycleLogger.LogFaulted(faultException);
-                _logger.LogError(faultException, "BackgroundService {Name} faulted", _service.Name);
-                await TryRecordFaultAsync(_service.Name, faultException, hostStoppingToken);
+                    new KeyValuePair<string, object?>("exception_type", ex.GetType().Name));
+
+                var backoffSequence = BackgroundServiceSupervisorConstants.BackoffSequence;
+                var backoff = backoffSequence[Math.Min(backoffIndex, backoffSequence.Length - 1)];
+                backoffIndex++;
+
+                try
+                {
+                    // Supervisor-fault recovery uses REAL time, not `_time`. The injected
+                    // TimeProvider exists so user-fault backoff (1s, 2s, 4s...) can be compressed
+                    // by fake-time tests, but supervisor faults are infrastructure-recovery delays
+                    // (DB blip, pool exhaustion) that should pass on the wall clock regardless of
+                    // what fake-time the test is driving for its own choreography.
+                    await Task.Delay(backoff, hostStoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    _lifecycleLogger.LogStopped();
+                    break;
+                }
             }
-
-            // Healthy-reset check: if the service ran for ≥5 min before this fault, reset
-            // the backoff — it was a transient blip on an otherwise healthy service.
-            //
-            // ORDER CONTRACT: RecordFaultAsync (above) increments RestartCount BEFORE this
-            // block clears it. HealthyResetTests asserts RestartCount == 1 after a second
-            // fault, which only holds if the order stays Record→Reset (not Reset→Record).
-            // If you reorder these, update HealthyResetTestsBase's assertion accordingly.
-            var ranFor = _time.GetUtcNow() - startedAt;
-            if (ranFor >= BackgroundServiceSupervisorConstants.HealthyResetThreshold)
+            finally
             {
-                await TryResetRestartCountAsync(_service.Name, hostStoppingToken);
-                backoffIndex = 0;
-            }
-
-            var backoffSequence = BackgroundServiceSupervisorConstants.BackoffSequence;
-            var backoff = backoffSequence[Math.Min(backoffIndex, backoffSequence.Length - 1)];
-            backoffIndex++;
-            attempt++;
-
-            await TrySetStatusAsync(_service.Name, BackgroundServiceStatus.Restarting, hostStoppingToken);
-            _lifecycleLogger.LogRestarting(attempt, backoff);
-
-            WarpTelemetry.BackgroundServicesRestarts.Add(1, new KeyValuePair<string, object?>("service_name", _service.Name));
-
-            try
-            {
-                await Task.Delay(backoff, _time, hostStoppingToken);
-            }
-            catch (OperationCanceledException)
-            {
-                _lifecycleLogger.LogStopped();
-                break;
+                // Release the execution scope if the iteration body threw before the inline
+                // release call. Prevents singleton-lease leaks when a status write fails
+                // between AcquireAsync and the explicit release point.
+                if (executionScope != null)
+                {
+                    await TryReleaseAsync(executionScope);
+                }
             }
         }
 
@@ -302,60 +336,39 @@ internal sealed class BackgroundServiceSupervisor<TContext>
         return null;
     }
 
-    private async Task TrySetStatusAsync(string name, BackgroundServiceStatus status, CancellationToken ct)
+    // Status / fault / reset writes propagate exceptions to the supervisor's outer iteration
+    // catch. The observer is only invoked after the DB write succeeds — observers can rely on
+    // "if I was called, the transition was persisted." This is the contract documented on
+    // IBackgroundServiceStatusObserver.
+    private async Task SetStatusAsync(string name, BackgroundServiceStatus status, CancellationToken ct)
     {
-        try
-        {
-            using var scope = _scopes.CreateScope();
-            var stateService = scope.ServiceProvider.GetRequiredService<IBackgroundServiceStateService>();
-            await stateService.SetStatusAsync(name, status, ct);
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
-        {
-            _logger.LogWarning(ex, "BackgroundService {Name}: failed to set status {Status}", name, status);
+        using var scope = _scopes.CreateScope();
+        var stateService = scope.ServiceProvider.GetRequiredService<IBackgroundServiceStateService>();
+        await stateService.SetStatusAsync(name, status, ct);
 
-            return;
-        }
-
-        // Fire the observer only after the DB write succeeds — observers can rely on
-        // "if I was called, the transition was persisted." This is the contract documented
-        // on IBackgroundServiceStatusObserver.
         try
         {
             _statusObserver.OnStatusChanged(name, status);
         }
         catch (Exception ex)
         {
+            // A misbehaving observer must not take the supervisor down.
             _logger.LogWarning(ex, "BackgroundService {Name}: status observer threw on transition to {Status}", name, status);
         }
     }
 
-    private async Task TryRecordFaultAsync(string name, Exception ex, CancellationToken ct)
+    private async Task RecordFaultAsync(string name, Exception ex, CancellationToken ct)
     {
-        try
-        {
-            using var scope = _scopes.CreateScope();
-            var stateService = scope.ServiceProvider.GetRequiredService<IBackgroundServiceStateService>();
-            await stateService.RecordFaultAsync(name, ex, ct);
-        }
-        catch (Exception innerEx) when (!ct.IsCancellationRequested)
-        {
-            _logger.LogWarning(innerEx, "BackgroundService {Name}: failed to record fault", name);
-        }
+        using var scope = _scopes.CreateScope();
+        var stateService = scope.ServiceProvider.GetRequiredService<IBackgroundServiceStateService>();
+        await stateService.RecordFaultAsync(name, ex, ct);
     }
 
-    private async Task TryResetRestartCountAsync(string name, CancellationToken ct)
+    private async Task ResetRestartCountAsync(string name, CancellationToken ct)
     {
-        try
-        {
-            using var scope = _scopes.CreateScope();
-            var stateService = scope.ServiceProvider.GetRequiredService<IBackgroundServiceStateService>();
-            await stateService.ResetRestartCountAsync(name, ct);
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
-        {
-            _logger.LogWarning(ex, "BackgroundService {Name}: failed to reset restart count", name);
-        }
+        using var scope = _scopes.CreateScope();
+        var stateService = scope.ServiceProvider.GetRequiredService<IBackgroundServiceStateService>();
+        await stateService.ResetRestartCountAsync(name, ct);
     }
 
     private async Task<ServiceScope?> TryGetDefinedScopeAsync(string name, CancellationToken ct)

--- a/src/core/Warp.Worker/Services/ExpirationCleanup.cs
+++ b/src/core/Warp.Worker/Services/ExpirationCleanup.cs
@@ -63,9 +63,14 @@ public sealed class ExpirationCleanup<TContext> : IServerTask
         var now = _time.GetUtcNow().UtcDateTime;
         var batchSize = _configuration.ExpirationBatchSize;
 
+        // Only delete jobs that have no children at all. Internal nodes of an expired tree
+        // wait until their (already-expired) children are cleaned in an earlier tick — this
+        // prevents the self-FK fk_job_job_parent_job_id from firing when Take(batchSize)
+        // would otherwise return a parent without all of its children. Trees drain one level
+        // per tick.
         var expiredJobIds = await _context.Set<Job>()
             .Where(x => x.ExpireAt != null && x.ExpireAt < now)
-            .Where(x => !x.ChildJobs.Any(c => c.ExpireAt == null || c.ExpireAt >= now))
+            .Where(x => !x.ChildJobs.Any())
             .Select(x => x.Id)
             .Take(batchSize)
             .ToListAsync(ct);
@@ -157,11 +162,13 @@ public sealed class ExpirationCleanup<TContext> : IServerTask
             }
 
             var toDelete = Math.Min(expirableCount - maxCount, batchSize);
-            var now = _time.GetUtcNow().UtcDateTime;
 
+            // Same FK-safety constraint as RunCleanupAsync: only delete leaves so the
+            // self-FK fk_job_job_parent_job_id can't fire on a parent whose children
+            // happen to land in a different batch.
             var jobIds = await _context.Set<Job>()
                 .Where(x => x.ExpireAt != null)
-                .Where(x => !x.ChildJobs.Any(c => c.ExpireAt == null || c.ExpireAt >= now))
+                .Where(x => !x.ChildJobs.Any())
                 .OrderBy(x => x.ExpireAt)
                 .Select(x => x.Id)
                 .Take(toDelete)

--- a/src/tests/Warp.Tests/BackgroundServices/HealthyResetTestsBase.cs
+++ b/src/tests/Warp.Tests/BackgroundServices/HealthyResetTestsBase.cs
@@ -17,12 +17,13 @@ public abstract class HealthyResetTestsBase : IntegrationTestBase
     {
     }
 
-    [TimedFact(20_000)]
+    [TimedFact]
     public async Task ServiceRanFor5Min_ThenFaults_RestartCountResetsToZero()
     {
         var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
         var state = new HealthyResetServiceState();
         var observer = new TestStatusObserver();
+        var ct = Xunit.TestContext.Current.CancellationToken;
 
         // Register the first Running waiter BEFORE starting the server so we cannot miss
         // the transition even if the supervisor sets Running synchronously during startup.
@@ -43,11 +44,11 @@ public abstract class HealthyResetTestsBase : IntegrationTestBase
             });
 
         // Step 1: Supervisor wrote Running — first ExecuteAsync call is in-flight.
-        await firstRunningReached;
+        await WaitForObserverAsync(firstRunningReached, "first Running transition", ct);
 
         // Wait for the service itself to signal that it is inside ExecuteAsync and parked
         // on CanAdvanceTime. This ensures the startedAt timestamp is captured before we advance.
-        await state.RunningGate.WaitAsync(Xunit.TestContext.Current.CancellationToken);
+        await state.RunningGate.WaitAsync(ct);
 
         // Step 2: Register Restarting waiter BEFORE releasing the first attempt so we don't
         // race the supervisor's post-fault path.
@@ -60,31 +61,33 @@ public abstract class HealthyResetTestsBase : IntegrationTestBase
         time.Advance(TimeSpan.FromMinutes(6));
         state.CanAdvanceTime.Release();
 
-        await firstRestartingReached;
+        await WaitForObserverAsync(firstRestartingReached, "first Restarting transition", ct);
 
-        // Step 3: At this point the supervisor has written Restarting and is about to park at
-        // Task.Delay(1s, _time, hostStoppingToken). The observer fires BEFORE the delay is
-        // created (supervisor runs a few sync statements between Restarting and Delay). Advance
-        // time in small steps with Task.Yield() between each so the supervisor has a chance to
-        // reach and process each advance.
+        // Step 3: Supervisor has written Restarting and will park on Task.Delay(1s, _time, ct)
+        // after a few sync statements. PumpFakeTimeUntilAsync advances fake time in 1s steps
+        // until the next observer event fires, with Task.Delay(10ms) between advances so the
+        // supervisor's continuation gets real CPU on a contended runner rather than just being
+        // re-queued behind us. Bounded by a wall-clock deadline that throws with a clear message
+        // if the supervisor never reaches Running.
         var secondRunningReached = observer.NextStatus(nameof(HealthyResetService), BackgroundServiceStatus.Running);
 
-        while (!secondRunningReached.IsCompleted)
-        {
-            time.Advance(TimeSpan.FromSeconds(1));
-            await Task.Yield();
-        }
+        await PumpFakeTimeUntilAsync(
+            time,
+            secondRunningReached,
+            step: TimeSpan.FromSeconds(1),
+            description: "second Running transition",
+            ct: ct);
 
         // Step 4: Second attempt is now Running. Register Restarting waiter for the second
         // fault before waiting for FaultedGate.
         var secondRestartingReached = observer.NextStatus(nameof(HealthyResetService), BackgroundServiceStatus.Restarting);
 
         // Wait for the service to signal that it is about to throw on the second attempt.
-        await state.FaultedGate.WaitAsync(Xunit.TestContext.Current.CancellationToken);
+        await state.FaultedGate.WaitAsync(ct);
 
         // Supervisor: RecordFault (RestartCount = 1, because HealthyReset cleared it to 0 after
         // the first fault), HealthyReset check (ranFor < 5 min → no reset), SetStatus(Restarting).
-        await secondRestartingReached;
+        await WaitForObserverAsync(secondRestartingReached, "second Restarting transition", ct);
 
         // Step 5: Assert. RestartCount should be 1:
         //   - First fault: RecordFault → count=1, HealthyReset fires → count reset to 0
@@ -94,11 +97,68 @@ public abstract class HealthyResetTestsBase : IntegrationTestBase
         var instance = await ctx.Set<BackgroundServiceInstance>()
             .Where(x => x.ServerId == server.ServerId)
             .Where(x => x.ServiceName == nameof(HealthyResetService))
-            .FirstOrDefaultAsync(Xunit.TestContext.Current.CancellationToken);
+            .FirstOrDefaultAsync(ct);
 
         instance.ShouldNotBeNull();
         instance.RestartCount.ShouldBe(
             1,
             "healthy-reset cleared the counter after the 5-min first run; the second fault then adds 1");
+    }
+
+    // Wall-clock budget per observer wait. Sized to fit comfortably inside [TimedFact]'s default
+    // 10s budget while still surfacing real hangs fast with a named transition rather than
+    // blowing the whole [TimedFact] silently. A healthy run hits each wait in well under a
+    // second; if the budget here is being exhausted, the right response is to investigate what
+    // the supervisor is stuck on — not to raise the budget.
+    private static readonly TimeSpan ObserverWaitTimeout = TimeSpan.FromSeconds(8);
+
+    /// <summary>
+    /// Awaits an observer task with a bounded wall-clock deadline. If the deadline hits before
+    /// the observer fires, throws <see cref="TimeoutException"/> naming the missed transition.
+    /// Without this, a dropped observer (e.g. a supervisor-side fault that prevents
+    /// <c>SetStatusAsync</c> from completing) wedges the test until xUnit's <c>[TimedFact]</c>
+    /// budget hits, with no information about which step actually stalled.
+    /// </summary>
+    private static async Task WaitForObserverAsync(Task observerTask, string description, CancellationToken ct)
+    {
+        var completed = await Task.WhenAny(observerTask, Task.Delay(ObserverWaitTimeout, ct));
+        if (completed != observerTask)
+        {
+            throw new TimeoutException(
+                $"HealthyResetService did not reach {description} within {ObserverWaitTimeout.TotalSeconds:F0}s.");
+        }
+
+        // Surface any exception captured on the observer task.
+        await observerTask;
+    }
+
+    /// <summary>
+    /// Drives <paramref name="time"/> forward in <paramref name="step"/> chunks until
+    /// <paramref name="signal"/> completes, with a small real-time delay between advances to
+    /// let the supervisor continuation actually run on contended runners. Bounded by
+    /// <see cref="ObserverWaitTimeout"/>; throws <see cref="TimeoutException"/> naming
+    /// <paramref name="description"/> on miss.
+    /// </summary>
+    private static async Task PumpFakeTimeUntilAsync(
+        FakeTimeProvider time,
+        Task signal,
+        TimeSpan step,
+        string description,
+        CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + ObserverWaitTimeout;
+        while (!signal.IsCompleted)
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new TimeoutException(
+                    $"HealthyResetService did not reach {description} within {ObserverWaitTimeout.TotalSeconds:F0}s of fake-time pumping.");
+            }
+
+            time.Advance(step);
+            await Task.Delay(TimeSpan.FromMilliseconds(10), ct);
+        }
+
+        await signal;
     }
 }

--- a/src/tests/Warp.Tests/BackgroundServices/HealthyResetTestsBase.cs
+++ b/src/tests/Warp.Tests/BackgroundServices/HealthyResetTestsBase.cs
@@ -63,13 +63,18 @@ public abstract class HealthyResetTestsBase : IntegrationTestBase
 
         await WaitForObserverAsync(firstRestartingReached, "first Restarting transition", ct);
 
-        // Step 3: Supervisor has written Restarting and will park on Task.Delay(1s, _time, ct)
-        // after a few sync statements. PumpFakeTimeUntilAsync advances fake time in 1s steps
-        // until the next observer event fires, with Task.Delay(10ms) between advances so the
-        // supervisor's continuation gets real CPU on a contended runner rather than just being
-        // re-queued behind us. Bounded by a wall-clock deadline that throws with a clear message
-        // if the supervisor never reaches Running.
+        // Step 3: register BOTH the second Running waiter AND the second Restarting waiter
+        // BEFORE pumping fake time. The second-attempt service body releases FaultedGate and
+        // throws immediately (no gate), so under fast DB conditions (warm Postgres pool,
+        // sub-millisecond UPDATEs) the supervisor races through SetStatus(Running) →
+        // service.ExecuteAsync → RecordFault → SetStatus(Restarting) in well under the pump
+        // loop's 10ms Task.Delay tick. If we registered the Restarting waiter *after* the pump
+        // exits, the supervisor's SetStatus(Restarting) would fire OnStatusChanged with no
+        // matching waiter — TestStatusObserver does not buffer unmatched events, so the
+        // transition would be lost and the subsequent await would hang to the bounded-wait
+        // timeout. Registering both up-front closes the race regardless of DB latency.
         var secondRunningReached = observer.NextStatus(nameof(HealthyResetService), BackgroundServiceStatus.Running);
+        var secondRestartingReached = observer.NextStatus(nameof(HealthyResetService), BackgroundServiceStatus.Restarting);
 
         await PumpFakeTimeUntilAsync(
             time,
@@ -78,15 +83,13 @@ public abstract class HealthyResetTestsBase : IntegrationTestBase
             description: "second Running transition",
             ct: ct);
 
-        // Step 4: Second attempt is now Running. Register Restarting waiter for the second
-        // fault before waiting for FaultedGate.
-        var secondRestartingReached = observer.NextStatus(nameof(HealthyResetService), BackgroundServiceStatus.Restarting);
-
-        // Wait for the service to signal that it is about to throw on the second attempt.
+        // Step 4: Wait for the service to signal that it is about to throw on the second attempt.
         await state.FaultedGate.WaitAsync(ct);
 
         // Supervisor: RecordFault (RestartCount = 1, because HealthyReset cleared it to 0 after
         // the first fault), HealthyReset check (ranFor < 5 min → no reset), SetStatus(Restarting).
+        // The Restarting waiter was registered in step 3 so this completes regardless of how
+        // fast the supervisor got there.
         await WaitForObserverAsync(secondRestartingReached, "second Restarting transition", ct);
 
         // Step 5: Assert. RestartCount should be 1:

--- a/src/tests/Warp.Tests/BackgroundServices/SupervisorFaultTestsBase.cs
+++ b/src/tests/Warp.Tests/BackgroundServices/SupervisorFaultTestsBase.cs
@@ -1,0 +1,147 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Shouldly;
+using Warp.Core.BackgroundServices;
+using Warp.Core.Data.Entities;
+using Warp.Tests.Fixtures;
+using Warp.Tests.TestData.BackgroundServices;
+using Warp.Worker.BackgroundServices;
+
+namespace Warp.Tests.BackgroundServices;
+
+[GenerateDatabaseTests]
+public abstract class SupervisorFaultTestsBase : IntegrationTestBase
+{
+    protected SupervisorFaultTestsBase(IDatabaseFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [TimedFact(15_000)]
+    public async Task SetStatusRunningThrowsOnce_SupervisorFaultLogged_ServiceRunsOnNextIteration()
+    {
+        var injector = new StateServiceFaultInjector { ThrowsRemaining = 1 };
+        var counter = new CountingServiceState();
+
+        await using var server = await WarpTestServer.StartAsync(
+            Fixture,
+            configure: cfg => cfg.AddBackgroundService<TestContext, CountingService>(),
+            configureServices: services =>
+            {
+                services.AddSingleton(counter);
+                services.AddSingleton(injector);
+
+                // Last scoped registration wins on GetRequiredService. The real
+                // BackgroundServiceStateService<TestContext> is still in the descriptor list
+                // and is the concrete type the decorator delegates to.
+                services.AddScoped<IBackgroundServiceStateService>(sp =>
+                    new FaultInjectingStateService(
+                        ActivatorUtilities.CreateInstance<BackgroundServiceStateService<TestContext>>(sp),
+                        sp.GetRequiredService<StateServiceFaultInjector>()));
+            });
+
+        // The supervisor's first iteration must trip the injector: SetStatus(Running) throws
+        // → outer catch logs LogSupervisorFault (Lifecycle / Error). Wait for the log row to
+        // land in the DB so we know the supervisor took the new fault path, not the old
+        // silent-swallow path.
+        await WarpTestServer.WaitUntil(
+            async () =>
+            {
+                var ctx = Fixture.CreateContext();
+                return await ctx.Set<BackgroundServiceLog>()
+                    .Where(x => x.ServerId == server.ServerId)
+                    .Where(x => x.ServiceName == nameof(CountingService))
+                    .Where(x => x.Source == BackgroundServiceLogSource.Lifecycle)
+                    .Where(x => x.Level == LogLevel.Error)
+                    .Where(x => x.Message.StartsWith("Supervisor faulted"))
+                    .AnyAsync(Xunit.TestContext.Current.CancellationToken);
+            },
+            timeout: TimeSpan.FromSeconds(10),
+            ct: Xunit.TestContext.Current.CancellationToken);
+
+        // After backoff (1s) the supervisor retries; the injector is exhausted, SetStatus(Running)
+        // succeeds, and CountingService runs. The counter incrementing is the proof that user
+        // code reached ExecuteAsync after the supervisor recovered.
+        await WarpTestServer.WaitUntil(
+            () => Task.FromResult(Volatile.Read(ref counter.Count) > 0),
+            timeout: TimeSpan.FromSeconds(10),
+            ct: Xunit.TestContext.Current.CancellationToken);
+
+        // RestartCount is reserved for user-code faults. A supervisor fault must NOT bump it.
+        var instance = await Fixture.CreateContext().Set<BackgroundServiceInstance>()
+            .Where(x => x.ServerId == server.ServerId)
+            .Where(x => x.ServiceName == nameof(CountingService))
+            .FirstOrDefaultAsync(Xunit.TestContext.Current.CancellationToken);
+
+        instance.ShouldNotBeNull();
+        instance.RestartCount.ShouldBe(0, "supervisor faults must not increment the user-fault counter");
+    }
+}
+
+public sealed class StateServiceFaultInjector
+{
+    private int _throwsRemaining;
+
+    public int ThrowsRemaining
+    {
+        get => Volatile.Read(ref _throwsRemaining);
+        set => Volatile.Write(ref _throwsRemaining, value);
+    }
+
+    public bool ConsumeIfRemaining()
+    {
+        // Atomic decrement-if-positive — multiple supervisors / pipeline behaviors hitting
+        // the injector concurrently must not all consume the same allotment.
+        while (true)
+        {
+            var current = Volatile.Read(ref _throwsRemaining);
+            if (current <= 0)
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _throwsRemaining, current - 1, current) == current)
+            {
+                return true;
+            }
+        }
+    }
+}
+
+internal sealed class FaultInjectingStateService : IBackgroundServiceStateService
+{
+    private readonly IBackgroundServiceStateService _inner;
+    private readonly StateServiceFaultInjector _injector;
+
+    public FaultInjectingStateService(IBackgroundServiceStateService inner, StateServiceFaultInjector injector)
+    {
+        _inner = inner;
+        _injector = injector;
+    }
+
+    public Task<RegistrationOutcome> RegisterAsync(string serviceName, ServiceScope declaredScope, CancellationToken ct)
+        => _inner.RegisterAsync(serviceName, declaredScope, ct);
+
+    public Task SetStatusAsync(string serviceName, BackgroundServiceStatus status, CancellationToken ct)
+    {
+        if (status == BackgroundServiceStatus.Running && _injector.ConsumeIfRemaining())
+        {
+            throw new InvalidOperationException("Injected DB failure on SetStatusAsync(Running)");
+        }
+
+        return _inner.SetStatusAsync(serviceName, status, ct);
+    }
+
+    public Task RecordFaultAsync(string serviceName, Exception ex, CancellationToken ct)
+        => _inner.RecordFaultAsync(serviceName, ex, ct);
+
+    public Task ResetRestartCountAsync(string serviceName, CancellationToken ct)
+        => _inner.ResetRestartCountAsync(serviceName, ct);
+
+    public Task DeleteAsync(string serviceName, CancellationToken ct)
+        => _inner.DeleteAsync(serviceName, ct);
+
+    public Task<ServiceScope?> GetDefinedScopeAsync(string serviceName, CancellationToken ct)
+        => _inner.GetDefinedScopeAsync(serviceName, ct);
+}

--- a/src/tests/Warp.Tests/Scheduling/ExpirationEdgeCaseTests.cs
+++ b/src/tests/Warp.Tests/Scheduling/ExpirationEdgeCaseTests.cs
@@ -398,13 +398,16 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
     }
 
     /// <summary>
-    /// BUG: Expiration cleanup fails with FK violation when parent job has ExpireAt
-    /// but child jobs still reference it via ParentJobId.
+    /// Expired parent + expired child must drain without violating the self-FK
+    /// <c>fk_job_job_parent_job_id</c>. The cleanup only deletes leaves on any given
+    /// tick, so this two-level tree clears in exactly two ticks: tick 1 removes the
+    /// child, tick 2 removes the (now-leaf) parent. Earlier code attempted to delete
+    /// parent + child in one batch and intermittently hit the FK when
+    /// <c>Take(batchSize)</c> dropped the child but kept the parent.
     /// </summary>
     [TimedFact]
-    public async Task ExpirationCleanup_ParentWithChildren_DoesNotThrowFkViolation()
+    public async Task ExpirationCleanup_ParentWithChildren_DrainsAcrossTicks()
     {
-        // Arrange: parent with ExpireAt in the past, child referencing it
         var ctx = _fixture.CreateContext();
         var parentId = Guid.NewGuid();
         var childId = Guid.NewGuid();
@@ -417,7 +420,7 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
             CreateTime = DateTime.UtcNow,
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
-            ExpireAt = DateTime.UtcNow.AddHours(-1), // expired
+            ExpireAt = DateTime.UtcNow.AddHours(-1),
         });
         ctx.Set<Job>().Add(new Job
         {
@@ -428,21 +431,105 @@ public abstract class ExpirationEdgeCaseTestsBase : IAsyncLifetime
             ScheduleTime = DateTime.UtcNow,
             Queue = "default",
             ParentJobId = parentId,
-            ExpireAt = DateTime.UtcNow.AddHours(-1), // also expired
+            ExpireAt = DateTime.UtcNow.AddHours(-1),
         });
         await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
 
-        // Act: should not throw FK violation
-        var cleanCtx = _fixture.CreateContext();
+        // Tick 1: only the child (a leaf) is eligible.
+        var firstTick = _fixture.CreateContext();
         await Should.NotThrowAsync(async () =>
-            await Warp.Tests.Helpers.TestTasks.CreateExpirationCleanup(cleanCtx, TimeProvider.System).RunCleanupAsync(CancellationToken.None));
+            await Warp.Tests.Helpers.TestTasks.CreateExpirationCleanup(firstTick, TimeProvider.System).RunCleanupAsync(CancellationToken.None));
 
-        // Assert: both should be deleted
-        var readCtx = _fixture.CreateContext();
-        var parent = await readCtx.Set<Job>().FindAsync([parentId], Xunit.TestContext.Current.CancellationToken);
-        var child = await readCtx.Set<Job>().FindAsync([childId], Xunit.TestContext.Current.CancellationToken);
-        parent.ShouldBeNull("Parent should be cleaned up");
-        child.ShouldBeNull("Child should be cleaned up");
+        var afterTick1 = _fixture.CreateContext();
+        (await afterTick1.Set<Job>().FindAsync([childId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldBeNull("Child is a leaf and should be deleted on the first tick");
+        (await afterTick1.Set<Job>().FindAsync([parentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldNotBeNull("Parent has a remaining child reference on tick 1 — must wait for tick 2");
+
+        // Tick 2: parent is now a leaf (its child is gone) and eligible.
+        var secondTick = _fixture.CreateContext();
+        await Should.NotThrowAsync(async () =>
+            await Warp.Tests.Helpers.TestTasks.CreateExpirationCleanup(secondTick, TimeProvider.System).RunCleanupAsync(CancellationToken.None));
+
+        var afterTick2 = _fixture.CreateContext();
+        (await afterTick2.Set<Job>().FindAsync([parentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldBeNull("Parent should be cleaned up on the second tick");
+    }
+
+    /// <summary>
+    /// Three-level tree (grandparent → parent → child) all expired. Drains one level per
+    /// tick: tick 1 removes child, tick 2 removes parent (now a leaf), tick 3 removes
+    /// grandparent (now a leaf). No tick should violate <c>fk_job_job_parent_job_id</c>.
+    /// </summary>
+    [TimedFact]
+    public async Task ExpirationCleanup_ThreeLevelTree_DrainsOneLevelPerTick()
+    {
+        var ctx = _fixture.CreateContext();
+        var grandparentId = Guid.NewGuid();
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var expired = DateTime.UtcNow.AddHours(-1);
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = grandparentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ExpireAt = expired,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = grandparentId,
+            ExpireAt = expired,
+        });
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = childId,
+            Kind = JobKind.Job,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ParentJobId = parentId,
+            ExpireAt = expired,
+        });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        async Task RunCleanupTickAsync()
+        {
+            var tickCtx = _fixture.CreateContext();
+            await Should.NotThrowAsync(async () =>
+                await Warp.Tests.Helpers.TestTasks
+                    .CreateExpirationCleanup(tickCtx, TimeProvider.System)
+                    .RunCleanupAsync(CancellationToken.None));
+        }
+
+        await RunCleanupTickAsync();
+        (await _fixture.CreateContext().Set<Job>().FindAsync([childId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldBeNull("tick 1: child is a leaf");
+        (await _fixture.CreateContext().Set<Job>().FindAsync([parentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldNotBeNull("tick 1: parent still has child reference");
+        (await _fixture.CreateContext().Set<Job>().FindAsync([grandparentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldNotBeNull("tick 1: grandparent still has parent reference");
+
+        await RunCleanupTickAsync();
+        (await _fixture.CreateContext().Set<Job>().FindAsync([parentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldBeNull("tick 2: parent is now a leaf");
+        (await _fixture.CreateContext().Set<Job>().FindAsync([grandparentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldNotBeNull("tick 2: grandparent still has parent reference");
+
+        await RunCleanupTickAsync();
+        (await _fixture.CreateContext().Set<Job>().FindAsync([grandparentId], Xunit.TestContext.Current.CancellationToken))
+            .ShouldBeNull("tick 3: grandparent is now a leaf");
     }
 
     /// <summary>

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,44 @@ sidebar_position: 6
 
 # Releases
 
+## 0.15.2
+
+*2026-05-18*
+
+Two bug fixes — one correctness fix in `ExpirationCleanup`, one supervisor behavior change that stops silently dropping `BackgroundService` state writes. No public API changes.
+
+### Fixed: `ExpirationCleanup` foreign-key violation when batch splits a parent from its children
+
+`ExpirationCleanup.RunCleanupAsync` and `RunCountBasedCleanupAsync` selected expired jobs whose children were all expired and then `ExecuteDeleteAsync`-ed the batch in one statement. When `Take(ExpirationBatchSize)` (default 100) cut off mid-tree — parent included, some expired children outside the batch — the DELETE intermittently violated the self-FK `fk_job_job_parent_job_id`:
+
+```
+23503: update or delete on table "job" violates foreign key constraint
+       "fk_job_job_parent_job_id" on table "job"
+```
+
+The fix tightens both predicates to delete only **leaves** (`!x.ChildJobs.Any()`). An expired job with any child rows still pointing at it stays in place; on the next cleanup tick its (already-expired) children are gone and the parent itself becomes a leaf and is deleted. Trees of expired jobs drain one level per tick — a 3-level chain takes 3 ticks of `ExpirationCleanupInterval` (default 5 minutes) to fully clear, but never violates the FK.
+
+Behavior preserved:
+- Failed jobs still never auto-expire (`ExpireAt = null`, §8.2). An expired ancestor of a `Failed` descendant remains uncleanable until an operator requeues/deletes the failed leaf — same as before.
+- Sibling successes still expire and clean up independently of failed siblings — also the same as before. Trace context for failure investigations should come from your OTel export, not the operational DB.
+
+No action required on upgrade.
+
+### Changed: supervisor no longer silently swallows DB write failures
+
+`BackgroundServiceSupervisor` previously caught and logged any DB exception from its own state writes (`SetStatus`, `RecordFault`, `ResetRestartCount`) and continued as if the write had succeeded. Under DB contention (pool exhaustion, command-timeout under load) this meant the dashboard timeline could quietly stop matching reality — the service would still run, but the row's `Status` and the lifecycle log would diverge from the actual supervisor state. Observers never fired for the dropped transition, so anyone watching `IBackgroundServiceStatusObserver` would just see gaps.
+
+The supervisor now lets those exceptions propagate to a single outer iteration-level `try/catch` that treats the failure exactly like a faulted service: emits `LogSupervisorFault` (a new `Lifecycle / Error` log entry distinct from `LogFaulted`, which is reserved for user-code faults), increments `warp.background_services.faulted` (tagged with `exception_type`), waits out the next entry in the backoff sequence on real wall-clock time, and re-runs the iteration. `RestartCount` is **not** incremented for supervisor-side faults — that counter remains reserved for user-code faults.
+
+The trade-off this codifies: service execution is now gated on the supervisor's ability to persist its status. A `BackgroundService` whose own `ExecuteAsync` doesn't touch the DB at all will be briefly paused (1s+ backoff) during a Warp-DB blip rather than running with a stale dashboard reading. This was judged the better default — silent staleness on a thrashing service is worse to diagnose than a delayed-but-visible fault.
+
+Operator-facing changes:
+- Lifecycle log now has a new entry type `Supervisor faulted: <ExceptionType>: <message>` (Lifecycle / Error) — distinct from `Service faulted: …` which is still emitted for user-code throws.
+- `warp.background_services.faulted` counter is now incremented for supervisor-side faults too. If you alert on this counter, expect a small bump under DB contention; the `exception_type` tag will distinguish infrastructure faults (`NpgsqlException`, `SqlException`) from user faults.
+- For deployments using `WarpBackgroundService` with no scoped DB dependencies, expect occasional brief restart-backoff cycles during DB pressure rather than silent execution.
+
+No public API changes.
+
 ## 0.15.1
 
 *2026-05-18*


### PR DESCRIPTION
## Summary

Two unrelated bug fixes that surfaced from investigating a single failing CI run on `HealthyResetTests_PostgreSql`. Both are real correctness issues, not just test flake.

- **`BackgroundServiceSupervisor`**: stops silently swallowing DB write failures on its own state writes. A `SetStatus`/`RecordFault`/`ResetRestartCount` exception now propagates to an iteration-level fault handler — emits a new `LogSupervisorFault` lifecycle entry, increments `warp.background_services.faulted` with `exception_type`, applies real-time backoff, retries. RestartCount stays a user-fault-only counter. Trade-off: a `BackgroundService` whose own `ExecuteAsync` doesn't touch the DB will now briefly pause during a Warp-DB blip rather than running with a stale dashboard reading. Judged the better default — silent staleness is worse to diagnose than a delayed-but-visible fault.

- **`ExpirationCleanup`**: fixes intermittent `23503` FK violation on `fk_job_job_parent_job_id` when `Take(batchSize)` split a parent from some of its expired children. Predicate tightened to `!x.ChildJobs.Any()` — only leaves are deleted. Trees of expired jobs drain one level per `ExpirationCleanupInterval` tick. Existing behavior preserved for failed-job retention and sibling-success cleanup.

Plus diagnostic improvements in `HealthyResetTestsBase` (bounded `WaitForObserverAsync` / `PumpFakeTimeUntilAsync` helpers that fail fast with a named missed transition instead of consuming the whole `[TimedFact]` budget silently), and a new `SupervisorFaultTestsBase` that exercises the supervisor-fault path via a fault-injecting `IBackgroundServiceStateService` decorator.

Release notes at `website/docs/releases.md` (0.15.2).

## Test plan

- [x] `dotnet build src/Warp.slnx` analyzer-clean (`TreatWarningsAsErrors=true`)
- [x] `*HealthyReset*` — 2/2 pass isolated on both providers, 5/5 stable across repeated runs
- [x] `*SupervisorFault*` — 2/2 pass, 5/5 stable
- [x] `Warp.Tests.Scheduling.*` — 158/158 pass
- [x] `Warp.Tests.BackgroundServices.*` — 167/167 pass when not under heavy parallel local contention
- [x] `NoDb` smoke — 520/520 pass
- [ ] CI run on this branch — green

## Known residual local flake

On a 16-core local machine running the full `BackgroundServices` folder in parallel against a single shared Postgres container, `HealthyResetTests` still flakes ~30% of runs — but now with `"did not reach <transition> within 8s"` as the failure message instead of a silent 20s `[TimedFact]` hang. This is genuine cross-test DB contention, not a regression from this PR. CI's parallelism is much lower (~2 vCPU) so should be more stable; if it flakes there, the named-transition diagnostic gives a clear next-step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)