### PR TITLE
perf: batch BulkDeleteJobs and BulkRequeueJobs

### DIFF
--- a/src/core/Warp.Core/Services/JobCommandService.cs
+++ b/src/core/Warp.Core/Services/JobCommandService.cs
@@ -175,17 +175,155 @@ public class JobCommandService<TContext> : IJobCommandService
     public async Task<BulkResultModel> BulkDeleteJobs(Guid[] jobIds)
     {
         var result = new BulkResultModel();
-        foreach (var jobId in jobIds)
+
+        if (jobIds.Length == 0)
         {
-            try
+            return result;
+        }
+
+        // Dedupe — matches 1-by-1 where repeating an ID after the first delete is a no-op
+        // success (state is already Deleted). Credit each duplicate to Succeeded so totals
+        // stay at jobIds.Length.
+        var uniqueIds = jobIds.Distinct().ToArray();
+        result.Succeeded += jobIds.Length - uniqueIds.Length;
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var expireAt = now.Add(_configuration.JobExpirationTimeout);
+
+        // Chunk to keep parameter counts under SQL Server's 2100 limit and to bound lock footprint.
+        const int chunkSize = 500;
+
+        foreach (var chunk in uniqueIds.Chunk(chunkSize))
+        {
+            var snapshot = await _context.Set<Job>()
+                .AsNoTracking()
+                .Where(x => chunk.Contains(x.Id))
+                .Select(x =>
+                    new
+                    {
+                        x.Id,
+                        x.CurrentState,
+                    })
+                .ToListAsync();
+
+            // IDs missing from the DB count as Skipped (matches per-row ArgumentException behavior).
+            result.Skipped += chunk.Length - snapshot.Count;
+
+            // Already-Deleted matches the single-job no-op success path.
+            result.Succeeded += snapshot.Count(x => x.CurrentState == State.Deleted);
+
+            var groups = snapshot
+                .Where(x => x.CurrentState != State.Deleted)
+                .GroupBy(x => x.CurrentState)
+                .ToList();
+
+            if (groups.Count == 0)
             {
-                await DeleteJob(jobId);
-                result.Succeeded++;
+                continue;
             }
-            catch
+
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+
+            foreach (var group in groups)
             {
-                result.Skipped++;
+                var sourceState = group.Key;
+
+                // Sort ids — gives concurrent bulk callers identical UPDATE statements, so
+                // the engine plans an identical scan/lock order and no cycle can form across
+                // the row-lock acquisition phase.
+                var ids = group.Select(x => x.Id).Order().ToArray();
+
+                // Conditional UPDATE: only mutates rows still in sourceState. A concurrent
+                // RequeueJob holds the row lock from LockJobByIdWaitAsync; our UPDATE blocks
+                // behind it and re-evaluates the predicate after Requeue commits. If state
+                // moved off sourceState, the row is excluded. This is a tie-breaker, not a
+                // priority — whichever writer commits first wins, the loser observes the new
+                // state and skips. Either way exactly one of {Delete, Requeue} ever wins per
+                // job, with no half-updates and no log/counter rows for the loser.
+                //
+                // Processing jobs don't flip state here: we signal graceful cancellation and
+                // let RunJobMonitor pick it up — same contract as the single-job path.
+                var affected = sourceState == State.Processing
+                    ? await _context.Set<Job>()
+                        .Where(x => ids.Contains(x.Id))
+                        .Where(x => x.CurrentState == State.Processing)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(j => j.CancellationMode, CancellationMode.Graceful))
+                    : await _context.Set<Job>()
+                        .Where(x => ids.Contains(x.Id))
+                        .Where(x => x.CurrentState == sourceState)
+                        .ExecuteUpdateAsync(s => s
+                            .SetProperty(j => j.CurrentState, State.Deleted)
+                            .SetProperty(j => j.ExpireAt, expireAt));
+
+                if (affected == 0)
+                {
+                    result.Skipped += ids.Length;
+                    continue;
+                }
+
+                // Re-query inside the same transaction to identify the exact IDs that flipped.
+                // Our UPDATE's row locks block any other writer from interleaving here.
+                var changedIds = sourceState == State.Processing
+                    ? await _context.Set<Job>()
+                        .AsNoTracking()
+                        .Where(x => ids.Contains(x.Id))
+                        .Where(x => x.CurrentState == State.Processing)
+                        .Where(x => x.CancellationMode == CancellationMode.Graceful)
+                        .Select(x => x.Id)
+                        .ToListAsync()
+                    : await _context.Set<Job>()
+                        .AsNoTracking()
+                        .Where(x => ids.Contains(x.Id))
+                        .Where(x => x.CurrentState == State.Deleted)
+                        .Select(x => x.Id)
+                        .ToListAsync();
+
+                if (sourceState == State.Processing)
+                {
+                    foreach (var id in changedIds)
+                    {
+                        _context.Set<JobLog>().Add(new JobLog
+                        {
+                            JobId = id,
+                            EventType = "CancellationRequested",
+                            Timestamp = now,
+                            Level = "Information",
+                            Message = $"Graceful cancellation requested for job {id}",
+                        });
+                    }
+                }
+                else
+                {
+                    foreach (var id in changedIds)
+                    {
+                        _context.Set<JobLog>().Add(new JobLog
+                        {
+                            JobId = id,
+                            EventType = "Deleted",
+                            Timestamp = now,
+                            Level = "Information",
+                            Message = $"Job {id} was deleted",
+                        });
+                    }
+
+                    _context.Set<Counter>().Add(new Counter { Key = "stats:deleted", Value = affected });
+                    if (sourceState == State.Completed)
+                    {
+                        _context.Set<Counter>().Add(new Counter { Key = "stats:succeeded", Value = -affected });
+                    }
+                    else if (sourceState == State.Failed)
+                    {
+                        _context.Set<Counter>().Add(new Counter { Key = "stats:failed", Value = -affected });
+                    }
+                }
+
+                result.Succeeded += affected;
+                result.Skipped += ids.Length - affected;
             }
+
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
         }
 
         return result;
@@ -194,20 +332,266 @@ public class JobCommandService<TContext> : IJobCommandService
     public async Task<BulkResultModel> BulkRequeueJobs(Guid[] jobIds)
     {
         var result = new BulkResultModel();
-        foreach (var jobId in jobIds)
+
+        if (jobIds.Length == 0)
         {
-            try
+            return result;
+        }
+
+        // Dedupe — matches 1-by-1 where repeating an ID after the first requeue is a no-op
+        // success (state is already Enqueued). Credit each duplicate to Succeeded so totals
+        // stay at jobIds.Length.
+        var uniqueIds = jobIds.Distinct().ToArray();
+        result.Succeeded += jobIds.Length - uniqueIds.Length;
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var queuesToNotify = new HashSet<string>(StringComparer.Ordinal);
+
+        const int chunkSize = 500;
+
+        foreach (var chunk in uniqueIds.Chunk(chunkSize))
+        {
+            var snapshot = await _context.Set<Job>()
+                .AsNoTracking()
+                .Where(x => chunk.Contains(x.Id))
+                .Select(x =>
+                    new
+                    {
+                        x.Id,
+                        x.CurrentState,
+                        x.ParentJobId,
+                        x.Queue,
+                    })
+                .ToListAsync();
+
+            result.Skipped += chunk.Length - snapshot.Count;
+
+            // already-Enqueued and Processing match the single-job no-op success path.
+            result.Succeeded += snapshot.Count(x => x.CurrentState == State.Enqueued || x.CurrentState == State.Processing);
+
+            var requeueable = snapshot
+                .Where(x => x.CurrentState != State.Enqueued && x.CurrentState != State.Processing)
+                .ToList();
+
+            if (requeueable.Count == 0)
             {
-                await RequeueJob(jobId);
-                result.Succeeded++;
+                continue;
             }
-            catch
+
+            var queueById = requeueable.ToDictionary(x => x.Id, x => string.IsNullOrEmpty(x.Queue) ? "default" : x.Queue);
+
+            // Pre-fetch parent kinds (lock-free) so the child UPDATE step can decide HandlerType
+            // clearing without holding any parent lock. Job.Kind is immutable after creation,
+            // so reading it without a lock is safe.
+            var parentIds = requeueable
+                .Where(x => x.ParentJobId != null)
+                .Select(x => x.ParentJobId!.Value)
+                .Distinct()
+                .ToArray();
+
+            var parentKinds = parentIds.Length == 0
+                ? []
+                : await _context.Set<Job>()
+                    .AsNoTracking()
+                    .Where(p => parentIds.Contains(p.Id))
+                    .Select(p =>
+                        new
+                        {
+                            p.Id,
+                            p.Kind,
+                        })
+                    .ToDictionaryAsync(x => x.Id, x => x.Kind);
+
+            await using var transaction = await _context.Database.BeginTransactionAsync();
+
+            // Step 1: UPDATE all child rows first. ExecuteUpdateAsync acquires statement-level
+            // row locks held until commit, matching the child-then-parent lock order used by
+            // single RequeueJob (line 107 → 139). This is the must-fix for the deadlock that
+            // would otherwise occur when a concurrent single RequeueJob races us for the same
+            // (child, parent) pair.
+            var perParentAffected = new Dictionary<Guid, int>();
+
+            // Parentless requeues — HandlerType always cleared (matches single-job RequeueJob).
+            var parentless = requeueable.Where(x => x.ParentJobId == null).ToList();
+            foreach (var group in parentless.GroupBy(x => x.CurrentState))
             {
-                result.Skipped++;
+                var sourceState = group.Key;
+
+                // Sort ids — gives concurrent bulk callers identical UPDATE statements.
+                var ids = group.Select(x => x.Id).Order().ToArray();
+
+                var affected = await ExecuteRequeueUpdate(ids, sourceState, now, clearHandler: true);
+                ApplyRequeueAccounting(result, affected, sourceState, ids.Length);
+                await AddRequeueLogsForFlipped(ids, now);
+                CollectQueues(ids, queueById, affected, queuesToNotify);
             }
+
+            // Parented children — clearHandler decided from pre-fetched parent kind (no lock).
+            // Parent missing from the kind dict ⇒ treat as no-parent ⇒ clearHandler = true
+            // (matches single RequeueJob's behavior when LockJobByIdWaitAsync returns null).
+            // Sort by parent id so concurrent BulkRequeueJobs callers acquire parent locks in
+            // identical order — eliminates the cross-caller cycle on Phase 2 parent locks.
+            var byParent = requeueable
+                .Where(x => x.ParentJobId != null)
+                .GroupBy(x => x.ParentJobId!.Value)
+                .OrderBy(g => g.Key)
+                .ToList();
+
+            foreach (var pg in byParent)
+            {
+                var parentId = pg.Key;
+                var clearHandler = !parentKinds.TryGetValue(parentId, out var parentKind)
+                    || parentKind != JobKind.Message;
+                var totalAffected = 0;
+
+                foreach (var group in pg.GroupBy(x => x.CurrentState))
+                {
+                    var sourceState = group.Key;
+                    var ids = group.Select(x => x.Id).Order().ToArray();
+
+                    var affected = await ExecuteRequeueUpdate(ids, sourceState, now, clearHandler);
+                    totalAffected += affected;
+
+                    ApplyRequeueAccounting(result, affected, sourceState, ids.Length);
+                    await AddRequeueLogsForFlipped(ids, now);
+                    CollectQueues(ids, queueById, affected, queuesToNotify);
+                }
+
+                if (totalAffected > 0)
+                {
+                    perParentAffected[parentId] = totalAffected;
+                }
+            }
+
+            // Step 2: Lock each parent and bump JobCount. Sorted iteration — concurrent
+            // BulkRequeueJobs callers walk parents in PK order, so no two callers can hold
+            // parent locks in opposing orders, eliminating the cross-caller deadlock cycle.
+            foreach (var (parentId, affectedCount) in perParentAffected.OrderBy(kvp => kvp.Key))
+            {
+                var parent = await _sqlQueries.LockJobByIdWaitAsync(_context, parentId, default);
+                if (parent == null)
+                {
+                    continue;
+                }
+
+                parent.JobCount += affectedCount;
+                if (parent.CurrentState == State.Completed || parent.CurrentState == State.Failed)
+                {
+                    parent.CurrentState = parent.Kind == JobKind.Batch ? State.Awaiting : State.Processing;
+                    parent.ExpireAt = null;
+                }
+            }
+
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+
+        if (queuesToNotify.Count > 0)
+        {
+            var notifications = queuesToNotify
+                .Select(q => new Notification(NotificationKind.JobEnqueued, q))
+                .ToArray();
+            await NotificationDispatch.FireAsync(_notificationTransport, notifications);
         }
 
         return result;
+    }
+
+    private async Task<int> ExecuteRequeueUpdate(Guid[] ids, State sourceState, DateTime now, bool clearHandler)
+    {
+        // Conditional UPDATE: only flips rows still in sourceState. Concurrent DeleteJob holds
+        // the row lock from LockJobByIdWaitAsync; this UPDATE blocks, then sees the post-Delete
+        // state and excludes the row. Tie-breaker semantic — whichever writer commits first
+        // wins, exactly one of {Delete, Requeue} ever wins per row.
+        if (clearHandler)
+        {
+            return await _context.Set<Job>()
+                .Where(x => ids.Contains(x.Id))
+                .Where(x => x.CurrentState == sourceState)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(j => j.CurrentState, State.Enqueued)
+                    .SetProperty(j => j.ScheduleTime, now)
+                    .SetProperty(j => j.ExpireAt, (DateTime?)null)
+                    .SetProperty(j => j.HandlerType, (string?)null));
+        }
+
+        return await _context.Set<Job>()
+            .Where(x => ids.Contains(x.Id))
+            .Where(x => x.CurrentState == sourceState)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(j => j.CurrentState, State.Enqueued)
+                .SetProperty(j => j.ScheduleTime, now)
+                .SetProperty(j => j.ExpireAt, (DateTime?)null));
+    }
+
+    private void ApplyRequeueAccounting(BulkResultModel result, int affected, State sourceState, int groupSize)
+    {
+        if (affected == 0)
+        {
+            result.Skipped += groupSize;
+
+            return;
+        }
+
+        if (sourceState == State.Completed)
+        {
+            _context.Set<Counter>().Add(new Counter { Key = "stats:succeeded", Value = -affected });
+        }
+        else if (sourceState == State.Failed)
+        {
+            _context.Set<Counter>().Add(new Counter { Key = "stats:failed", Value = -affected });
+        }
+        else if (sourceState == State.Deleted)
+        {
+            _context.Set<Counter>().Add(new Counter { Key = "stats:deleted", Value = -affected });
+        }
+
+        result.Succeeded += affected;
+        result.Skipped += groupSize - affected;
+    }
+
+    private async Task AddRequeueLogsForFlipped(Guid[] ids, DateTime now)
+    {
+        // Re-query inside the transaction to identify rows our UPDATE just flipped. ScheduleTime
+        // = now narrows the result to our batch — collisions only matter if two BulkRequeueJobs
+        // calls land on the same tick, in which case both add identical Requeued log entries.
+        var flippedIds = await _context.Set<Job>()
+            .AsNoTracking()
+            .Where(x => ids.Contains(x.Id))
+            .Where(x => x.CurrentState == State.Enqueued)
+            .Where(x => x.ScheduleTime == now)
+            .Select(x => x.Id)
+            .ToListAsync();
+
+        foreach (var id in flippedIds)
+        {
+            _context.Set<JobLog>().Add(new JobLog
+            {
+                JobId = id,
+                EventType = "Requeued",
+                Timestamp = now,
+                Level = "Information",
+                Message = $"Job {id} was requeued",
+            });
+        }
+    }
+
+    private static void CollectQueues(Guid[] ids, Dictionary<Guid, string> queueById, int affected, HashSet<string> queues)
+    {
+        if (affected == 0)
+        {
+            return;
+        }
+
+        // Worst case: queues includes a queue where every row lost the race. The notification
+        // is then a harmless wake-up — workers fetch, find nothing, go back to sleep.
+        foreach (var id in ids)
+        {
+            if (queueById.TryGetValue(id, out var queue))
+            {
+                queues.Add(queue);
+            }
+        }
     }
 
     public async Task<BulkResultModel> DeleteFailedJobsByType(string type)

--- a/src/tests/Warp.Tests/Admin/JobCommandServiceTests.cs
+++ b/src/tests/Warp.Tests/Admin/JobCommandServiceTests.cs
@@ -379,6 +379,196 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
     }
 
     [TimedFact]
+    public async Task BulkDeleteJobs_MixedStates_DeletesAllAndUpdatesCounters()
+    {
+        var ctx = _fixture.CreateContext();
+        var completedId = Guid.NewGuid();
+        var failedId = Guid.NewGuid();
+        var enqueuedId = Guid.NewGuid();
+        var scheduledId = Guid.NewGuid();
+
+        ctx.Set<Job>().Add(new Job { Id = completedId, Kind = JobKind.Job, CurrentState = State.Completed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        ctx.Set<Job>().Add(new Job { Id = failedId, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        ctx.Set<Job>().Add(new Job { Id = enqueuedId, Kind = JobKind.Job, CurrentState = State.Enqueued, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        ctx.Set<Job>().Add(new Job { Id = scheduledId, Kind = JobKind.Job, CurrentState = State.Scheduled, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow.AddHours(1), Queue = "default" });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkDeleteJobs([completedId, failedId, enqueuedId, scheduledId]);
+
+        result.Succeeded.ShouldBe(4);
+        result.Skipped.ShouldBe(0);
+
+        var readCtx = _fixture.CreateContext();
+        var jobs = await readCtx.Set<Job>().Where(j => new[] { completedId, failedId, enqueuedId, scheduledId }.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        jobs.ShouldAllBe(j => j.CurrentState == State.Deleted);
+        jobs.ShouldAllBe(j => j.ExpireAt != null);
+
+        // Aggregated counters: +4 deleted, -1 succeeded (Completed), -1 failed (Failed).
+        // Enqueued and Scheduled have no source-state counter.
+        var counters = await readCtx.Set<Counter>().ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        counters.Where(c => string.Equals(c.Key, "stats:deleted", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(4);
+        counters.Where(c => string.Equals(c.Key, "stats:succeeded", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(-1);
+        counters.Where(c => string.Equals(c.Key, "stats:failed", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(-1);
+    }
+
+    [TimedFact]
+    public async Task BulkDeleteJobs_ProcessingJob_SignalsGracefulCancellation()
+    {
+        var ctx = _fixture.CreateContext();
+        var processingId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = processingId,
+            Kind = JobKind.Job,
+            CurrentState = State.Processing,
+            CancellationMode = CancellationMode.None,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkDeleteJobs([processingId]);
+
+        result.Succeeded.ShouldBe(1);
+
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == processingId, Xunit.TestContext.Current.CancellationToken);
+        job.CurrentState.ShouldBe(State.Processing);
+        job.CancellationMode.ShouldBe(CancellationMode.Graceful);
+
+        var logs = await readCtx.Set<JobLog>().Where(l => l.JobId == processingId).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        logs.ShouldContain(l => l.EventType == "CancellationRequested");
+    }
+
+    [TimedFact]
+    public async Task BulkDeleteJobs_AlreadyDeleted_CountedAsSucceeded()
+    {
+        var ctx = _fixture.CreateContext();
+        var deletedId = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = deletedId,
+            Kind = JobKind.Job,
+            CurrentState = State.Deleted,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            ExpireAt = DateTime.UtcNow.AddDays(1),
+        });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkDeleteJobs([deletedId]);
+
+        result.Succeeded.ShouldBe(1);
+        result.Skipped.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task BulkDeleteJobs_DuplicateIds_CountedAsSucceeded()
+    {
+        // Matches 1-by-1: DeleteJob(A); DeleteJob(A) returns silently because state is already
+        // Deleted, both count as Succeeded. Bulk dedupes the input and credits the duplicate.
+        var ctx = _fixture.CreateContext();
+        var id = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkDeleteJobs([id, id, id]);
+
+        result.Succeeded.ShouldBe(3);
+        result.Skipped.ShouldBe(0);
+
+        var readCtx = _fixture.CreateContext();
+        var job = await readCtx.Set<Job>().FirstAsync(j => j.Id == id, Xunit.TestContext.Current.CancellationToken);
+        job.CurrentState.ShouldBe(State.Deleted);
+
+        // Counter must reflect a single delete, not three.
+        var counters = await readCtx.Set<Counter>().ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        counters.Where(c => string.Equals(c.Key, "stats:deleted", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(1);
+        counters.Where(c => string.Equals(c.Key, "stats:failed", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(-1);
+    }
+
+    [TimedFact]
+    public async Task BulkDeleteJobs_PhantomIds_CountedAsSkipped()
+    {
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkDeleteJobs([Guid.NewGuid(), Guid.NewGuid()]);
+
+        result.Succeeded.ShouldBe(0);
+        result.Skipped.ShouldBe(2);
+    }
+
+    [TimedFact]
+    public async Task BulkDeleteJobs_LargeBatch_DeletesAll()
+    {
+        var ctx = _fixture.CreateContext();
+        var ids = Enumerable.Range(0, 1200).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var id in ids)
+        {
+            ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkDeleteJobs(ids);
+
+        result.Succeeded.ShouldBe(1200);
+
+        var readCtx = _fixture.CreateContext();
+        var remainingNonDeleted = await readCtx.Set<Job>()
+            .Where(j => ids.Contains(j.Id))
+            .Where(j => j.CurrentState != State.Deleted)
+            .CountAsync(Xunit.TestContext.Current.CancellationToken);
+        remainingNonDeleted.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task BulkDeleteJobs_ConcurrentRequeue_NeverCorruptsState()
+    {
+        // Concurrent Bulk Delete + Single Requeue on the same Failed job: each transition is
+        // atomic (DB row lock + conditional UPDATE / SELECT FOR UPDATE), so the final state
+        // is always one of {Deleted, Enqueued} — never a torn write.
+        var ctx = _fixture.CreateContext();
+        var ids = Enumerable.Range(0, 50).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var id in ids)
+        {
+            ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var deleteSvc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+
+        var deleteTask = deleteSvc.BulkDeleteJobs(ids);
+        var requeueTasks = ids.Select(id => Task.Run(async () =>
+        {
+            // Fresh service per task — DbContext is not thread-safe.
+            var requeueSvc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+            try
+            {
+                await requeueSvc.RequeueJob(id);
+            }
+            catch
+            {
+                // Requeue may legitimately fail if the row was just deleted between read and lock.
+            }
+        }));
+
+        await Task.WhenAll([deleteTask, .. requeueTasks]);
+
+        var readCtx = _fixture.CreateContext();
+        var jobs = await readCtx.Set<Job>().Where(j => ids.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        jobs.Count.ShouldBe(50);
+        jobs.ShouldAllBe(j => j.CurrentState == State.Deleted || j.CurrentState == State.Enqueued);
+    }
+
+    [TimedFact]
     public async Task BulkRequeueJobs_RequeuesMultiple()
     {
         // Arrange
@@ -408,5 +598,339 @@ public abstract class JobCommandServiceTestsBase : IAsyncLifetime
         var readCtx = _fixture.CreateContext();
         var jobs = await readCtx.Set<Job>().Where(j => ids.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
         jobs.ShouldAllBe(j => j.CurrentState == State.Enqueued);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_MessageParent_KeepsHandlerTypeAndBumpsParentOnce()
+    {
+        // Many children of a single Message parent — the optimized path locks the parent once
+        // and bumps JobCount by N (not N parent-locks).
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var childIds = Enumerable.Range(0, 5).Select(_ => Guid.NewGuid()).ToArray();
+        const string handlerType = "Some.Handler.Type, SomeAssembly";
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Message,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            JobCount = 0,
+            ExpireAt = DateTime.UtcNow.AddDays(1),
+        });
+        foreach (var id in childIds)
+        {
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = id,
+                Kind = JobKind.Job,
+                CurrentState = State.Failed,
+                CreateTime = DateTime.UtcNow,
+                ScheduleTime = DateTime.UtcNow,
+                Queue = "default",
+                ParentJobId = parentId,
+                HandlerType = handlerType,
+            });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkRequeueJobs(childIds);
+
+        result.Succeeded.ShouldBe(5);
+
+        var readCtx = _fixture.CreateContext();
+        var children = await readCtx.Set<Job>().Where(j => childIds.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        children.ShouldAllBe(j => j.CurrentState == State.Enqueued);
+        children.ShouldAllBe(j => j.HandlerType == handlerType);
+
+        var parent = await readCtx.Set<Job>().FirstAsync(j => j.Id == parentId, Xunit.TestContext.Current.CancellationToken);
+        parent.JobCount.ShouldBe(5);
+        parent.CurrentState.ShouldBe(State.Processing);
+        parent.ExpireAt.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_BatchParent_FlipsParentToAwaiting()
+    {
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var childIds = Enumerable.Range(0, 3).Select(_ => Guid.NewGuid()).ToArray();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Failed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            JobCount = 0,
+        });
+        foreach (var id in childIds)
+        {
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = id,
+                Kind = JobKind.Job,
+                CurrentState = State.Failed,
+                CreateTime = DateTime.UtcNow,
+                ScheduleTime = DateTime.UtcNow,
+                Queue = "default",
+                ParentJobId = parentId,
+                HandlerType = "ignored.for.batch",
+            });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        await svc.BulkRequeueJobs(childIds);
+
+        var readCtx = _fixture.CreateContext();
+        var parent = await readCtx.Set<Job>().FirstAsync(j => j.Id == parentId, Xunit.TestContext.Current.CancellationToken);
+        parent.JobCount.ShouldBe(3);
+        parent.CurrentState.ShouldBe(State.Awaiting);
+
+        // Batch parent → children's HandlerType cleared (parent.Kind != Message)
+        var children = await readCtx.Set<Job>().Where(j => childIds.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        children.ShouldAllBe(j => j.HandlerType == null);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_DirectJob_ClearsHandlerTypeAndUpdatesCounters()
+    {
+        var ctx = _fixture.CreateContext();
+        var ids = Enumerable.Range(0, 4).Select(_ => Guid.NewGuid()).ToArray();
+        for (var i = 0; i < ids.Length; i++)
+        {
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = ids[i],
+                Kind = JobKind.Job,
+                CurrentState = i < 2 ? State.Completed : State.Failed,
+                CreateTime = DateTime.UtcNow,
+                ScheduleTime = DateTime.UtcNow,
+                Queue = "default",
+                HandlerType = "Some.Handler",
+            });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkRequeueJobs(ids);
+
+        result.Succeeded.ShouldBe(4);
+
+        var readCtx = _fixture.CreateContext();
+        var jobs = await readCtx.Set<Job>().Where(j => ids.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        jobs.ShouldAllBe(j => j.CurrentState == State.Enqueued);
+        jobs.ShouldAllBe(j => j.HandlerType == null);
+        jobs.ShouldAllBe(j => j.ExpireAt == null);
+
+        var counters = await readCtx.Set<Counter>().ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        counters.Where(c => string.Equals(c.Key, "stats:succeeded", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(-2);
+        counters.Where(c => string.Equals(c.Key, "stats:failed", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(-2);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_DuplicateIds_CountedAsSucceeded()
+    {
+        var ctx = _fixture.CreateContext();
+        var id = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkRequeueJobs([id, id, id]);
+
+        result.Succeeded.ShouldBe(3);
+        result.Skipped.ShouldBe(0);
+
+        var readCtx = _fixture.CreateContext();
+        var counters = await readCtx.Set<Counter>().ToListAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // Counter reflects a single Failed→Enqueued transition, not three.
+        counters.Where(c => string.Equals(c.Key, "stats:failed", StringComparison.Ordinal)).Sum(c => c.Value).ShouldBe(-1);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_AlreadyEnqueued_CountedAsSucceeded()
+    {
+        var ctx = _fixture.CreateContext();
+        var id = Guid.NewGuid();
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = id,
+            Kind = JobKind.Job,
+            CurrentState = State.Enqueued,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+        });
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkRequeueJobs([id]);
+
+        result.Succeeded.ShouldBe(1);
+        result.Skipped.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_LargeBatch_RequeuesAll()
+    {
+        var ctx = _fixture.CreateContext();
+        var ids = Enumerable.Range(0, 1200).Select(_ => Guid.NewGuid()).ToArray();
+        foreach (var id in ids)
+        {
+            ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default" });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var svc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var result = await svc.BulkRequeueJobs(ids);
+
+        result.Succeeded.ShouldBe(1200);
+
+        var readCtx = _fixture.CreateContext();
+        var stillFailed = await readCtx.Set<Job>()
+            .Where(j => ids.Contains(j.Id))
+            .Where(j => j.CurrentState != State.Enqueued)
+            .CountAsync(Xunit.TestContext.Current.CancellationToken);
+        stillFailed.ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_TwoConcurrentBulks_DoNotDeadlockAndConvergeJobCount()
+    {
+        // Two BulkRequeueJobs callers race for the same parent's children. With sorted parent
+        // locks in Phase 2 plus sorted ids in Phase 1 UPDATEs, neither caller can hold parent
+        // locks in opposing orders — no cross-caller deadlock cycle is possible. Final
+        // parent.JobCount must equal the number of children actually transitioned Failed→Enqueued
+        // (each row transitions at most once across the two callers via the conditional WHERE).
+        var ctx = _fixture.CreateContext();
+        var parentA = Guid.NewGuid();
+        var parentB = Guid.NewGuid();
+        var childIdsA = Enumerable.Range(0, 20).Select(_ => Guid.NewGuid()).ToArray();
+        var childIdsB = Enumerable.Range(0, 20).Select(_ => Guid.NewGuid()).ToArray();
+
+        ctx.Set<Job>().Add(new Job { Id = parentA, Kind = JobKind.Batch, CurrentState = State.Completed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default", JobCount = 0 });
+        ctx.Set<Job>().Add(new Job { Id = parentB, Kind = JobKind.Batch, CurrentState = State.Completed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default", JobCount = 0 });
+        foreach (var id in childIdsA)
+        {
+            ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default", ParentJobId = parentA });
+        }
+
+        foreach (var id in childIdsB)
+        {
+            ctx.Set<Job>().Add(new Job { Id = id, Kind = JobKind.Job, CurrentState = State.Failed, CreateTime = DateTime.UtcNow, ScheduleTime = DateTime.UtcNow, Queue = "default", ParentJobId = parentB });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // Caller 1 sees parents in {A, B} order; Caller 2 sees them in {B, A} order. Without
+        // sorting at Phase 2, this would be the canonical opposing-lock-order deadlock setup.
+        var caller1Ids = childIdsA.Concat(childIdsB).ToArray();
+        var caller2Ids = childIdsB.Concat(childIdsA).ToArray();
+
+        var svc1 = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+        var svc2 = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+
+        var task1 = Task.Run(() => svc1.BulkRequeueJobs(caller1Ids));
+        var task2 = Task.Run(() => svc2.BulkRequeueJobs(caller2Ids));
+
+        await Task.WhenAll(task1, task2);
+
+        var readCtx = _fixture.CreateContext();
+        var pA = await readCtx.Set<Job>().FirstAsync(j => j.Id == parentA, Xunit.TestContext.Current.CancellationToken);
+        var pB = await readCtx.Set<Job>().FirstAsync(j => j.Id == parentB, Xunit.TestContext.Current.CancellationToken);
+
+        // Each Failed→Enqueued transition bumps exactly one parent. Both callers race on the
+        // same children but the conditional UPDATE ensures only one wins per row.
+        pA.JobCount.ShouldBe(childIdsA.Length);
+        pB.JobCount.ShouldBe(childIdsB.Length);
+
+        var allChildren = await readCtx.Set<Job>().Where(j => caller1Ids.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        allChildren.ShouldAllBe(j => j.CurrentState == State.Enqueued);
+    }
+
+    [TimedFact]
+    public async Task BulkRequeueJobs_ConcurrentDelete_NeverCorruptsParentJobCount()
+    {
+        // Concurrent BulkRequeue + single Delete on the same Failed children: the conditional
+        // UPDATE + parent lock combination guarantees parent.JobCount equals exactly the count
+        // of children that ended up Enqueued, never over-bumped by raced-out children.
+        var ctx = _fixture.CreateContext();
+        var parentId = Guid.NewGuid();
+        var childIds = Enumerable.Range(0, 30).Select(_ => Guid.NewGuid()).ToArray();
+
+        ctx.Set<Job>().Add(new Job
+        {
+            Id = parentId,
+            Kind = JobKind.Batch,
+            CurrentState = State.Completed,
+            CreateTime = DateTime.UtcNow,
+            ScheduleTime = DateTime.UtcNow,
+            Queue = "default",
+            JobCount = 0,
+        });
+        foreach (var id in childIds)
+        {
+            ctx.Set<Job>().Add(new Job
+            {
+                Id = id,
+                Kind = JobKind.Job,
+                CurrentState = State.Failed,
+                CreateTime = DateTime.UtcNow,
+                ScheduleTime = DateTime.UtcNow,
+                Queue = "default",
+                ParentJobId = parentId,
+            });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        var requeueSvc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+
+        var requeueTask = requeueSvc.BulkRequeueJobs(childIds);
+        var deleteTasks = childIds.Select(id => Task.Run(async () =>
+        {
+            // Fresh service per task — DbContext is not thread-safe.
+            var deleteSvc = Warp.Tests.Helpers.TestTasks.CreateJobCommandService(_fixture.CreateContext());
+            try
+            {
+                await deleteSvc.DeleteJob(id);
+            }
+            catch
+            {
+                // Delete may fail if the row state moved during the race.
+            }
+        }));
+
+        await Task.WhenAll([requeueTask, .. deleteTasks]);
+
+        var readCtx = _fixture.CreateContext();
+        var children = await readCtx.Set<Job>().Where(j => childIds.Contains(j.Id)).ToListAsync(Xunit.TestContext.Current.CancellationToken);
+        children.ShouldAllBe(j => j.CurrentState == State.Deleted || j.CurrentState == State.Enqueued);
+
+        // Invariant: parent.JobCount bumps exactly once per successful Failed→Enqueued transition.
+        // - Lower bound: any child currently Enqueued was requeued and survived (no later delete).
+        //   So JobCount >= count(Enqueued).
+        // - Upper bound: at most snapshot.Count children could have been requeued; some of those
+        //   may have been deleted-after-requeue, which doesn't decrement parent.JobCount (a
+        //   pre-existing semantic shared with single DeleteJob). So JobCount <= snapshot.Count.
+        // The point of the test: bulk requeue never over-bumps from raced-out children whose
+        // conditional UPDATE didn't actually fire.
+        var actuallyEnqueued = children.Count(j => j.CurrentState == State.Enqueued);
+        var parent = await readCtx.Set<Job>().FirstAsync(j => j.Id == parentId, Xunit.TestContext.Current.CancellationToken);
+        parent.JobCount.ShouldBeGreaterThanOrEqualTo(actuallyEnqueued);
+        parent.JobCount.ShouldBeLessThanOrEqualTo(childIds.Length);
     }
 }


### PR DESCRIPTION
## Summary

Closes #197. Replaces the per-row loops in `BulkDeleteJobs` / `BulkRequeueJobs` with chunked conditional UPDATEs — deleting 20k jobs from the dashboard drops from ~120k DB round-trips to a few hundred.

## What changed

- **500-row chunks** sized to stay under SQL Server's 2100-parameter limit
- **One `ExecuteUpdateAsync` per source-state group** with `WHERE CurrentState = sourceState` — turns Delete vs Requeue into a tie-breaker (exactly one transition wins per row, no half-updates, no log/counter rows for the loser)
- **Aggregated `Counter` rows** sized to the actual affected count, never the snapshot count — race-induced skips don't drift counters
- **Batched `JobLog` inserts** identified by a post-UPDATE re-query inside the same transaction
- **Processing jobs**: same conditional UPDATE pattern setting `CancellationMode = Graceful` plus a `CancellationRequested` log — no per-row fallback
- **`BulkRequeueJobs` lock order**: children first (Phase 1 `ExecuteUpdateAsync`) then parents (Phase 2 `LockJobByIdWaitAsync`), matching single `RequeueJob` to prevent cross-caller deadlock. Parents iterated in sorted PK order to eliminate the cross-caller parent-lock cycle.
- **Notifications**: one `JobEnqueued` per distinct queue, fired after all chunks commit
- **Dedupe at entry** so duplicate IDs match 1-by-1 accounting (`Succeeded = jobIds.Length`)

## Correctness guarantees

- Per-chunk atomicity (all-or-nothing within the transaction; partial progress only at chunk boundaries — same property as single 1-by-1)
- `parent.JobCount` bumped by the actual `ExecuteUpdateAsync` affected count — never over-bumped from a child raced out by a concurrent Delete
- Sorted child ids + sorted parent iteration → no cross-caller cycle possible
- Real DB deadlocks (engine-detected) still abort cleanly within 1-5s and throw — no infinite waits introduced

## Test plan

- [x] 14 new tests across both Postgres and SQL Server providers (28 concrete)
- [x] Large batch (1,200 rows) — proves scaling
- [x] Mixed-state counter aggregation
- [x] Processing graceful-cancel via batch path
- [x] Phantom IDs, already-Deleted/Enqueued, duplicate IDs
- [x] Message-parent: HandlerType preserved + parent flips to Processing + JobCount bumped once for the whole batch
- [x] Batch-parent: HandlerType cleared + parent flips to Awaiting
- [x] Direct job: HandlerType cleared, counter aggregation correct
- [x] Concurrent Delete vs single Requeue race — never corrupt state, only one wins per row
- [x] Concurrent BulkRequeue vs many concurrent single Deletes — parent.JobCount invariant: `count(Enqueued) ≤ JobCount ≤ snapshot.Count`
- [x] Two concurrent BulkRequeueJobs with opposing parent iteration orders — converges without deadlock
- [x] Full suite: **1,978 / 1,978 pass** on both Postgres and SQL Server (~2m 7s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)