### PR TITLE
docs: escape MDX brace expression in 0.15.3 notes

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -24,7 +24,7 @@ The conditional UPDATE uses `WHERE CurrentState = sourceState` (the source state
 
 - Whichever writer commits first wins the row's transition.
 - The loser's UPDATE re-evaluates the predicate against the post-commit state, finds the row excluded, and reports it as `Skipped` in the `BulkResultModel`.
-- The loser writes **no** `JobLog`, **no** `Counter` increment, **no** half-update — exactly one of {Delete, Requeue} ever lands per row.
+- The loser writes **no** `JobLog`, **no** `Counter` increment, **no** half-update — exactly one of `Delete` or `Requeue` ever lands per row.
 
 `BulkRequeueJobs` Phase 1 (children) runs before Phase 2 (parent lock), matching the child-then-parent lock order used by single `RequeueJob` to prevent cross-caller deadlock with a single-row requeue racing for the same parent. Both methods sort their target IDs and `BulkRequeueJobs` sorts parents by PK before iteration, so two concurrent `BulkRequeueJobs` callers cannot acquire parent locks in opposing orders — the only remaining deadlock cycle in this code path is eliminated by construction rather than relying on DB-level detection.
 


### PR DESCRIPTION
## Summary
- Docs deploy on a20d640 failed: MDX parsed \`{Delete, Requeue}\` in the 0.15.3 release notes as a JSX expression and threw \`ReferenceError: Delete is not defined\`.
- Rephrase to backticked identifiers connected by "or" — same meaning, no JSX interpretation.
- Verified locally with \`npm run build\` (succeeds; only the pre-existing non-fatal HTML-minifier "Control character" warnings remain).

Blocking the 0.15.3 release on this — release notes need to render on the docs site before the GH release publishes to NuGet.

## Test plan
- [x] Local \`npm run build\` from \`website/\` passes
- [x] CI re-runs the docs deploy + test workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)