### PR TITLE
docs: bump 0.15.3 release notes date to publish day

### DIFF
--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 ## 0.15.3
 
-*2026-05-21*
+*2026-05-22*
 
 One performance fix to the bulk job operations behind the dashboard's "Delete" and "Requeue" buttons. No public API changes; no behavior changes on the single-row paths.
 


### PR DESCRIPTION
## Summary
- 1-character date bump to match the actual GitHub-release publish day, mirroring 0.15.0/.1/.2 pattern where the notes date is the release date.

## Test plan
- [x] CI workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)