### PR TITLE
fix: races in WarpTestServer dispose + Postgres listener startup (#201, #203)

### DIFF
--- a/src/core/Warp.Core/Notifications/IWarpNotificationTransport.cs
+++ b/src/core/Warp.Core/Notifications/IWarpNotificationTransport.cs
@@ -26,4 +26,14 @@ public interface IWarpNotificationTransport
     /// failures and only terminate when <paramref name="ct"/> is cancelled.
     /// </summary>
     IAsyncEnumerable<Notification> ListenAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Completes the first time the listener has registered with the underlying transport
+    /// (Postgres <c>LISTEN</c> on the wire / SQL Server Service Broker setup done). Tests use
+    /// this to gate the first publish so notifications can't be dropped by a race between
+    /// host startup and the listener's <c>ListenAsync</c> call. Once set, stays set for the
+    /// transport's lifetime — reconnect drops are handled by the listener task's reconnect
+    /// drain, not by re-arming this signal.
+    /// </summary>
+    Task ListenerReady { get; }
 }

--- a/src/core/Warp.Core/Notifications/NullNotificationTransport.cs
+++ b/src/core/Warp.Core/Notifications/NullNotificationTransport.cs
@@ -18,4 +18,6 @@ public sealed class NullNotificationTransport : IWarpNotificationTransport
         await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, ct);
         yield break;
     }
+
+    public Task ListenerReady { get; } = Task.CompletedTask;
 }

--- a/src/core/providers/Warp.Provider.PostgreSql/PostgresNotificationTransport.cs
+++ b/src/core/providers/Warp.Provider.PostgreSql/PostgresNotificationTransport.cs
@@ -20,6 +20,7 @@ public sealed class PostgresNotificationTransport : IWarpNotificationTransport
     private readonly string? _connectionString;
     private readonly string _channelName;
     private readonly ILogger<PostgresNotificationTransport>? _logger;
+    private readonly TaskCompletionSource _listenerReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public PostgresNotificationTransport(string connectionString, WarpDatabasePushConfiguration options, ILogger<PostgresNotificationTransport>? logger = null)
     {
@@ -38,6 +39,8 @@ public sealed class PostgresNotificationTransport : IWarpNotificationTransport
         _channelName = options.ChannelName;
         _logger = logger;
     }
+
+    public Task ListenerReady => _listenerReady.Task;
 
     public async Task PublishAsync(NotificationKind kind, string? queue, CancellationToken ct)
     {
@@ -65,20 +68,7 @@ public sealed class PostgresNotificationTransport : IWarpNotificationTransport
         }
     }
 
-    public IAsyncEnumerable<Notification> ListenAsync(CancellationToken ct)
-    {
-        return ListenCoreAsync(readySignal: null, ct);
-    }
-
-    // Test hook: deterministic listener-ready signal. Fires after LISTEN has been
-    // executed on the wire, before the first WaitAsync. Lets tests await readiness
-    // instead of guessing with Task.Delay — see PostgresNotificationTransportTests.
-    internal IAsyncEnumerable<Notification> ListenAsync(TaskCompletionSource ready, CancellationToken ct)
-    {
-        return ListenCoreAsync(ready, ct);
-    }
-
-    private async IAsyncEnumerable<Notification> ListenCoreAsync(TaskCompletionSource? readySignal, [EnumeratorCancellation] CancellationToken ct)
+    public async IAsyncEnumerable<Notification> ListenAsync([EnumeratorCancellation] CancellationToken ct)
     {
         await using var conn = await OpenConnectionAsync(ct);
 
@@ -89,7 +79,9 @@ public sealed class PostgresNotificationTransport : IWarpNotificationTransport
             await cmd.ExecuteNonQueryAsync(ct);
         }
 
-        readySignal?.TrySetResult();
+        // First-LISTEN-on-the-wire signal. Latches once; reconnects rely on the listener
+        // task's drain-on-reconnect to catch up, not on re-arming this TCS.
+        _listenerReady.TrySetResult();
 
         // Npgsql fires the Notification event synchronously during WaitAsync on the same thread
         // the iterator runs on — so a plain Queue is safe, no Channel/Task.Run needed. The event

--- a/src/core/providers/Warp.Provider.SqlServer/SqlServerNotificationTransport.cs
+++ b/src/core/providers/Warp.Provider.SqlServer/SqlServerNotificationTransport.cs
@@ -28,6 +28,9 @@ public sealed class SqlServerNotificationTransport : IWarpNotificationTransport
     // first awaiter runs the setup, others wait; if it faults, every subsequent await throws
     // the cached exception without reopening any connections.
     private readonly Lazy<Task> _setup;
+    private readonly TaskCompletionSource _listenerReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task ListenerReady => _listenerReady.Task;
 
     public SqlServerNotificationTransport(string connectionString, WarpDatabasePushConfiguration options, ILogger<SqlServerNotificationTransport>? logger = null)
     {
@@ -103,6 +106,12 @@ public sealed class SqlServerNotificationTransport : IWarpNotificationTransport
 
         await using var conn = new SqlConnection(_connectionString);
         await conn.OpenAsync(ct);
+
+        // Service Broker setup is the slow part and the listen connection is now open — from
+        // this point the WAITFOR loop is the listener. Tests use this signal to gate the first
+        // publish so it can't be dropped by a host-startup vs. listener-startup race. Latches
+        // once; reconnects rely on the listener task's drain-on-reconnect to catch up.
+        _listenerReady.TrySetResult();
 
         // WAITFOR RECEIVE blocks the connection until messages arrive or the TIMEOUT fires.
         // The 30s timeout is a heartbeat so we can observe cancellation — not a poll of job state.

--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -12,6 +12,7 @@ using Warp.Core.Entities;
 using Warp.Core.Enums;
 using Warp.Core.Handlers;
 using Warp.Core.NoRestart;
+using Warp.Core.Notifications;
 using Warp.Core.RateLimit;
 using Warp.Core.Retry;
 using Warp.Core.Services;
@@ -311,6 +312,14 @@ public class WarpTestServer : IAsyncDisposable
         ServerLifecycleTrace.Record(serverId, "IHost.StartAsync starting");
         await host.StartAsync(Xunit.TestContext.Current.CancellationToken);
         ServerLifecycleTrace.Record(serverId, "IHost.StartAsync returned");
+
+        // Gate test return on the push listener finishing its registration (Postgres LISTEN on
+        // the wire / SQL Server Service Broker setup done). Without this the first publish
+        // races the listener and can be silently dropped — see issue #201. NullNotificationTransport
+        // completes ListenerReady immediately, so tests not using push pay nothing.
+        var transport = host.Services.GetRequiredService<IWarpNotificationTransport>();
+        await transport.ListenerReady.WaitAsync(TimeSpan.FromSeconds(10), Xunit.TestContext.Current.CancellationToken);
+
         TestLifecycleTrace.Record($"WarpTestServer.StartAsync returned (server={serverId})");
 
         return new WarpTestServer(host, fixture, jobLogObserver);
@@ -514,12 +523,19 @@ public class WarpTestServer : IAsyncDisposable
         TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(8);
+
+        // Capture ServerId before building any LINQ predicates. EF's expression-tree funcletizer
+        // evaluates captured members lazily at materialization time, so a getter that reads from
+        // _host.Services would throw ObjectDisposedException if the host disposed between query
+        // build and execution (tests that race DisposeAsync against this method, e.g.
+        // GracefulShutdownOrderingTests). Same rationale in WaitForBackgroundServiceDeleted.
+        var serverId = ServerId;
         var deadline = DateTime.UtcNow + effectiveTimeout;
         while (DateTime.UtcNow < deadline)
         {
             var ctx = CreateContext();
             var current = await ctx.Set<BackgroundServiceInstance>()
-                .Where(x => x.ServerId == ServerId)
+                .Where(x => x.ServerId == serverId)
                 .Where(x => x.ServiceName == serviceName)
                 .Select(x => (BackgroundServiceStatus?)x.Status)
                 .FirstOrDefaultAsync(Xunit.TestContext.Current.CancellationToken);
@@ -534,13 +550,13 @@ public class WarpTestServer : IAsyncDisposable
 
         var ctx2 = CreateContext();
         var finalStatus = await ctx2.Set<BackgroundServiceInstance>()
-            .Where(x => x.ServerId == ServerId)
+            .Where(x => x.ServerId == serverId)
             .Where(x => x.ServiceName == serviceName)
             .Select(x => (BackgroundServiceStatus?)x.Status)
             .FirstOrDefaultAsync(Xunit.TestContext.Current.CancellationToken);
 
         throw new TimeoutException(
-            $"BackgroundService '{serviceName}' on server {ServerId} did not reach status {status} within {effectiveTimeout}. " +
+            $"BackgroundService '{serviceName}' on server {serverId} did not reach status {status} within {effectiveTimeout}. " +
             $"Current status: {finalStatus?.ToString() ?? "row not found"}");
     }
 
@@ -552,12 +568,16 @@ public class WarpTestServer : IAsyncDisposable
     public async Task WaitForBackgroundServiceDeleted(string serviceName, TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(8);
+
+        // Capture ServerId before DisposeAsync can race the predicate's lazy funcletization —
+        // see WaitForBackgroundServiceState for the full rationale.
+        var serverId = ServerId;
         var deadline = DateTime.UtcNow + effectiveTimeout;
         while (DateTime.UtcNow < deadline)
         {
             var ctx = CreateContext();
             var exists = await ctx.Set<BackgroundServiceInstance>()
-                .Where(x => x.ServerId == ServerId)
+                .Where(x => x.ServerId == serverId)
                 .Where(x => x.ServiceName == serviceName)
                 .AnyAsync(Xunit.TestContext.Current.CancellationToken);
 
@@ -570,7 +590,7 @@ public class WarpTestServer : IAsyncDisposable
         }
 
         throw new TimeoutException(
-            $"BackgroundService '{serviceName}' instance row on server {ServerId} was not deleted within {effectiveTimeout}");
+            $"BackgroundService '{serviceName}' instance row on server {serverId} was not deleted within {effectiveTimeout}");
     }
 
     /// <summary>

--- a/src/tests/Warp.Tests/Notifications/ListenerReconnectDrainTests.cs
+++ b/src/tests/Warp.Tests/Notifications/ListenerReconnectDrainTests.cs
@@ -116,5 +116,7 @@ public abstract class ListenerReconnectDrainTestsBase : IntegrationTestBase
             yield break;
 #pragma warning restore CS0162
         }
+
+        public Task ListenerReady { get; } = Task.CompletedTask;
     }
 }

--- a/src/tests/Warp.Tests/Notifications/PostgresNotificationTransportTests.cs
+++ b/src/tests/Warp.Tests/Notifications/PostgresNotificationTransportTests.cs
@@ -25,15 +25,14 @@ public class PostgresNotificationTransportTests : IAsyncLifetime, IClassFixture<
             new WarpDatabasePushConfiguration { ChannelName = "warp_notify_test" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var enumerator = transport.ListenAsync(ready, cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
             // Kick off MoveNextAsync first so the iterator runs OpenAsync+LISTEN before we publish.
-            // Then await the listener-ready signal — deterministic, no Task.Delay race.
+            // Then await the public ListenerReady signal — deterministic, no Task.Delay race.
             var moveTask = enumerator.MoveNextAsync();
-            await ready.Task.WaitAsync(cts.Token);
+            await transport.ListenerReady.WaitAsync(cts.Token);
 
             await transport.PublishAsync(NotificationKind.JobEnqueued, "default", cts.Token);
 
@@ -63,13 +62,12 @@ public class PostgresNotificationTransportTests : IAsyncLifetime, IClassFixture<
             new WarpDatabasePushConfiguration { ChannelName = "warp_notify_test2" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var enumerator = transport.ListenAsync(ready, cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
             var firstMoveTask = enumerator.MoveNextAsync();
-            await ready.Task.WaitAsync(cts.Token);
+            await transport.ListenerReady.WaitAsync(cts.Token);
 
             await transport.PublishAsync(NotificationKind.MessageEnqueued, null, cts.Token);
             await transport.PublishAsync(NotificationKind.JobFinalized, null, cts.Token);
@@ -113,13 +111,12 @@ public class PostgresNotificationTransportTests : IAsyncLifetime, IClassFixture<
             new WarpDatabasePushConfiguration { ChannelName = "warp_notify_ds_test" });
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var enumerator = transport.ListenAsync(ready, cts.Token).GetAsyncEnumerator(cts.Token);
+        var enumerator = transport.ListenAsync(cts.Token).GetAsyncEnumerator(cts.Token);
         try
         {
             var moveTask = enumerator.MoveNextAsync();
-            await ready.Task.WaitAsync(cts.Token);
+            await transport.ListenerReady.WaitAsync(cts.Token);
 
             await transport.PublishAsync(NotificationKind.JobEnqueued, "default", cts.Token);
 

--- a/src/tests/Warp.Tests/Notifications/PushFailurePollingBackstopTests.cs
+++ b/src/tests/Warp.Tests/Notifications/PushFailurePollingBackstopTests.cs
@@ -107,5 +107,7 @@ public abstract class PushFailurePollingBackstopTestsBase : IntegrationTestBase
             yield break;
 #pragma warning restore CS0162
         }
+
+        public Task ListenerReady { get; } = Task.CompletedTask;
     }
 }

--- a/src/tests/Warp.Tests/Scheduling/RecurringJobTests.cs
+++ b/src/tests/Warp.Tests/Scheduling/RecurringJobTests.cs
@@ -180,6 +180,8 @@ public abstract class RecurringJobTestsBase : IAsyncLifetime
             await Task.Yield();
             yield break;
         }
+
+        public Task ListenerReady { get; } = Task.CompletedTask;
     }
 
     [TimedFact]

--- a/src/tests/Warp.Tests/Scheduling/ScheduledJobActivationTaskTests.cs
+++ b/src/tests/Warp.Tests/Scheduling/ScheduledJobActivationTaskTests.cs
@@ -181,5 +181,7 @@ public abstract class ScheduledJobActivationTaskTestsBase : IAsyncLifetime
             await Task.Delay(Timeout.InfiniteTimeSpan, ct);
             yield break;
         }
+
+        public Task ListenerReady { get; } = Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary

- Fix #203: deterministic race in `WarpTestServer.WaitForBackgroundService{State,Deleted}`. Predicates captured `ServerId`, whose getter resolves `IOptions<WarpWorkerConfiguration>` from `_host.Services`. EF funcletizes captured members lazily at materialization, so a racing `DisposeAsync()` disposed the service provider between query build and `AnyAsync` execution and surfaced as `ObjectDisposedException`. Capture `ServerId` to a local before any predicate.
- Fix #201: Postgres LISTEN registration could race the first publish. `NotificationListenerTask`'s `ExecuteAsync` runs on the thread pool after `host.StartAsync` returns, so a publish that happens immediately after startup could land before LISTEN, losing the NOTIFY. Added `IWarpNotificationTransport.ListenerReady` — latched once LISTEN is on the wire (Postgres) / Service Broker setup completes (SQL Server). `WarpTestServer.StartAsync` awaits it before returning, closing the window for the first publish. Replaces the previous Postgres-only test hook.

## Test plan

- [x] Build: 0 warnings, 0 errors
- [x] `Shutdown_LeaseDeletedBeforeWaitingOnExecuteAsync` — 10/10 local PG reruns
- [x] `JobEnqueued_WithDispatcherPlusPush_DispatcherPicksUpWithoutPolling` — 10/10 local PG reruns
- [x] `*NotificationTransport*` class filter — 12/12 pass
- [x] `*BackgroundService*` class filter — 167/167 pass
- [ ] CI green on both PG and SQL Server matrix legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)