### PR TITLE
test: warm SQL Server connection pool before worker fanout (#205)

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -309,6 +310,22 @@ public class WarpTestServer : IAsyncDisposable
         TestLifecycleTrace.Record("Host.Build returned");
 
         var serverId = host.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<WarpWorkerConfiguration>>().Value.ServerId;
+
+        // SQL Server only: warm the per-test connection pool with a single sequential Open
+        // before IHost.StartAsync fans out the worker + server-task fleet. Without this, the
+        // 5 workers + ~8 server-task loops all hit OpenAsync on a cold pool simultaneously and
+        // can trip a server-side State 7 ("error while evaluating the password") under the
+        // login burst — see issue #205. The lonely warm-up call primes SQL Server's auth path
+        // and seeds the pool with one cached physical connection. Npgsql doesn't have the
+        // same pathology, so we skip it there.
+        if (!isPostgres)
+        {
+            ServerLifecycleTrace.Record(serverId, "SqlServer pool warm-up starting");
+            await using var warmup = new SqlConnection(connectionString);
+            await warmup.OpenAsync(Xunit.TestContext.Current.CancellationToken);
+            ServerLifecycleTrace.Record(serverId, "SqlServer pool warm-up returned");
+        }
+
         ServerLifecycleTrace.Record(serverId, "IHost.StartAsync starting");
         await host.StartAsync(Xunit.TestContext.Current.CancellationToken);
         ServerLifecycleTrace.Record(serverId, "IHost.StartAsync returned");


### PR DESCRIPTION
## Summary

Fix #205: SQL Server `Login failed for user 'sa'` State 7 cascade when fresh per-test connection pool gets a burst of ~13 simultaneous cold logins on `IHost.StartAsync`.

Open one sequential `SqlConnection` in `WarpTestServer.StartAsync` *before* host startup. The lonely auth primes SQL Server's password evaluator and seeds the pool with a warm cached connection, so the subsequent worker + server-task burst borrows from a primed pool instead of cold-creating 13 fresh logins concurrently.

## Root cause (see #205 for full trace)

Captured directly from the SQL Server errorlog under repro:

\`\`\`
Logon  Error: 18456, Severity: 14, State: 7.
Logon  Login failed for user 'sa'. Reason: An error occurred while evaluating the password.
Logon  Error: 18456, Severity: 14, State: 1.
Logon  Login failed for user 'sa'. Reason: Infrastructure error occurred. Check for previous errors.
\`\`\`

State 7 ≠ wrong password. It's a server-side auth-subsystem race where password-hash evaluation errors out mid-process under concurrent login burst. The half-authed physical connection then poisons the client pool — State 1 ("Infrastructure error... check previous errors") on every subsequent borrow.

## Test plan

- [x] Local repro before fix: ~1/7 failure rate on `SagaIntegrationTests_SqlServer.TwoConcurrentMessagesSameSaga_OneRequeuesWithBusyOutcome`
- [x] Local with fix: 20/20 pass on the same test
- [x] PG twin test still passes (warm-up gated on SQL Server only)
- [x] #201/#203 regression check: `JobEnqueued_WithDispatcherPlusPush_DispatcherPicksUpWithoutPolling` + `Shutdown_LeaseDeletedBeforeWaitingOnExecuteAsync` both still pass
- [x] Full SQL Server suite: 717/718 pass; 1 failure is `BulkRequeueJobs_TwoConcurrentBulks_DoNotDeadlockAndConvergeJobCount`, a pre-existing flake unrelated to this PR (it also failed intermittently before #204)
- [ ] CI green

## What this is NOT

- Not a production-code change. Production deployments warm their pool naturally over time. The burst-on-cold-pool failure mode is specific to the test harness's per-test `Application Name` pool isolation.
- Not a workaround for #201 (push listener race) or #203 (ObjectDisposed). Those are already fixed in #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)