### PR TITLE
fix(http-sourcegen): diagnose multi-body Mixed plans instead of crashing (fix #208)

### DIFF
--- a/src/core/Warp.Http.SourceGenerator/Diagnostics.cs
+++ b/src/core/Warp.Http.SourceGenerator/Diagnostics.cs
@@ -24,4 +24,19 @@ internal static class Diagnostics
 
     // WHTTP003 (FromBody on GET/DELETE) was removed when binding switched to ASP.NET Minimal API.
     // ASP.NET surfaces the equivalent error at runtime / startup.
+    public static readonly DiagnosticDescriptor MultipleBodyTargets = new(
+        id: "WHTTP004",
+        title: "Body-verb handler has more than one body-bound parameter",
+        messageFormat: "Handler '{0}' on a POST/PUT/PATCH route has multiple body-bound parameters. Minimal API accepts at most one body parameter. Wrap them in a single [FromBody] sub-record, or annotate each parameter with [FromRoute], [FromQuery], or [FromHeader].",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor InternalGeneratorError = new(
+        id: "WHTTP999",
+        title: "Warp.Http source generator encountered an internal error",
+        messageFormat: "Warp.Http source generator failed to process handler '{0}': {1}. Other handlers in the assembly are unaffected; please file an issue with a minimal repro.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/core/Warp.Http.SourceGenerator/Emitters/DelegateEmitter.cs
+++ b/src/core/Warp.Http.SourceGenerator/Emitters/DelegateEmitter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -75,6 +76,20 @@ internal static class DelegateEmitter
         //   3. The single body target (if any), [FromBody]-attributed, with TRequest body shape
         //
         // Inside the lambda, we construct TRequest from the bound parts and dispatch.
+        var bodyTargetCount = plan.Targets.Count(t => t.Source == BindingSource.Body);
+        if (bodyTargetCount > 1)
+        {
+            // Minimal API only accepts one body parameter, and the param-name dictionary below
+            // only captures the first body target — so emission would fail with a cryptic
+            // KeyNotFoundException on construction. This case must be diagnosed earlier as
+            // WHTTP004 in WarpHttpGenerator.ProcessCandidate. Throwing here is defense-in-depth:
+            // if the gate is ever bypassed, the outer try/catch surfaces a clear WHTTP999.
+            throw new InvalidOperationException(
+                "EmitMixedHandler invariant violated: BindingPlan has "
+                + bodyTargetCount
+                + " body-bound targets but at most one is supported. This should have been diagnosed as WHTTP004 before reaching emission.");
+        }
+
         sb.Append("            static async global::System.Threading.Tasks.Task (global::Microsoft.AspNetCore.Http.HttpContext ctx");
 
         var bodyTarget = plan.Targets.FirstOrDefault(t => t.Source == BindingSource.Body);

--- a/src/core/Warp.Http.SourceGenerator/WarpHttpGenerator.cs
+++ b/src/core/Warp.Http.SourceGenerator/WarpHttpGenerator.cs
@@ -72,71 +72,22 @@ public sealed class WarpHttpGenerator : IIncrementalGenerator
                 continue;
             }
 
-            var httpAttributes = candidate.GetAttributes()
-                .Where(a => InheritsFrom(a.AttributeClass, warpHttpAttributeSymbol))
-                .ToArray();
-
-            if (httpAttributes.Length == 0)
+            try
             {
-                continue;
-            }
-
-            var classification = ClassifyHandler(candidate, iRequestHandlerSymbol, iStreamRequestHandlerSymbol);
-            if (classification is null)
-            {
-                ReportInvalidHandler(
+                ProcessCandidate(
                     context,
+                    compilation,
                     candidate,
-                    "must implement IRequestHandler<TRequest, TResponse> or IStreamRequestHandler<TRequest, TResponse>");
-                continue;
+                    warpHttpAttributeSymbol,
+                    iRequestHandlerSymbol,
+                    iStreamRequestHandlerSymbol,
+                    iJobSymbol,
+                    iMessageSymbol,
+                    endpoints);
             }
-
-            var requestType = classification.Value.RequestType;
-            if (RequestImplementsBackgroundWorkInterface(requestType, iJobSymbol, iMessageSymbol))
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                ReportInvalidHandler(
-                    context,
-                    candidate,
-                    $"request type '{requestType.ToDisplayString()}' implements IJob or IMessage and cannot be HTTP-exposed (write a thin IRequest<Guid> wrapper that calls IPublisher.Enqueue instead)");
-                continue;
-            }
-
-            if (httpAttributes.Length > 1)
-            {
-                var anyMissingName = httpAttributes.Any(a => ReadNamedArg(a, "Name") is null);
-                if (anyMissingName)
-                {
-                    var location = candidate.Locations.FirstOrDefault() ?? Location.None;
-                    context.ReportDiagnostic(Diagnostic.Create(
-                        Diagnostics.MissingNameOnMultiAttribute,
-                        location,
-                        candidate.ToDisplayString()));
-                }
-            }
-
-            foreach (var attr in httpAttributes)
-            {
-                var (method, route) = ReadRouteAndMethod(attr);
-                if (method is null || route is null)
-                {
-                    continue;
-                }
-
-                var group = ReadNamedArg(attr, "Group") as string;
-                var name = ReadNamedArg(attr, "Name") as string;
-
-                var model = new HttpEndpointModel(
-                    handlerType: candidate,
-                    requestType: requestType,
-                    responseType: classification.Value.ResponseType,
-                    kind: classification.Value.Kind,
-                    method: method,
-                    route: route,
-                    group: group,
-                    name: name);
-
-                var plan = Emitters.BindingEmitter.Build(compilation, requestType, method);
-                endpoints.Add((model, plan));
+                ReportInternalError(context, candidate, ex);
             }
         }
 
@@ -148,6 +99,97 @@ public sealed class WarpHttpGenerator : IIncrementalGenerator
         var assemblySafe = SanitizeIdentifier(compilation.AssemblyName ?? "Unknown");
         var source = RegistryEmitter.Emit(assemblySafe, endpoints);
         context.AddSource("WarpHttpRegistry.g.cs", source);
+    }
+
+    private static void ProcessCandidate(
+        SourceProductionContext context,
+        Compilation compilation,
+        INamedTypeSymbol candidate,
+        INamedTypeSymbol warpHttpAttributeSymbol,
+        INamedTypeSymbol? iRequestHandlerSymbol,
+        INamedTypeSymbol? iStreamRequestHandlerSymbol,
+        INamedTypeSymbol? iJobSymbol,
+        INamedTypeSymbol? iMessageSymbol,
+        List<(HttpEndpointModel Model, BindingPlan Plan)> endpoints)
+    {
+        var httpAttributes = candidate.GetAttributes()
+            .Where(a => InheritsFrom(a.AttributeClass, warpHttpAttributeSymbol))
+            .ToArray();
+
+        if (httpAttributes.Length == 0)
+        {
+            return;
+        }
+
+        var classification = ClassifyHandler(candidate, iRequestHandlerSymbol, iStreamRequestHandlerSymbol);
+        if (classification is null)
+        {
+            ReportInvalidHandler(
+                context,
+                candidate,
+                "must implement IRequestHandler<TRequest, TResponse> or IStreamRequestHandler<TRequest, TResponse>");
+            return;
+        }
+
+        var requestType = classification.Value.RequestType;
+        if (RequestImplementsBackgroundWorkInterface(requestType, iJobSymbol, iMessageSymbol))
+        {
+            ReportInvalidHandler(
+                context,
+                candidate,
+                $"request type '{requestType.ToDisplayString()}' implements IJob or IMessage and cannot be HTTP-exposed (write a thin IRequest<Guid> wrapper that calls IPublisher.Enqueue instead)");
+            return;
+        }
+
+        if (httpAttributes.Length > 1)
+        {
+            var anyMissingName = httpAttributes.Any(a => ReadNamedArg(a, "Name") is null);
+            if (anyMissingName)
+            {
+                var location = candidate.Locations.FirstOrDefault() ?? Location.None;
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.MissingNameOnMultiAttribute,
+                    location,
+                    candidate.ToDisplayString()));
+            }
+        }
+
+        foreach (var attr in httpAttributes)
+        {
+            var (method, route) = ReadRouteAndMethod(attr);
+            if (method is null || route is null)
+            {
+                continue;
+            }
+
+            var group = ReadNamedArg(attr, "Group") as string;
+            var name = ReadNamedArg(attr, "Name") as string;
+
+            var plan = Emitters.BindingEmitter.Build(compilation, requestType, method);
+
+            // Mixed shape with more than one body-bound target is unsupported — Minimal API
+            // accepts at most one body parameter, and emitting the lambda would throw
+            // KeyNotFoundException because EmitMixedHandler captures only the first body
+            // target. Diagnose explicitly so the rest of the assembly's endpoints still emit.
+            if (plan.Shape == BindingShape.Mixed
+                && plan.Targets.Count(t => t.Source == BindingSource.Body) > 1)
+            {
+                ReportMultipleBodyTargets(context, candidate);
+                continue;
+            }
+
+            var model = new HttpEndpointModel(
+                handlerType: candidate,
+                requestType: requestType,
+                responseType: classification.Value.ResponseType,
+                kind: classification.Value.Kind,
+                method: method,
+                route: route,
+                group: group,
+                name: name);
+
+            endpoints.Add((model, plan));
+        }
     }
 
     private static (HttpHandlerKind Kind, INamedTypeSymbol RequestType, ITypeSymbol ResponseType)? ClassifyHandler(
@@ -251,6 +293,25 @@ public sealed class WarpHttpGenerator : IIncrementalGenerator
             location,
             type.ToDisplayString(),
             reason));
+    }
+
+    private static void ReportMultipleBodyTargets(SourceProductionContext context, INamedTypeSymbol type)
+    {
+        var location = type.Locations.FirstOrDefault() ?? Location.None;
+        context.ReportDiagnostic(Diagnostic.Create(
+            Diagnostics.MultipleBodyTargets,
+            location,
+            type.ToDisplayString()));
+    }
+
+    private static void ReportInternalError(SourceProductionContext context, INamedTypeSymbol type, Exception ex)
+    {
+        var location = type.Locations.FirstOrDefault() ?? Location.None;
+        context.ReportDiagnostic(Diagnostic.Create(
+            Diagnostics.InternalGeneratorError,
+            location,
+            type.ToDisplayString(),
+            ex.GetType().Name + ": " + ex.Message));
     }
 
     private static string SanitizeIdentifier(string raw)

--- a/src/tests/Warp.Tests/Http/BindingTests.cs
+++ b/src/tests/Warp.Tests/Http/BindingTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Shouldly;
@@ -104,6 +105,24 @@ public sealed class BindingTests
         var body = await resp.Content.ReadFromJsonAsync<InitOnlyResponse>();
         body!.Name.ShouldBe("init-set");
         body.Count.ShouldBe(7);
+    }
+
+    [TimedFact]
+    public async Task RouteAndBodyScalar_BindsBothInMixedShape()
+    {
+        // POST with [FromRoute] route param + a single unattributed scalar body param —
+        // exercises the Mixed shape with one body target end-to-end. Regression coverage
+        // for #208. Minimal API binds a scalar [FromBody] from a raw JSON string body.
+        await using var app = await WarpHttpTestApp.StartAsync(configureApp: a => a.MapWarpHttp());
+
+        var id = Guid.NewGuid();
+        using var content = new StringContent("\"admin\"", Encoding.UTF8, "application/json");
+        var resp = await app.Client.PostAsync("/api/users/" + id + "/promote", content);
+
+        resp.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var body = await resp.Content.ReadFromJsonAsync<PromoteUserResponse>();
+        body!.Id.ShouldBe(id);
+        body.NewRole.ShouldBe("admin");
     }
 
     [TimedFact]

--- a/src/tests/Warp.Tests/Http/DiagnosticsTests.cs
+++ b/src/tests/Warp.Tests/Http/DiagnosticsTests.cs
@@ -215,6 +215,151 @@ public sealed class DiagnosticsTests
     }
 
     [TimedFact]
+    public void WHTTP004_FiresOnBodyVerbWithRouteAndMultipleUnattributedParams()
+    {
+        const string source = """
+            using Warp.Core.Handlers;
+            using Warp.Http;
+            using Microsoft.AspNetCore.Mvc;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestSamples;
+
+            public sealed record CreateThing([FromRoute] int TenantId, string Name, decimal Price) : IRequest<string>;
+
+            [WarpHttpPost("/api/tenants/{tenantId}/things")]
+            public sealed class CreateThingHandler : IRequestHandler<CreateThing, string>
+            {
+                public Task<string> HandleAsync(CreateThing request, CancellationToken ct) => Task.FromResult(request.Name);
+            }
+            """;
+
+        var result = GeneratorTestHarness.Run(source);
+
+        result.Diagnostics.ShouldContain(d => d.Id == "WHTTP004" && d.GetMessage().Contains("CreateThingHandler"));
+
+        // The generator must not also throw CS8785 ("Generator failed to generate source").
+        result.Diagnostics.ShouldNotContain(d => d.Id == "CS8785");
+    }
+
+    [TimedFact]
+    public void WHTTP004_FiresOnTwoExplicitFromBodyParams()
+    {
+        const string source = """
+            using Warp.Core.Handlers;
+            using Warp.Http;
+            using Microsoft.AspNetCore.Mvc;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestSamples;
+
+            public sealed record DoubleBody([FromRoute] int Id, [FromBody] BodyA A, [FromBody] BodyB B) : IRequest<string>;
+
+            public sealed record BodyA(string X);
+            public sealed record BodyB(string Y);
+
+            [WarpHttpPost("/api/double-body/{id}")]
+            public sealed class DoubleBodyHandler : IRequestHandler<DoubleBody, string>
+            {
+                public Task<string> HandleAsync(DoubleBody request, CancellationToken ct) => Task.FromResult(request.A.X);
+            }
+            """;
+
+        var diagnostics = GeneratorTestHarness.Run(source).Diagnostics;
+
+        diagnostics.ShouldContain(d => d.Id == "WHTTP004" && d.GetMessage().Contains("DoubleBodyHandler"));
+    }
+
+    [TimedFact]
+    public void WHTTP004_DoesNotFireOnSingleBodyTargetMixed()
+    {
+        // POST with [FromRoute] + one bare scalar parameter — Mixed shape with exactly one
+        // body target. This is supported and must not trip WHTTP004.
+        const string source = """
+            using Warp.Core.Handlers;
+            using Warp.Http;
+            using Microsoft.AspNetCore.Mvc;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestSamples;
+
+            public sealed record PromoteUser([FromRoute] int Id, string NewRole) : IRequest<string>;
+
+            [WarpHttpPost("/api/users/{id}/promote")]
+            public sealed class PromoteUserHandler : IRequestHandler<PromoteUser, string>
+            {
+                public Task<string> HandleAsync(PromoteUser request, CancellationToken ct) => Task.FromResult(request.NewRole);
+            }
+            """;
+
+        var diagnostics = GeneratorTestHarness.Run(source).Diagnostics;
+
+        diagnostics.ShouldNotContain(d => d.Id == "WHTTP004");
+    }
+
+    [TimedFact]
+    public void WHTTP004OnOneHandler_DoesNotWipeOtherHandlers()
+    {
+        // One bad handler (multi-body Mixed) sits alongside a good one. The bad handler is
+        // diagnosed and skipped; the good handler must still register exactly one endpoint.
+        const string source = """
+            using Warp.Core.Handlers;
+            using Warp.Http;
+            using Microsoft.AspNetCore.Mvc;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            namespace TestSamples;
+
+            public sealed record BadRequest([FromRoute] int Id, string A, string B) : IRequest<string>;
+
+            [WarpHttpPost("/api/bad/{id}")]
+            public sealed class BadHandler : IRequestHandler<BadRequest, string>
+            {
+                public Task<string> HandleAsync(BadRequest request, CancellationToken ct) => Task.FromResult(request.A);
+            }
+
+            public sealed record GoodRequest(string Name) : IRequest<string>;
+
+            [WarpHttpPost("/api/good")]
+            public sealed class GoodHandler : IRequestHandler<GoodRequest, string>
+            {
+                public Task<string> HandleAsync(GoodRequest request, CancellationToken ct) => Task.FromResult(request.Name);
+            }
+            """;
+
+        var result = GeneratorTestHarness.Run(source);
+
+        result.Diagnostics.ShouldContain(d => d.Id == "WHTTP004" && d.GetMessage().Contains("BadHandler"));
+        result.Diagnostics.ShouldNotContain(d => d.Id == "CS8785");
+
+        var generated = string.Concat(result.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Select(s => s.SourceText.ToString()));
+
+        // Exactly one endpoint registered, and it must be GoodHandler.
+        CountOccurrences(generated, "WarpGeneratedHttpRegistry.Add").ShouldBe(1);
+        generated.ShouldContain("typeof(global::TestSamples.GoodHandler)");
+        generated.ShouldNotContain("typeof(global::TestSamples.BadHandler)");
+    }
+
+    private static int CountOccurrences(string source, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    [TimedFact]
     public void WHTTP002_DoesNotFireForSingleAttribute()
     {
         const string source = """

--- a/src/tests/Warp.Tests/Http/TestHandlers.cs
+++ b/src/tests/Warp.Tests/Http/TestHandlers.cs
@@ -441,6 +441,20 @@ public sealed class BindingInitOnlyHandler : IRequestHandler<BindingInitOnlyQuer
         => Task.FromResult(new BindingInitOnlyResponse(request.Name, request.Count));
 }
 
+// Mixed shape with a single body target — POST with [FromRoute] route param + one bare
+// scalar body param. Regression coverage for #208: this is the working Mixed path and
+// must not trip WHTTP004.
+public sealed record PromoteUser([FromRoute(Name = "id")] Guid Id, string NewRole) : IRequest<PromoteUserResponse>;
+
+public sealed record PromoteUserResponse(Guid Id, string NewRole);
+
+[WarpHttpPost("/api/users/{id}/promote")]
+public sealed class PromoteUserHandler : IRequestHandler<PromoteUser, PromoteUserResponse>
+{
+    public Task<PromoteUserResponse> HandleAsync(PromoteUser request, CancellationToken cancellationToken)
+        => Task.FromResult(new PromoteUserResponse(request.Id, request.NewRole));
+}
+
 // Submit-a-job pattern (#4) — IRequest<Guid> wrapper. We use a fake IPublisher in tests
 // so this stays NoDb; real DB path is exercised end-to-end in the demo app.
 public sealed record QueueWorkRequest(string Tag) : IRequest<Guid>;

--- a/website/docs/features/http.md
+++ b/website/docs/features/http.md
@@ -145,6 +145,19 @@ public sealed class SubmitOrderHandler : IRequestHandler<SubmitOrder, OrderDto> 
 
 The generator emits explicit lambda parameters per source and constructs `SubmitOrder` from the bound parts. ASP.NET's `[AsParameters]` doesn't support `[FromBody]` properties directly, so the generator handles this case explicitly.
 
+> **One body parameter only.** ASP.NET Minimal API accepts at most one body-bound parameter per endpoint. On a body verb (POST / PUT / PATCH), any parameter that isn't annotated with `[FromRoute]` / `[FromQuery]` / `[FromHeader]` defaults to the body. If more than one parameter ends up body-bound (e.g. `[FromRoute] int Id` plus two bare scalars), the generator emits a `WHTTP004` error. Fix it by wrapping the body fields in a single record and tagging it `[FromBody]`:
+>
+> ```csharp
+> // ✘ WHTTP004: Name and Price both default to the body
+> public sealed record CreateOrder([FromRoute] int TenantId, string Name, decimal Price) : IRequest<OrderDto>;
+>
+> // ✓ one [FromBody] sub-record
+> public sealed record CreateOrderBody(string Name, decimal Price);
+> public sealed record CreateOrder([FromRoute] int TenantId, [FromBody] CreateOrderBody Body) : IRequest<OrderDto>;
+> ```
+>
+> If no parameter is annotated at all, the verb defaults to **whole-body** binding (shape 1 above) and `TRequest` deserializes from the JSON body — that path has no multi-body limitation.
+
 > **Tip:** for mixed binding, prefer **classes with property setters** over records with primary constructors. Attributes on record positional parameters apply to the parameter, not the synthesized property, which can confuse `[AsParameters]`. Classes with `{ get; set; }` or `{ get; init; }` properties are unambiguous.
 
 ### Records vs classes


### PR DESCRIPTION
## Summary

The `Warp.Http` source generator threw `KeyNotFoundException` whenever a Mixed-shape binding plan had more than one body-bound target. Roslyn surfaced it as `CS8785` — a warning, not an error — so **every** `[WarpHttp*]` endpoint in the assembly silently vanished, while CI stayed green.

**Trigger**: a body verb (POST/PUT/PATCH) handler whose request type has at least one `[FromX]` attribute plus multiple unattributed parameters (which default to the body). Issue #208 documents three reproductions; only the multi-body case actually triggers the crash, but because the generator's failure is assembly-wide, neighbouring handlers (including `DELETE` and single-scalar POST patterns) all look broken too.

## Changes

- **`WHTTP004`** — diagnose Mixed plans with more than one body-bound target instead of crashing. Skip that endpoint; the rest of the assembly still emits.
- **`WHTTP999`** — per-candidate `try/catch` (excluding `OperationCanceledException`) so an unexpected failure is reported as a per-handler diagnostic instead of wiping the whole assembly.
- **`EmitMixedHandler`** — defensive `InvalidOperationException` if the `WHTTP004` gate is ever bypassed, replacing the cryptic `KeyNotFoundException` with a clear invariant-violation message.
- **Docs** — callout in `features/http.md` explaining Minimal API's one-body limit and the `[FromBody]` sub-record fix.

## Test plan

- [x] `dotnet build src/Warp.slnx` — analyzer-clean (TreatWarningsAsErrors).
- [x] `dotnet test ... --filter-trait "Category=NoDb"` — 525/525 pass, including 5 new tests:
  - `WHTTP004_FiresOnBodyVerbWithRouteAndMultipleUnattributedParams`
  - `WHTTP004_FiresOnTwoExplicitFromBodyParams`
  - `WHTTP004_DoesNotFireOnSingleBodyTargetMixed`
  - `WHTTP004OnOneHandler_DoesNotWipeOtherHandlers` — locks in the blast-radius fix.
  - `BindingTests.RouteAndBodyScalar_BindsBothInMixedShape` — end-to-end regression coverage for the working single-body Mixed pattern.
- [ ] CI green on Postgres + SQL Server suites.

Fixes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)