### PR TITLE
fix: deterministic ordering for dashboard collection queries

### DIFF
--- a/src/core/Warp.Core/Services/DashboardStatsService.cs
+++ b/src/core/Warp.Core/Services/DashboardStatsService.cs
@@ -137,9 +137,16 @@ public class DashboardStatsService<TContext> : IDashboardStatsService
 
     public async Task<List<ServerModel>> GetServers()
     {
-        var servers = await _context.Set<Server>().OrderBy(s => s.StartedTime).ToListAsync();
+        var servers = await _context.Set<Server>()
+            .OrderBy(s => s.StartedTime)
+            .ThenBy(s => s.Id)
+            .ToListAsync();
 
-        var workers = await _context.Set<Worker>().Include(w => w.WorkerGroup).OrderBy(w => w.WorkerGroupId).ThenBy(w => w.Id).ToListAsync();
+        var workers = await _context.Set<Worker>()
+            .Include(w => w.WorkerGroup)
+            .OrderBy(w => w.WorkerGroupId)
+            .ThenBy(w => w.Id)
+            .ToListAsync();
 
         var processingJobs = await _context.Set<Job>()
             .Where(x => x.CurrentState == State.Processing)
@@ -197,7 +204,8 @@ public class DashboardStatsService<TContext> : IDashboardStatsService
         var workers = await _context.Set<Worker>()
             .Include(w => w.WorkerGroup)
             .Where(w => w.ServerId == serverId)
-            .OrderBy(w => w.WorkerGroupId).ThenBy(w => w.Id)
+            .OrderBy(w => w.WorkerGroupId)
+            .ThenBy(w => w.Id)
             .ToListAsync();
 
         var processingJobs = await _context.Set<Job>()
@@ -240,6 +248,7 @@ public class DashboardStatsService<TContext> : IDashboardStatsService
     {
         return await _context.Set<ServerTask>()
             .Where(x => x.ServerId == serverId)
+            .OrderBy(x => x.TaskName)
             .Select(x => new ServerTaskSummary
             {
                 TaskName = x.TaskName,

--- a/src/core/Warp.Core/Services/JobQueryService.cs
+++ b/src/core/Warp.Core/Services/JobQueryService.cs
@@ -336,6 +336,7 @@ public class JobQueryService<TContext> : IJobQueryService
             .GroupBy(x => x.Type)
             .Select(g => new TypeCountModel { Type = g.Key!, Count = g.Count() })
             .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Type)
             .ToListAsync();
     }
 

--- a/src/core/Warp.Core/Services/RecurringJobService.cs
+++ b/src/core/Warp.Core/Services/RecurringJobService.cs
@@ -45,6 +45,7 @@ public class RecurringJobService<TContext> : IRecurringJobService
     {
         return await _context.Set<RecurringJob>()
             .OrderBy(x => x.NextExecution)
+            .ThenBy(x => x.Name)
             .Select(x => new RecurringJobModel
             {
                 Id = x.Id,

--- a/src/tests/Warp.Tests/Admin/ServerQueryTests.cs
+++ b/src/tests/Warp.Tests/Admin/ServerQueryTests.cs
@@ -188,4 +188,63 @@ public abstract class ServerQueryTestsBase : IAsyncLifetime
         recovery.LastMessage.ShouldBe("Requeued 2 stale jobs");
         recovery.LastDurationMs.ShouldBe(42.5);
     }
+
+    [TimedFact]
+    public async Task GetServerTaskSummaries_OrdersByTaskName()
+    {
+        // Arrange
+        var ctx = _fixture.CreateContext();
+        var serverId = Guid.NewGuid();
+
+        ctx.Set<Server>().Add(new Server
+        {
+            Id = serverId,
+            StartedTime = DateTime.UtcNow,
+            LastHeartbeatTime = DateTime.UtcNow,
+            ServiceCount = 1,
+        });
+
+        // Insert in deliberately non-alphabetical order
+        foreach (var name in new[] { "StaleJobRecovery", "Heartbeat", "MessageRouter", "ExpirationCleanup" })
+        {
+            ctx.Set<ServerTask>().Add(new ServerTask
+            {
+                ServerId = serverId,
+                TaskName = name,
+                IntervalSeconds = 60,
+            });
+        }
+
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // Act
+        var svc = new DashboardStatsService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
+        var summaries = await svc.GetServerTaskSummaries(serverId);
+
+        // Assert
+        summaries.Select(s => s.TaskName).ShouldBe(["ExpirationCleanup", "Heartbeat", "MessageRouter", "StaleJobRecovery"]);
+    }
+
+    [TimedFact]
+    public async Task GetServers_OrdersByStartedTime()
+    {
+        // Arrange — insert in non-chronological order; the query must return them by StartedTime
+        var ctx = _fixture.CreateContext();
+        var baseTime = DateTime.UtcNow.AddMinutes(-10);
+        var oldest = new Server { Id = Guid.NewGuid(), StartedTime = baseTime, LastHeartbeatTime = baseTime, ServiceCount = 1 };
+        var middle = new Server { Id = Guid.NewGuid(), StartedTime = baseTime.AddMinutes(3), LastHeartbeatTime = baseTime, ServiceCount = 1 };
+        var newest = new Server { Id = Guid.NewGuid(), StartedTime = baseTime.AddMinutes(6), LastHeartbeatTime = baseTime, ServiceCount = 1 };
+
+        ctx.Set<Server>().Add(middle);
+        ctx.Set<Server>().Add(newest);
+        ctx.Set<Server>().Add(oldest);
+        await ctx.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        // Act
+        var svc = new DashboardStatsService<TestContext>(_fixture.CreateContext(), TimeProvider.System);
+        var servers = await svc.GetServers();
+
+        // Assert
+        servers.Select(s => s.Id).ShouldBe([oldest.Id, middle.Id, newest.Id]);
+    }
 }

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,21 @@ sidebar_position: 6
 
 # Releases
 
+## 0.17.2
+
+*2026-06-02*
+
+Bug-fix release. No API changes, no schema changes — just deterministic ordering on dashboard queries.
+
+### Fix: stable ordering for servers, server tasks, and other dashboard lists
+
+Several dashboard query paths fetched collections without a fully-specified `ORDER BY`, so the database was free to return rows in any order. Because the UI renders rows in API order and refetches every ~10s, lists visibly reshuffled between refreshes.
+
+- **Server tasks** (`GetServerTaskSummaries`) had no ordering at all — now ordered by task name.
+- **Servers** (`GetServers`) were ordered only by `StartedTime`; servers in a cluster can share a start instant, leaving the tie unresolved. An `Id` tiebreaker now keeps the order stable. Worker groups are derived from the already-deterministic worker query (`WorkerGroupId`, then worker `Id`), so they were unaffected.
+- **Failed-job type counts** (`GetFailedJobTypeCounts`) were ordered by count only; equal counts now break ties by type name.
+- **Recurring jobs** (`GetRecurringJobs`) were ordered by `NextExecution` only; equal schedules now break ties by name.
+
 ## 0.17.1
 
 *2026-05-26*


### PR DESCRIPTION
## What

Several dashboard query paths fetched collections without a fully-specified `ORDER BY`, so the database returned rows in an arbitrary order. Because the UI renders in API order and refetches every ~10s, lists visibly reshuffled between refreshes — most noticeably the **server tasks** list.

## Changes

- **`GetServerTaskSummaries`** — was completely unordered; now ordered by `TaskName`.
- **`GetServers`** — ordered only by `StartedTime`; added an `Id` tiebreaker so clustered servers sharing a start instant stay stable. Worker groups derive from the already-deterministic worker query (`WorkerGroupId`, then `Id`), so they were unaffected.
- **`GetFailedJobTypeCounts`** — ordered by count only; added a `Type` tiebreaker for equal counts.
- **`GetRecurringJobs`** — ordered by `NextExecution` only; added a `Name` tiebreaker for equal schedules.
- Split the touched LINQ chains onto separate lines per coding-style §3.6.

## Tests

Two new tests in `ServerQueryTests` (run on both Postgres and SQL Server):
- `GetServerTaskSummaries_OrdersByTaskName`
- `GetServers_OrdersByStartedTime`

The `Id`/`Name` tiebreakers are intentionally not asserted against a hardcoded order — GUID/collation ordering differs between providers — but production code still guarantees a stable per-database order, which is what the UI needs.

## Docs

Added 0.17.2 release notes. No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)