### PR TITLE
Forward all handler-class attributes to HTTP endpoint metadata

### DIFF
--- a/src/core/Warp.Http/EndpointRouteBuilderExtensions.cs
+++ b/src/core/Warp.Http/EndpointRouteBuilderExtensions.cs
@@ -1,7 +1,5 @@
 using System.Collections.Concurrent;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -76,18 +74,20 @@ public static class EndpointRouteBuilderExtensions
             builder.Produces(StatusCodes.Status200OK, descriptor.ResponseType, "application/json");
         }
 
-        // Surface [Authorize] / [AllowAnonymous] declared on the handler class as standard
-        // ASP.NET endpoint metadata so group-level RequireAuthorization() composes naturally.
-        var authzAttrs = descriptor.HandlerType.GetCustomAttributes<AuthorizeAttribute>(inherit: false);
-        foreach (var attr in authzAttrs)
+        // Surface attributes declared on the handler class as standard ASP.NET endpoint
+        // metadata so the matching middleware picks them up — [Authorize] / [AllowAnonymous]
+        // (RequireAuthorization composes naturally), [EnableRateLimiting] / [DisableRateLimiting],
+        // [Tags], [OutputCache], [ProducesResponseType], and any future metadata attribute.
+        // Warp's own [WarpHttp*] routing markers carry route/verb info, not endpoint metadata,
+        // and are already consumed by the source generator — skip them.
+        foreach (var attribute in descriptor.HandlerType.GetCustomAttributes(inherit: false))
         {
-            builder.WithMetadata(attr);
-        }
+            if (attribute is WarpHttpAttribute)
+            {
+                continue;
+            }
 
-        var anonAttr = descriptor.HandlerType.GetCustomAttribute<AllowAnonymousAttribute>(inherit: false);
-        if (anonAttr is not null)
-        {
-            builder.WithMetadata(anonAttr);
+            builder.WithMetadata(attribute);
         }
     }
 

--- a/src/tests/Warp.Tests/Http/RateLimitMetadataTests.cs
+++ b/src/tests/Warp.Tests/Http/RateLimitMetadataTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Warp.Http;
+
+namespace Warp.Tests.Http;
+
+[Trait("Category", "NoDb")]
+public sealed class RateLimitMetadataTests
+{
+    [TimedFact]
+    public async Task EnableRateLimitingAttribute_OnHandler_SurfacesAsEndpointMetadata()
+    {
+        await using var app = await WarpHttpTestApp.StartAsync(configureApp: a => a.MapWarpHttp());
+
+        var dataSource = app.Services.GetRequiredService<EndpointDataSource>();
+        var endpoint = dataSource.Endpoints.FirstOrDefault(e =>
+            e is RouteEndpoint re && string.Equals(re.RoutePattern.RawText, "/api/rate-limited/echo", StringComparison.Ordinal));
+
+        endpoint.ShouldNotBeNull();
+
+        var meta = endpoint.Metadata.GetMetadata<EnableRateLimitingAttribute>();
+        meta.ShouldNotBeNull();
+        meta.PolicyName.ShouldBe("WarpHttpTestRateLimit");
+    }
+}

--- a/src/tests/Warp.Tests/Http/TestHandlers.cs
+++ b/src/tests/Warp.Tests/Http/TestHandlers.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using Warp.Core;
 using Warp.Core.Handlers;
 using Warp.Http;
@@ -252,6 +253,17 @@ public sealed record WebhookEcho : IRequest<string>;
 public sealed class WebhookEchoHandler : IRequestHandler<WebhookEcho, string>
 {
     public Task<string> HandleAsync(WebhookEcho request, CancellationToken cancellationToken) => Task.FromResult("authorized");
+}
+
+// Rate-limit metadata — [EnableRateLimiting] on the handler must surface as endpoint
+// metadata so ASP.NET's rate-limiting middleware applies the named policy.
+public sealed record RateLimitedEcho : IRequest<string>;
+
+[EnableRateLimiting("WarpHttpTestRateLimit")]
+[WarpHttpGet("/api/rate-limited/echo")]
+public sealed class RateLimitedEchoHandler : IRequestHandler<RateLimitedEcho, string>
+{
+    public Task<string> HandleAsync(RateLimitedEcho request, CancellationToken cancellationToken) => Task.FromResult("rate-limited");
 }
 
 // Stream endpoints with array binding via Minimal API.

--- a/website/docs/features/http.md
+++ b/website/docs/features/http.md
@@ -275,9 +275,11 @@ app.MapGroup("/internal/admin").RequireAuthorization("adminPolicy").MapWarpHttp(
 
 `MapWarpHttp(group)` matches strictly — null matches null, "public" matches "public". No overlap. Calling `MapWarpHttp(group)` twice on the same `IEndpointRouteBuilder` instance with the same group throws `InvalidOperationException` at startup.
 
-## Auth
+## Endpoint metadata attributes
 
-Place `[Authorize]` or `[AllowAnonymous]` on the handler class — Warp.Http surfaces them as ASP.NET endpoint metadata, so they compose with group-level `RequireAuthorization()` exactly as Minimal API does:
+Any attribute you place on the handler class is surfaced as ASP.NET endpoint metadata (via `EndpointBuilder.WithMetadata(attr)`) — only Warp's own `[WarpHttp*]` routing markers are excluded. So `[Authorize]`, `[AllowAnonymous]`, `[EnableRateLimiting]` / `[DisableRateLimiting]`, `[Tags]`, `[OutputCache]`, `[ProducesResponseType]`, and any custom metadata attribute all compose with the matching middleware exactly as they would on a hand-written Minimal API endpoint.
+
+### Auth
 
 ```csharp
 [Authorize(Policy = "OrdersWrite")]
@@ -292,6 +294,16 @@ app.MapGroup("/api").RequireAuthorization().MapWarpHttp();
 [AllowAnonymous]
 [WarpHttpGet("/api/health")]
 public sealed class HealthCheckHandler : IRequestHandler<HealthCheck, HealthStatus> { ... }
+```
+
+### Rate limiting
+
+`[EnableRateLimiting("policy")]` on the handler class applies the named policy registered via `builder.Services.AddRateLimiter(...)`, just like on a Minimal API endpoint:
+
+```csharp
+[EnableRateLimiting("per-user")]
+[WarpHttpPost("/orders")]
+public sealed class CreateOrderHandler : IRequestHandler<CreateOrder, OrderDto> { ... }
 ```
 
 ## OpenAPI / Swagger


### PR DESCRIPTION
## Behavior delta

**Before:** `MapWarpHttp` reflected over each `[WarpHttp*]` handler class and forwarded *only* `[Authorize]` / `[AllowAnonymous]` as ASP.NET endpoint metadata. Every other attribute — `[EnableRateLimiting]`, `[Tags]`, `[OutputCache]`, `[ProducesResponseType]`, … — was silently dropped, so the corresponding middleware never saw it. `[EnableRateLimiting]` appeared to be ignored.

**After:** every attribute declared on the handler class is forwarded to the endpoint via `EndpointBuilder.WithMetadata(attr)`, excluding only Warp's own `[WarpHttp*]` routing markers (those carry route/verb info and are consumed by the source generator). `[EnableRateLimiting("policy")]` now applies its named policy exactly as on a hand-written `MapPost`.

## Where the fix lives

Not in the source generator. The generated delegate is a thin binding trampoline; metadata is attached at registration time in `EndpointRouteBuilderExtensions.ApplyMetadata`. The two hard-coded auth lookups are replaced by one loop over `HandlerType.GetCustomAttributes(inherit: false)`.

## Risk surface

- **Indiscriminate forwarding (`inherit: false`)** — all non-`WarpHttpAttribute` attributes are forwarded, which can include compiler-emitted markers. ASP.NET only reads metadata via typed `GetMetadata<T>()` lookups, so extras are inert. Deliberate tradeoff vs. an explicit allow-list.
- The attribute only *references* a rate-limit policy; consuming apps still need `AddRateLimiter(...)` + `app.UseRateLimiter()`.

## Tests

- New `RateLimitMetadataTests` asserts `[EnableRateLimiting]` surfaces with its `PolicyName` on the built endpoint.
- Existing `AuthMetadataTests` unchanged and green — auth forwarding still works.
- Full NoDb suite: 543/543 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)