### PR TITLE
chore: drop Microsoft.AspNetCore.App framework reference from Warp.Core

### DIFF
--- a/src/core/Warp.Core/Warp.Core.csproj
+++ b/src/core/Warp.Core/Warp.Core.csproj
@@ -9,10 +9,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<InternalsVisibleTo Include="Warp.Worker" />
 		<InternalsVisibleTo Include="Warp.Tests" />
 		<!-- Benchmarks need access to JobDispatcher to measure the reflection path against
@@ -23,6 +19,11 @@
 	<ItemGroup>
 		<PackageReference Include="Cronos" Version="0.11.1" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## What

`Warp.Core` carried a `<FrameworkReference Include="Microsoft.AspNetCore.App" />` that forced **every consumer** — workers, console apps, publishers — onto the ASP.NET Core shared runtime, dragging in Kestrel, MVC, SignalR, Razor, etc.

It was never deliberate: the reference has been there unchanged since the original Jobly→Warp rename (`f7aadd6`). A sweep of every `.cs` file in `Warp.Core` found **zero** `Microsoft.AspNetCore.*` usages. The only thing pulling it in was convenience — the shared framework bundles the `Microsoft.Extensions.*` assemblies the project actually uses.

## Change

Replace the framework reference with explicit `PackageReference`s to the five abstraction packages Core genuinely consumes:

| Package | Used for |
|---|---|
| `Microsoft.Extensions.DependencyInjection.Abstractions` | `IServiceCollection` registration |
| `Microsoft.Extensions.Logging.Abstractions` | `ILogger`, `LogLevel`, `ILoggerProvider` |
| `Microsoft.Extensions.Options` | `IOptions<WarpConfiguration>` |
| `Microsoft.Extensions.Configuration.Abstractions` | `IConfiguration` |
| `Microsoft.Extensions.Configuration.Binder` | `section.Bind(...)` in `WarpBuilderExtensions.BindConfiguration` |

`Configuration.Binder` is the non-obvious one — EF Core brings `Configuration.Abstractions` transitively but **not** the Binder.

## Behavior delta

- **Before:** consumers of `Moberg.Warp.Core` must run on the ASP.NET Core runtime.
- **After:** consumers run on the **base .NET runtime**. The ASP.NET dependency now lives only in `Warp.Http` / `Warp.UI`, which actually use SignalR/Http.
- No source changes — pure packaging.

## Verification

- ✅ Full `src/Warp.slnx` builds clean — all 18 projects, **0 warnings** (`TreatWarningsAsErrors=true`). Confirms no other project was leaning on Core's transitive ASP.NET reference.
- ✅ Full test suite: **2038 passed, 0 failed** (NoDb + Postgres + SQL Server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)