### PR TITLE
fix: ServerCleanup FK race with background-service instances (1.0.1)

### DIFF
--- a/src/core/providers/Warp.Provider.PostgreSql/PostgresWarpSqlQueries.cs
+++ b/src/core/providers/Warp.Provider.PostgreSql/PostgresWarpSqlQueries.cs
@@ -92,9 +92,15 @@ public sealed class PostgresWarpSqlQueries<TContext> : IWarpSqlQueries<TContext>
             WHERE ""{_n.Id}"" = {{0}}
             FOR NO KEY UPDATE";
 
+        // FOR UPDATE (not NO KEY): ServerCleanup deletes a stale server's
+        // BackgroundServiceInstance / BackgroundServiceLease children and then the server in one
+        // transaction. FOR NO KEY UPDATE is compatible with the FOR KEY SHARE lock a child INSERT
+        // takes on its parent, so a stale-but-alive server could insert a fresh instance row
+        // referencing the server mid-cleanup and orphan the FK (23503). FOR UPDATE conflicts with
+        // FOR KEY SHARE, so such inserts block until cleanup commits.
         _lockAllServersSql = $@"
             SELECT * FROM {serverTable}
-            FOR NO KEY UPDATE";
+            FOR UPDATE";
 
         // CTE+LEFT JOIN folds the heartbeat UPDATE, the server paused_at read, the
         // worker_group pause-state read, the BG-service instance heartbeat bump, and the

--- a/src/core/providers/Warp.Provider.SqlServer/SqlServerWarpSqlQueries.cs
+++ b/src/core/providers/Warp.Provider.SqlServer/SqlServerWarpSqlQueries.cs
@@ -94,9 +94,15 @@ public sealed class SqlServerWarpSqlQueries<TContext> : IWarpSqlQueries<TContext
             FROM {table} WITH (ROWLOCK, UPDLOCK)
             WHERE [{_n.Id}] = {{0}}";
 
+        // XLOCK (not UPDLOCK): ServerCleanup deletes a stale server's BackgroundServiceInstance /
+        // BackgroundServiceLease children and then the server in one transaction. UPDLOCK is
+        // compatible with the shared lock a child INSERT's FK check takes on the parent row, so a
+        // stale-but-alive server could insert a fresh instance row referencing the server
+        // mid-cleanup and orphan the FK (error 547). An exclusive XLOCK conflicts with that
+        // FK-check lock, so such inserts block until cleanup commits.
         _lockAllServersSql = $@"
             SELECT *
-            FROM {serverTable} WITH (ROWLOCK, UPDLOCK)";
+            FROM {serverTable} WITH (ROWLOCK, XLOCK)";
 
         // Table variable + chained SELECT folds the heartbeat UPDATE, the server paused_at
         // read, the worker_group pause-state read, the BG-service instance heartbeat bump,

--- a/src/tests/Warp.Tests/BackgroundServices/ServerCleanupLockContentionSqlServerTests.cs
+++ b/src/tests/Warp.Tests/BackgroundServices/ServerCleanupLockContentionSqlServerTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Warp.Core.BackgroundServices;
+using Warp.Core.Data.Entities;
+using Warp.Tests.Fixtures;
+using Warp.Tests.Helpers;
+
+namespace Warp.Tests.BackgroundServices;
+
+/// <summary>
+/// SQL Server sibling of <see cref="ServerCleanupLockContentionTests"/>. Same ServerCleanup
+/// foreign-key race: the cleanup lock must block a concurrent BackgroundServiceInstance insert
+/// for a server being cleaned up, or that insert orphans the FK and crashes ServerCleanup.
+/// SQL Server uses <c>SET LOCK_TIMEOUT</c>, and a blocked request raises error 1222
+/// ("Lock request time out period exceeded"), which makes "blocked" deterministically observable.
+/// </summary>
+[Trait("Category", "SqlServer")]
+public class ServerCleanupLockContentionSqlServerTests : IAsyncLifetime, IClassFixture<SqlServerClassFixture>
+{
+    private readonly SqlServerClassFixture _fixture;
+    private static readonly Guid StaleServerId = Guid.NewGuid();
+
+    public ServerCleanupLockContentionSqlServerTests(SqlServerClassFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+        await _fixture.SeedServerAsync(StaleServerId, "stale-server");
+
+        var ctx = _fixture.CreateContext();
+        ctx.Set<BackgroundServiceDefinition>().Add(new BackgroundServiceDefinition
+        {
+            Name = "Svc",
+            DeclaredScope = ServiceScope.PerServer,
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync(TestCancellation);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [TimedFact]
+    public async Task LockAllServers_HeldDuringCleanup_BlocksConcurrentInstanceInsert()
+    {
+        await using var lockCtx = _fixture.CreateContext();
+        await using var lockTx = await lockCtx.Database.BeginTransactionAsync(TestCancellation);
+        var queries = TestTasks.QueriesFor(lockCtx);
+        await queries.LockAllServersAsync(lockCtx, TestCancellation);
+
+        await using var insertCtx = _fixture.CreateContext();
+        await using var insertTx = await insertCtx.Database.BeginTransactionAsync(TestCancellation);
+        await insertCtx.Database.ExecuteSqlRawAsync("SET LOCK_TIMEOUT 1000", TestCancellation);
+        insertCtx.Set<BackgroundServiceInstance>().Add(new BackgroundServiceInstance
+        {
+            ServerId = StaleServerId,
+            ServiceName = "Svc",
+            DeclaredScope = ServiceScope.PerServer,
+            Status = BackgroundServiceStatus.Running,
+            StartedAt = DateTime.UtcNow,
+            LastHeartbeatAt = DateTime.UtcNow,
+            RestartCount = 0,
+        });
+
+        var insert = async () => await insertCtx.SaveChangesAsync(TestCancellation);
+
+        // A held cleanup lock that blocks the insert trips SQL Server error 1222. If the lock is
+        // too weak (compatible with the insert's FK-check lock), the insert proceeds and nothing
+        // is thrown — failing this assertion, exactly as the orphaning race would in production.
+        var ex = await Should.ThrowAsync<Exception>(insert);
+        ex.ToString().ShouldContain("1222");
+
+        await insertTx.RollbackAsync(TestCancellation);
+        await lockTx.RollbackAsync(TestCancellation);
+    }
+
+    private static CancellationToken TestCancellation => Xunit.TestContext.Current.CancellationToken;
+}

--- a/src/tests/Warp.Tests/BackgroundServices/ServerCleanupLockContentionTests.cs
+++ b/src/tests/Warp.Tests/BackgroundServices/ServerCleanupLockContentionTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.EntityFrameworkCore;
+using Shouldly;
+using Warp.Core.BackgroundServices;
+using Warp.Core.Data.Entities;
+using Warp.Tests.Fixtures;
+using Warp.Tests.Helpers;
+
+namespace Warp.Tests.BackgroundServices;
+
+/// <summary>
+/// Regression for the ServerCleanup foreign-key race (1.0.0). ServerCleanup locks server rows
+/// via <c>LockAllServersAsync</c>, deletes a stale server's <c>BackgroundServiceInstance</c> rows,
+/// then the server itself — all in one transaction. While that lock was <c>FOR NO KEY UPDATE</c>,
+/// it was *compatible* with the <c>FOR KEY SHARE</c> lock a child INSERT takes on its parent, so a
+/// still-alive-but-stale server's <c>BackgroundServiceStateService</c> could insert a fresh instance
+/// row referencing the server between cleanup's instance-SELECT and its server-DELETE — orphaning the
+/// FK and crashing ServerCleanup with <c>23503</c>. The cleanup lock must instead block concurrent
+/// child inserts for servers under cleanup.
+///
+/// This is a Postgres lock-mode behaviour, so it is asserted directly against the lock query and
+/// proven deterministically with <c>lock_timeout</c> (a blocked insert raises 55P03 rather than
+/// hanging) — no sleeps, no spray.
+/// </summary>
+[Trait("Category", "PostgreSql")]
+public class ServerCleanupLockContentionTests : IAsyncLifetime, IClassFixture<PostgreSqlClassFixture>
+{
+    private readonly PostgreSqlClassFixture _fixture;
+    private static readonly Guid StaleServerId = Guid.NewGuid();
+
+    public ServerCleanupLockContentionTests(PostgreSqlClassFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _fixture.ResetAsync();
+        await _fixture.SeedServerAsync(StaleServerId, "stale-server");
+
+        var ctx = _fixture.CreateContext();
+        ctx.Set<BackgroundServiceDefinition>().Add(new BackgroundServiceDefinition
+        {
+            Name = "Svc",
+            DeclaredScope = ServiceScope.PerServer,
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync(TestCancellation);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [TimedFact]
+    public async Task LockAllServers_HeldDuringCleanup_BlocksConcurrentInstanceInsert()
+    {
+        // tx1 takes the exact lock ServerCleanup holds while it deletes a stale server.
+        await using var lockCtx = _fixture.CreateContext();
+        await using var lockTx = await lockCtx.Database.BeginTransactionAsync(TestCancellation);
+        var queries = TestTasks.QueriesFor(lockCtx);
+        await queries.LockAllServersAsync(lockCtx, TestCancellation);
+
+        // A concurrent transaction (a stale-but-alive server's BackgroundServiceStateService)
+        // inserts a fresh instance for the locked server. A blocking lock makes that insert
+        // wait, and a short lock_timeout turns "waited" into a deterministic 55P03 rather than
+        // an indefinite hang.
+        await using var insertCtx = _fixture.CreateContext();
+        await using var insertTx = await insertCtx.Database.BeginTransactionAsync(TestCancellation);
+        await insertCtx.Database.ExecuteSqlRawAsync("SET LOCAL lock_timeout = '1s'", TestCancellation);
+        insertCtx.Set<BackgroundServiceInstance>().Add(new BackgroundServiceInstance
+        {
+            ServerId = StaleServerId,
+            ServiceName = "Svc",
+            DeclaredScope = ServiceScope.PerServer,
+            Status = BackgroundServiceStatus.Running,
+            StartedAt = DateTime.UtcNow,
+            LastHeartbeatAt = DateTime.UtcNow,
+            RestartCount = 0,
+        });
+
+        var insert = async () => await insertCtx.SaveChangesAsync(TestCancellation);
+
+        // FOR NO KEY UPDATE (pre-fix): the insert's FOR KEY SHARE is compatible with the held
+        // lock, so it proceeds immediately and nothing is thrown — this assertion fails.
+        // FOR UPDATE (post-fix): the insert blocks on the held lock and trips lock_timeout.
+        var ex = await Should.ThrowAsync<Exception>(insert);
+
+        // The insert must have been blocked by the held cleanup lock and tripped lock_timeout
+        // (55P03). Assert on the exception chain rather than a specific wrapper type — EF surfaces
+        // an in-SaveChanges lock timeout through more than one wrapper across versions.
+        ex.ToString().ShouldContain("55P03");
+
+        await insertTx.RollbackAsync(TestCancellation);
+        await lockTx.RollbackAsync(TestCancellation);
+    }
+
+    private static CancellationToken TestCancellation => Xunit.TestContext.Current.CancellationToken;
+}

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,18 @@ sidebar_position: 6
 
 # Releases
 
+## 1.0.1
+
+*2026-06-03*
+
+Bug-fix release. No API changes, no schema changes — drop-in upgrade from 1.0.0.
+
+### Fix: ServerCleanup foreign-key crash when reaping a stale server that runs background services
+
+`ServerCleanup` removes servers whose heartbeat has lapsed — deleting their `BackgroundServiceInstance` and `BackgroundServiceLease` child rows and then the server row in one transaction. It locked the server rows with a mode (`FOR NO KEY UPDATE` on Postgres, `UPDLOCK` on SQL Server) that is *compatible* with the lock a child `INSERT` takes on its parent for the foreign-key check. So a server that had only just lapsed — a GC pause or a slow loop — but was still running its `BackgroundServiceHost` could insert a fresh `BackgroundServiceInstance` row for itself between cleanup's child-delete and its server-delete. That orphaned the foreign key and aborted cleanup with `23503` (Postgres) / `547` (SQL Server); the task then failed on every tick and stale servers were never reaped.
+
+The cleanup lock is now exclusive (`FOR UPDATE` on Postgres, `XLOCK` on SQL Server), which conflicts with the FK-check lock: a concurrent instance insert for a server under cleanup now blocks until cleanup commits, then fails cleanly because the server is gone (a still-alive server simply re-registers on its next loop). Regression tests on both providers assert that the cleanup lock blocks the concurrent insert.
+
 ## 1.0.0
 
 *2026-06-03*


### PR DESCRIPTION
## The bug (reported from a 1.0.0 production deploy)

`ServerCleanup` crashed on every tick with:

```
Npgsql.PostgresException 23503: update or delete on table "server" violates foreign key
constraint "fk_background_service_instance_server_server_id" on table "background_service_instance"
```

## Root cause — a lock-mode race

`ServerCleanup` deletes a stale server's `BackgroundServiceInstance` / `BackgroundServiceLease` child rows and then the server row in one transaction. It locked the server rows with **`FOR NO KEY UPDATE`** (Postgres) / **`UPDLOCK`** (SQL Server) — both *compatible* with the lock a child `INSERT` takes on its parent for the FK check. So a server that had only just lapsed (GC pause / slow loop) but was still running its `BackgroundServiceHost` could insert a fresh instance row for itself **between** cleanup's child-delete and its server-delete, orphaning the FK. Cleanup then failed every tick and stale servers were never reaped. (App otherwise healthy — background task only.)

## Fix

Escalate the cleanup lock to exclusive — **`FOR UPDATE`** (Postgres) / **`XLOCK`** (SQL Server) — which conflicts with the FK-check lock, so a concurrent instance insert for a server under cleanup blocks until cleanup commits (then fails cleanly because the server is gone; a still-alive server re-registers next loop). `LockAllServersAsync` is called **only** by `ServerCleanup`, so nothing else is affected. Code-only — **no schema migration**, drop-in from 1.0.0.

## Tests (TDD, both providers)

New regression tests assert the cleanup lock **blocks** a concurrent instance insert, deterministically via lock timeout (no sleeps):
- Postgres: `lock_timeout` → `55P03`
- SQL Server: `SET LOCK_TIMEOUT` → `1222`

Both **fail on the old lock mode** (insert slips through — the orphaning race) and **pass on the new one**. Verified locally red→green on each provider; `BackgroundServices` (182) and `EndToEnd` (18) suites green.

Follow-up (not in this PR): `BackgroundServiceStateService`'s insert now blocks-then-fails when its server is being reaped — harmless (the host retries), but could be made to no-op on a vanished server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)