### PR TITLE
Register source-gen handlers for referenced-assembly contracts

### DIFF
--- a/src/Warp.slnx
+++ b/src/Warp.slnx
@@ -23,6 +23,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Warp.Tests/Warp.Tests.csproj" />
+    <Project Path="tests/Warp.Tests.Contracts/Warp.Tests.Contracts.csproj" />
     <Project Path="tests/Warp.Tests.Mutation/Warp.Tests.Mutation.csproj" />
     <Project Path="tests/Warp.Tests.SourceGenerator/Warp.Tests.SourceGenerator.csproj" />
   </Folder>

--- a/src/core/Warp.SourceGenerator/WarpMediatorGenerator.cs
+++ b/src/core/Warp.SourceGenerator/WarpMediatorGenerator.cs
@@ -118,7 +118,7 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
                 {
                     if (isJob && jobHandlerMap.TryGetValue(candidateFullName, out var jobHandlerSymbol))
                     {
-                        var methodName = "Execute_" + candidate.Name;
+                        var methodName = "Execute_" + GetUniqueIdentifierFragment(candidateFullName);
                         jobTypes.Add(new JobTypeInfo(
                             candidateFullName,
                             [GetFullyQualifiedName(jobHandlerSymbol)],
@@ -127,7 +127,7 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
                     }
                     else if (isMessage && messageHandlerMap.TryGetValue(candidateFullName, out var messageHandlers))
                     {
-                        var methodName = "Execute_" + candidate.Name;
+                        var methodName = "Execute_" + GetUniqueIdentifierFragment(candidateFullName);
                         var handlerNames = new List<string>(messageHandlers.Count);
                         foreach (var h in messageHandlers)
                         {
@@ -157,7 +157,7 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
                     var handlerKey = candidateFullName + "|" + responseFullName;
                     if (allHandlerMap.TryGetValue(handlerKey, out var reqHandlerSymbol))
                     {
-                        var wrapperFieldName = "_wrapper_" + candidate.Name;
+                        var wrapperFieldName = "_wrapper_" + GetUniqueIdentifierFragment(candidateFullName);
                         requestTypes.Add(new RequestTypeInfo(
                             candidateFullName,
                             responseFullName,
@@ -193,7 +193,7 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
                     var streamHandlerKey = candidateFullName + "|" + streamResponseFullName;
                     if (streamHandlerMap.TryGetValue(streamHandlerKey, out var streamHandlerSymbol))
                     {
-                        var wrapperFieldName = "_streamWrapper_" + candidate.Name;
+                        var wrapperFieldName = "_streamWrapper_" + GetUniqueIdentifierFragment(candidateFullName);
                         streamRequestTypes.Add(new StreamRequestTypeInfo(
                             candidateFullName,
                             streamResponseFullName,
@@ -204,6 +204,30 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
                 }
             }
         }
+
+        // Handler-driven discovery (cross-assembly fix).
+        //
+        // The message-driven pass above only sees types declared in *this* compilation that
+        // implement IRequest (the message/request/job/stream contracts). When the contract lives
+        // in a referenced assembly (shared-contract layouts: Contracts.dll defines FooMessage,
+        // Worker.dll defines FooHandler : IMessageHandler<FooMessage>), the contract is never a
+        // local candidate, the handler implements IMessageHandler<> (not IRequest), and nothing is
+        // emitted — the worker then fails the job with "No handlers registered".
+        //
+        // Fix: also iterate the *handlers* this assembly declares, keyed by their message/request
+        // generic argument regardless of where that argument is declared. This feeds the same
+        // collections the emitter consumes, so both the DI registration and the dispatch map pick
+        // the handler up.
+        AddHandlerDrivenRegistrations(
+            candidates,
+            compilation,
+            iJobHandlerSymbol,
+            iMessageHandlerSymbol,
+            iRequestHandlerSymbol,
+            iStreamRequestHandlerSymbol,
+            requestTypes,
+            streamRequestTypes,
+            jobTypes);
 
         // Collect pipeline behavior registrations — multiple behaviors per type are allowed (pipeline chain).
         // Scan only types declared in the *current* compilation (not referenced assemblies) so each
@@ -282,6 +306,154 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
             pipelineBehaviorRegistrations,
             streamPipelineBehaviorRegistrations);
         context.AddSource("WarpMediator.g.cs", source);
+    }
+
+    /// <summary>
+    /// Registers the handlers <paramref name="compilation"/> declares locally, keyed by the
+    /// message/request type read off the handler's generic argument — even when that type lives in
+    /// a referenced assembly. Only types the message-driven pass missed are added; the both-local
+    /// case is already covered there, so it is skipped here to avoid double emission.
+    /// </summary>
+    /// <remarks>
+    /// Only locally-declared handlers are registered: each assembly emits its own
+    /// <c>[ModuleInitializer]</c>, so registering a referenced assembly's handler here would
+    /// double-register it (an IMessageHandler&lt;T&gt; firing twice for the same message).
+    /// </remarks>
+    private static void AddHandlerDrivenRegistrations(
+        ImmutableArray<INamedTypeSymbol?> candidates,
+        Compilation compilation,
+        INamedTypeSymbol? iJobHandlerSymbol,
+        INamedTypeSymbol? iMessageHandlerSymbol,
+        INamedTypeSymbol? iRequestHandlerSymbol,
+        INamedTypeSymbol? iStreamRequestHandlerSymbol,
+        List<RequestTypeInfo> requestTypes,
+        List<StreamRequestTypeInfo> streamRequestTypes,
+        List<JobTypeInfo> jobTypes)
+    {
+        var requestPresent = new HashSet<string>(requestTypes.Select(x => x.RequestFullName), StringComparer.Ordinal);
+        var streamPresent = new HashSet<string>(streamRequestTypes.Select(x => x.RequestFullName), StringComparer.Ordinal);
+        var jobPresent = new HashSet<string>(jobTypes.Select(x => x.JobFullName), StringComparer.Ordinal);
+
+        // Referenced-message handlers are grouped so all of an assembly's local handlers for the
+        // same message land in a single JobTypeInfo (IMessage pub/sub allows multiple handlers).
+        var messageGroups = new Dictionary<string, (INamedTypeSymbol MessageType, List<string> Handlers)>(StringComparer.Ordinal);
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate is null || candidate.IsAbstract || candidate.TypeKind == TypeKind.Interface)
+            {
+                continue;
+            }
+
+            if (!SymbolEqualityComparer.Default.Equals(candidate.ContainingAssembly, compilation.Assembly))
+            {
+                continue;
+            }
+
+            var handlerFullName = GetFullyQualifiedName(candidate);
+
+            foreach (var iface in candidate.AllInterfaces)
+            {
+                var def = iface.OriginalDefinition;
+
+                if (iJobHandlerSymbol is not null && def.Equals(iJobHandlerSymbol, SymbolEqualityComparer.Default))
+                {
+                    if (iface.TypeArguments[0] is not INamedTypeSymbol jobType)
+                    {
+                        continue;
+                    }
+
+                    var jobFullName = GetFullyQualifiedName(jobType);
+                    if (jobPresent.Add(jobFullName))
+                    {
+                        jobTypes.Add(new JobTypeInfo(
+                            jobFullName,
+                            [handlerFullName],
+                            "Execute_" + GetUniqueIdentifierFragment(jobFullName),
+                            isMessage: false));
+                    }
+
+                    continue;
+                }
+
+                if (iMessageHandlerSymbol is not null && def.Equals(iMessageHandlerSymbol, SymbolEqualityComparer.Default))
+                {
+                    if (iface.TypeArguments[0] is not INamedTypeSymbol messageType)
+                    {
+                        continue;
+                    }
+
+                    var messageFullName = GetFullyQualifiedName(messageType);
+
+                    // A locally-declared message was already handled (with all of its — necessarily
+                    // local — handlers) by the message-driven pass. Only referenced messages reach here.
+                    if (jobPresent.Contains(messageFullName))
+                    {
+                        continue;
+                    }
+
+                    if (!messageGroups.TryGetValue(messageFullName, out var group))
+                    {
+                        group = (messageType, []);
+                        messageGroups[messageFullName] = group;
+                    }
+
+                    group.Handlers.Add(handlerFullName);
+                    continue;
+                }
+
+                if (iStreamRequestHandlerSymbol is not null && def.Equals(iStreamRequestHandlerSymbol, SymbolEqualityComparer.Default))
+                {
+                    if (iface.TypeArguments[0] is not INamedTypeSymbol streamRequestType)
+                    {
+                        continue;
+                    }
+
+                    var streamRequestFullName = GetFullyQualifiedName(streamRequestType);
+                    if (streamPresent.Add(streamRequestFullName))
+                    {
+                        streamRequestTypes.Add(new StreamRequestTypeInfo(
+                            streamRequestFullName,
+                            GetFullyQualifiedName(iface.TypeArguments[1]),
+                            handlerFullName,
+                            "_streamWrapper_" + GetUniqueIdentifierFragment(streamRequestFullName),
+                            streamRequestType.DeclaredAccessibility));
+                    }
+
+                    continue;
+                }
+
+                if (iRequestHandlerSymbol is not null && def.Equals(iRequestHandlerSymbol, SymbolEqualityComparer.Default))
+                {
+                    if (iface.TypeArguments[0] is not INamedTypeSymbol requestType)
+                    {
+                        continue;
+                    }
+
+                    var requestFullName = GetFullyQualifiedName(requestType);
+                    if (requestPresent.Add(requestFullName))
+                    {
+                        requestTypes.Add(new RequestTypeInfo(
+                            requestFullName,
+                            GetFullyQualifiedName(iface.TypeArguments[1]),
+                            handlerFullName,
+                            "_wrapper_" + GetUniqueIdentifierFragment(requestFullName),
+                            requestType.DeclaredAccessibility));
+                    }
+
+                    continue;
+                }
+            }
+        }
+
+        foreach (var entry in messageGroups)
+        {
+            jobTypes.Add(new JobTypeInfo(
+                entry.Key,
+                entry.Value.Handlers,
+                "Execute_" + GetUniqueIdentifierFragment(entry.Key),
+                isMessage: true));
+        }
     }
 
     /// <summary>
@@ -473,6 +645,32 @@ public sealed class WarpMediatorGenerator : IIncrementalGenerator
     private static string GetFullyQualifiedName(ISymbol symbol)
     {
         return symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    /// <summary>
+    /// Derives a collision-free identifier fragment from a fully-qualified type name, for use in
+    /// generated member names (<c>_wrapper_X</c> wrapper fields, <c>Execute_X</c> dispatch methods).
+    /// Deriving these from the simple <c>Type.Name</c> collides when two request/job types share a
+    /// name across namespaces or assemblies — the dedup keys use the fully-qualified name, so both
+    /// are emitted and produce duplicate members (CS0102 / CS0111). Two distinct fully-qualified
+    /// names always yield distinct fragments here.
+    /// </summary>
+    private static string GetUniqueIdentifierFragment(string fullyQualifiedName)
+    {
+        var trimmed = fullyQualifiedName.StartsWith("global::", StringComparison.Ordinal)
+            ? fullyQualifiedName.Substring("global::".Length)
+            : fullyQualifiedName;
+
+        var chars = trimmed.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (!char.IsLetterOrDigit(chars[i]))
+            {
+                chars[i] = '_';
+            }
+        }
+
+        return new string(chars);
     }
 
     private static string GenerateSource(

--- a/src/tests/Warp.Tests.Contracts/CrossAssemblyContractMessage.cs
+++ b/src/tests/Warp.Tests.Contracts/CrossAssemblyContractMessage.cs
@@ -1,0 +1,14 @@
+using Warp.Core.Handlers;
+
+namespace Warp.Tests.Contracts;
+
+/// <summary>
+/// A message contract whose handler is declared in a *different* assembly (Warp.Tests). Exercises
+/// the source generator's handler-driven discovery: the message type is never a local candidate in
+/// the worker assembly, so before the fix no handler was registered and the job failed with
+/// "No handlers registered for message type CrossAssemblyContractMessage".
+/// </summary>
+public sealed class CrossAssemblyContractMessage : IMessage
+{
+    public string Value { get; init; } = string.Empty;
+}

--- a/src/tests/Warp.Tests.Contracts/Warp.Tests.Contracts.csproj
+++ b/src/tests/Warp.Tests.Contracts/Warp.Tests.Contracts.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<!--
+		Deliberately a pure-contracts assembly: it references Warp.Core for the IMessage/IJob
+		marker interfaces but NOT the source generator. It mirrors the "Contracts.dll" leg of the
+		shared-contract layout (see WarpMediatorGenerator's handler-driven discovery) — the message
+		type lives here while its handler lives in the referencing Warp.Tests assembly.
+	-->
+	<ItemGroup>
+		<ProjectReference Include="..\..\core\Warp.Core\Warp.Core.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/tests/Warp.Tests/Core/CrossAssemblyHandlerTests.cs
+++ b/src/tests/Warp.Tests/Core/CrossAssemblyHandlerTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Warp.Core;
+using Warp.Core.Handlers;
+using Warp.Core.Handlers.Generated;
+using Warp.Provider.PostgreSql;
+using Warp.Tests.Contracts;
+using Warp.Tests.TestData.Handlers;
+
+namespace Warp.Tests.Core;
+
+/// <summary>
+/// Pins the source generator's handler-driven discovery for the shared-contract layout: the
+/// message contract (<see cref="CrossAssemblyContractMessage"/>) lives in the separate
+/// <c>Warp.Tests.Contracts</c> assembly while its handler
+/// (<see cref="CrossAssemblyContractMessageHandler"/>) is local to this assembly. Before the fix
+/// the generator only discovered message types declared locally, so the handler was never
+/// DI-registered or routed and the worker failed the job with "No handlers registered".
+/// </summary>
+[Trait("Category", "NoDb")]
+public sealed class CrossAssemblyHandlerTests
+{
+    private const string DummyConnectionString = "Host=x;Database=x;Username=x;Password=x";
+
+    [TimedFact]
+    public void CrossAssemblyMessage_RegistersHandlerExactlyOnce_ViaHandlerDrivenDiscovery()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestContext>(x => x.UseNpgsql(DummyConnectionString));
+        services.AddWarp<TestContext>(opt => opt.UsePostgreSql());
+
+        var registrations = services
+            .Where(x => x.ServiceType == typeof(IMessageHandler<CrossAssemblyContractMessage>))
+            .Where(x => x.ImplementationType == typeof(CrossAssemblyContractMessageHandler))
+            .ToList();
+
+        // Exactly one: the generator must register the handler for the referenced-assembly
+        // contract (the fix) without the handler-driven pass double-emitting it (dedup, §detail 3).
+        registrations.Count.ShouldBe(1);
+    }
+
+    [TimedFact]
+    public void CrossAssemblyMessage_HandlerIsDiscoverable_AtRuntime()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestContext>(x => x.UseNpgsql(DummyConnectionString));
+        services.AddSingleton<CrossAssemblyContractCounter>();
+        services.AddWarp<TestContext>(opt => opt.UsePostgreSql());
+
+        using var provider = services.BuildServiceProvider();
+
+        // Mirrors JobDispatcher.DiscoverMessageHandlers — the exact resolution whose empty result
+        // produced the "No handlers registered for message type ..." failure in MessageRouter.
+        var handlers = provider.GetServices<IMessageHandler<CrossAssemblyContractMessage>>().ToList();
+
+        handlers.ShouldHaveSingleItem().ShouldBeOfType<CrossAssemblyContractMessageHandler>();
+    }
+
+    [TimedFact]
+    public async Task CrossAssemblyMessage_Dispatcher_RoutesAndInvokesHandler()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<TestContext>(x => x.UseNpgsql(DummyConnectionString));
+        services.AddSingleton<CrossAssemblyContractCounter>();
+        services.AddWarp<TestContext>(opt => opt.UsePostgreSql());
+
+        await using var provider = services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        var message = new CrossAssemblyContractMessage { Value = "cross-asm" };
+
+        // The generated dispatch map must contain an entry for the referenced-assembly contract
+        // (§detail 2). TryExecute returns null for unknown types, so a non-null Task proves routing.
+        var task = GeneratedJobDispatcher.TryExecute(
+            message,
+            typeof(CrossAssemblyContractMessage),
+            typeof(CrossAssemblyContractMessageHandler),
+            scope.ServiceProvider,
+            Xunit.TestContext.Current.CancellationToken);
+
+        await task.ShouldNotBeNull();
+
+        var counter = provider.GetRequiredService<CrossAssemblyContractCounter>();
+        counter.Count.ShouldBe(1);
+        counter.LastValue.ShouldBe("cross-asm");
+    }
+}

--- a/src/tests/Warp.Tests/Core/MediatorGeneratorCrossAssemblyTests.cs
+++ b/src/tests/Warp.Tests/Core/MediatorGeneratorCrossAssemblyTests.cs
@@ -1,0 +1,268 @@
+using Shouldly;
+
+namespace Warp.Tests.Core;
+
+/// <summary>
+/// Generator-level coverage for <c>WarpMediatorGenerator</c>'s handler-driven discovery. Asserts on
+/// the emitted C# directly (deterministic, no DB), complementing the runtime end-to-end checks in
+/// <see cref="CrossAssemblyHandlerTests"/>.
+/// </summary>
+[Trait("Category", "NoDb")]
+public sealed class MediatorGeneratorCrossAssemblyTests
+{
+    private const string ContractsSource = """
+        using Warp.Core.Handlers;
+
+        namespace Contracts;
+
+        public sealed class FooMessage : IMessage { }
+        """;
+
+    [TimedFact]
+    public void HandlerForReferencedAssemblyContract_EmitsRegistrationAndDispatch()
+    {
+        const string workerSource = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Contracts;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class FooHandler : IMessageHandler<FooMessage>
+            {
+                public Task HandleAsync(FooMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
+            }
+            """;
+
+        var generated = MediatorGeneratorTestHarness.RunAndConcatGeneratedSources(workerSource, ContractsSource);
+
+        // DI registration keyed by the referenced-assembly message type (the fix).
+        generated.ShouldContain(
+            "services.AddTransient<global::Warp.Core.Handlers.IMessageHandler<global::Contracts.FooMessage>, global::Worker.FooHandler>();");
+
+        // Dispatch entry — without it routing still reports "No handlers registered" (§detail 2).
+        generated.ShouldContain("messageType == typeof(global::Contracts.FooMessage)");
+    }
+
+    [TimedFact]
+    public void CoLocatedHandler_RegistersExactlyOnce()
+    {
+        const string workerSource = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class LocalMessage : IMessage { }
+
+            public sealed class LocalHandler : IMessageHandler<LocalMessage>
+            {
+                public Task HandleAsync(LocalMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
+            }
+            """;
+
+        var generated = MediatorGeneratorTestHarness.RunAndConcatGeneratedSources(workerSource);
+
+        // The both-local case is found by the message-driven pass; the handler-driven pass must
+        // dedup it rather than emit a second registration (which would fire pub/sub twice).
+        var registration = "services.AddTransient<global::Warp.Core.Handlers.IMessageHandler<global::Worker.LocalMessage>, global::Worker.LocalHandler>();";
+        var occurrences = generated.Split([registration], StringSplitOptions.None).Length - 1;
+
+        occurrences.ShouldBe(1);
+    }
+
+    [TimedFact]
+    public void HandlerDeclaredInReferencedAssembly_IsNotReRegisteredByConsumer()
+    {
+        const string contractsWithHandler = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Warp.Core.Handlers;
+
+            namespace Contracts;
+
+            public sealed class BarMessage : IMessage { }
+
+            public sealed class BarHandler : IMessageHandler<BarMessage>
+            {
+                public Task HandleAsync(BarMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
+            }
+            """;
+
+        // The consumer declares its own handler (so it emits a generated file) and references the
+        // assembly that owns BarHandler. The consumer's generator must register only its own handler.
+        const string workerSource = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class WorkerMessage : IMessage { }
+
+            public sealed class WorkerHandler : IMessageHandler<WorkerMessage>
+            {
+                public Task HandleAsync(WorkerMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
+            }
+            """;
+
+        var generated = MediatorGeneratorTestHarness.RunAndConcatGeneratedSources(workerSource, contractsWithHandler);
+
+        generated.Contains("global::Worker.WorkerHandler", StringComparison.Ordinal)
+            .ShouldBeTrue("consumer registers its own handler");
+        generated.Contains("global::Contracts.BarHandler", StringComparison.Ordinal)
+            .ShouldBeFalse("a handler owned by a referenced assembly must not be re-registered by the consumer");
+    }
+
+    // The fix is applied symmetrically across all four handler interfaces (§"Apply symmetrically").
+    // The IMessage path is covered above and end-to-end in CrossAssemblyHandlerTests; the remaining
+    // three kinds are pinned here so a future regression in any one branch is caught.
+    [TimedFact]
+    public void JobHandlerForReferencedContract_EmitsRegistrationAndDispatch()
+    {
+        const string contractsSource = """
+            using Warp.Core.Handlers;
+
+            namespace Contracts;
+
+            public sealed class FooJob : IJob { }
+            """;
+
+        const string workerSource = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Contracts;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class FooJobHandler : IJobHandler<FooJob>
+            {
+                public Task HandleAsync(FooJob message, CancellationToken cancellationToken) => Task.CompletedTask;
+            }
+            """;
+
+        var generated = MediatorGeneratorTestHarness.RunAndConcatGeneratedSources(workerSource, contractsSource);
+
+        generated.ShouldContain(
+            "services.AddTransient<global::Warp.Core.Handlers.IJobHandler<global::Contracts.FooJob>, global::Worker.FooJobHandler>();");
+        generated.ShouldContain("messageType == typeof(global::Contracts.FooJob)");
+    }
+
+    [TimedFact]
+    public void RequestHandlerForReferencedContract_EmitsRegistrationAndMediator()
+    {
+        const string contractsSource = """
+            using Warp.Core.Handlers;
+
+            namespace Contracts;
+
+            public sealed class FooQuery : IRequest<string> { }
+            """;
+
+        const string workerSource = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Contracts;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class FooQueryHandler : IRequestHandler<FooQuery, string>
+            {
+                public Task<string> HandleAsync(FooQuery request, CancellationToken cancellationToken) => Task.FromResult("ok");
+            }
+            """;
+
+        var generated = MediatorGeneratorTestHarness.RunAndConcatGeneratedSources(workerSource, contractsSource);
+
+        generated.Contains("IRequestHandler<global::Contracts.FooQuery,", StringComparison.Ordinal)
+            .ShouldBeTrue("request handler is registered for the referenced-assembly request");
+        generated.Contains("global::Worker.FooQueryHandler", StringComparison.Ordinal)
+            .ShouldBeTrue("the consumer's handler is the registered implementation");
+        generated.ShouldContain("services.AddScoped<global::Warp.Core.Handlers.IMediator, GeneratedMediator>();");
+    }
+
+    [TimedFact]
+    public void StreamRequestHandlerForReferencedContract_EmitsRegistration()
+    {
+        const string contractsSource = """
+            using System.Collections.Generic;
+            using Warp.Core.Handlers;
+
+            namespace Contracts;
+
+            public sealed class FooStream : IStreamRequest<int> { }
+            """;
+
+        const string workerSource = """
+            using System;
+            using System.Collections.Generic;
+            using System.Threading;
+            using Contracts;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class FooStreamHandler : IStreamRequestHandler<FooStream, int>
+            {
+                public IAsyncEnumerable<int> HandleAsync(FooStream request, CancellationToken cancellationToken) => throw new NotImplementedException();
+            }
+            """;
+
+        var generated = MediatorGeneratorTestHarness.RunAndConcatGeneratedSources(workerSource, contractsSource);
+
+        generated.Contains("IStreamRequestHandler<global::Contracts.FooStream, int>", StringComparison.Ordinal)
+            .ShouldBeTrue("stream request handler is registered for the referenced-assembly request");
+        generated.Contains("global::Worker.FooStreamHandler", StringComparison.Ordinal)
+            .ShouldBeTrue("the consumer's handler is the registered implementation");
+    }
+
+    [TimedFact]
+    public void RequestTypesSharingASimpleNameAcrossAssemblies_DoNotCollideInGeneratedMembers()
+    {
+        // A local request and a referenced request both named "Ping" both land in the consumer's
+        // GeneratedMediator. Generated member names (wrapper fields / dispatch methods) must be
+        // derived from the full name, not the simple name — otherwise both emit `_wrapper_Ping`
+        // and the generated mediator fails to compile with CS0102 / CS0111.
+        const string contractsSource = """
+            using Warp.Core.Handlers;
+
+            namespace Contracts;
+
+            public sealed class Ping : IRequest<string> { }
+            """;
+
+        const string workerSource = """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using Warp.Core.Handlers;
+
+            namespace Worker;
+
+            public sealed class Ping : IRequest<string> { }
+
+            public sealed class LocalPingHandler : IRequestHandler<Ping, string>
+            {
+                public Task<string> HandleAsync(Ping request, CancellationToken cancellationToken) => Task.FromResult("local");
+            }
+
+            public sealed class ContractsPingHandler : IRequestHandler<global::Contracts.Ping, string>
+            {
+                public Task<string> HandleAsync(global::Contracts.Ping request, CancellationToken cancellationToken) => Task.FromResult("contracts");
+            }
+            """;
+
+        var errors = MediatorGeneratorTestHarness.RunAndGetCompilationErrors(workerSource, contractsSource);
+
+        var duplicateMemberErrors = errors
+            .Where(x => string.Equals(x.Id, "CS0102", StringComparison.Ordinal)
+                || string.Equals(x.Id, "CS0111", StringComparison.Ordinal))
+            .ToList();
+
+        duplicateMemberErrors.ShouldBeEmpty(
+            $"generated mediator has duplicate members: {string.Join("; ", duplicateMemberErrors.Select(x => x.GetMessage()))}");
+    }
+}

--- a/src/tests/Warp.Tests/Core/MediatorGeneratorTestHarness.cs
+++ b/src/tests/Warp.Tests/Core/MediatorGeneratorTestHarness.cs
@@ -1,0 +1,119 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Warp.Core.Handlers;
+using Warp.SourceGenerator;
+
+namespace Warp.Tests.Core;
+
+/// <summary>
+/// Drives <see cref="WarpMediatorGenerator"/> against ad-hoc source, optionally with a separately
+/// compiled "contracts" assembly referenced by the primary compilation. Lets the cross-assembly
+/// handler-discovery tests exercise shared-contract layouts without standing up real projects.
+/// </summary>
+internal static class MediatorGeneratorTestHarness
+{
+    /// <summary>
+    /// Runs the generator over <paramref name="primarySource"/>. When <paramref name="referencedSource"/>
+    /// is supplied it is compiled into its own assembly first and added as a metadata reference, so
+    /// types it declares are visible to the primary compilation exactly as a referenced package would be.
+    /// </summary>
+    public static string RunAndConcatGeneratedSources(
+        string primarySource,
+        string? referencedSource = null,
+        string primaryAssemblyName = "Worker",
+        string referencedAssemblyName = "Contracts")
+    {
+        var baseReferences = BuildBaseReferences();
+
+        var references = baseReferences;
+        if (referencedSource is not null)
+        {
+            references = references.Add(CompileToReference(referencedSource, referencedAssemblyName, baseReferences));
+        }
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: primaryAssemblyName,
+            syntaxTrees: [CSharpSyntaxTree.ParseText(primarySource)],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(new WarpMediatorGenerator());
+        var result = driver.RunGenerators(compilation).GetRunResult();
+
+        return string.Join("\n", result.GeneratedTrees.Select(x => x.ToString()));
+    }
+
+    /// <summary>
+    /// Runs the generator and compiles the resulting code together with <paramref name="primarySource"/>,
+    /// returning the error-severity diagnostics. Lets tests assert the generated mediator is valid C#
+    /// (e.g. no duplicate-member collisions, CS0102 / CS0111).
+    /// </summary>
+    public static IReadOnlyList<Diagnostic> RunAndGetCompilationErrors(
+        string primarySource,
+        string? referencedSource = null,
+        string primaryAssemblyName = "Worker",
+        string referencedAssemblyName = "Contracts")
+    {
+        var baseReferences = BuildBaseReferences();
+
+        var references = baseReferences;
+        if (referencedSource is not null)
+        {
+            references = references.Add(CompileToReference(referencedSource, referencedAssemblyName, baseReferences));
+        }
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: primaryAssemblyName,
+            syntaxTrees: [CSharpSyntaxTree.ParseText(primarySource)],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(new WarpMediatorGenerator());
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var updated, out _);
+
+        return [.. updated.GetDiagnostics().Where(x => x.Severity == DiagnosticSeverity.Error)];
+    }
+
+    private static PortableExecutableReference CompileToReference(
+        string source,
+        string assemblyName,
+        ImmutableArray<MetadataReference> references)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        if (!emitResult.Success)
+        {
+            var diagnostics = string.Join("\n", emitResult.Diagnostics.Where(x => x.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Failed to compile referenced assembly '{assemblyName}':\n{diagnostics}");
+        }
+
+        stream.Position = 0;
+        return MetadataReference.CreateFromImage(stream.ToArray());
+    }
+
+    private static ImmutableArray<MetadataReference> BuildBaseReferences()
+    {
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(x => !x.IsDynamic && !string.IsNullOrEmpty(x.Location))
+            .Select(x => MetadataReference.CreateFromFile(x.Location))
+            .Cast<MetadataReference>()
+            .ToImmutableArray();
+
+        // Be explicit about the Warp.Core assembly, which defines IRequest, IJob, IMessage and the
+        // handler interfaces. The AppDomain scan normally already includes it via the project reference.
+        var coreAssembly = typeof(IRequest<>).Assembly;
+        if (!references.Any(x => string.Equals(x.Display, coreAssembly.Location, StringComparison.OrdinalIgnoreCase)))
+        {
+            references = references.Add(MetadataReference.CreateFromFile(coreAssembly.Location));
+        }
+
+        return references;
+    }
+}

--- a/src/tests/Warp.Tests/TestData/Handlers/CrossAssemblyContractMessageHandler.cs
+++ b/src/tests/Warp.Tests/TestData/Handlers/CrossAssemblyContractMessageHandler.cs
@@ -1,0 +1,41 @@
+using Warp.Core.Handlers;
+using Warp.Tests.Contracts;
+
+namespace Warp.Tests.TestData.Handlers;
+
+/// <summary>
+/// Handler for <see cref="CrossAssemblyContractMessage"/>, which is declared in the separate
+/// <c>Warp.Tests.Contracts</c> assembly. Pins the source generator's handler-driven discovery:
+/// the handler is local to Warp.Tests, the message contract is not, so only handler-keyed
+/// discovery can register and route it.
+/// </summary>
+public sealed class CrossAssemblyContractMessageHandler : IMessageHandler<CrossAssemblyContractMessage>
+{
+    private readonly CrossAssemblyContractCounter _counter;
+
+    public CrossAssemblyContractMessageHandler(CrossAssemblyContractCounter counter)
+    {
+        _counter = counter;
+    }
+
+    public Task HandleAsync(CrossAssemblyContractMessage message, CancellationToken cancellationToken)
+    {
+        _counter.Record(message.Value);
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class CrossAssemblyContractCounter
+{
+    private int _count;
+
+    public int Count => _count;
+
+    public string? LastValue { get; private set; }
+
+    public void Record(string value)
+    {
+        Interlocked.Increment(ref _count);
+        LastValue = value;
+    }
+}

--- a/src/tests/Warp.Tests/Warp.Tests.csproj
+++ b/src/tests/Warp.Tests/Warp.Tests.csproj
@@ -55,16 +55,18 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\Warp.Tests.Contracts\Warp.Tests.Contracts.csproj" />
 		<ProjectReference Include="..\..\core\Warp.Core\Warp.Core.csproj" />
 		<ProjectReference Include="..\..\core\Warp.Http\Warp.Http.csproj" />
 		<ProjectReference Include="..\..\core\providers\Warp.Provider.PostgreSql\Warp.Provider.PostgreSql.csproj" />
 		<ProjectReference Include="..\..\core\providers\Warp.Provider.SqlServer\Warp.Provider.SqlServer.csproj" />
 		<ProjectReference Include="..\..\core\Warp.Worker\Warp.Worker.csproj" />
 		<ProjectReference Include="..\..\core\Warp.UI\Warp.UI.csproj" />
-		<ProjectReference Include="..\..\core\Warp.SourceGenerator\Warp.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-		<!-- Single reference: OutputItemType=Analyzer makes it run as a source generator at compile
-		     time; default ReferenceOutputAssembly=true keeps the assembly bindable so the test
-		     project can instantiate WarpHttpGenerator directly via Roslyn (see GeneratorTestHarness). -->
+		<ProjectReference Include="..\..\core\Warp.SourceGenerator\Warp.SourceGenerator.csproj" OutputItemType="Analyzer" />
+		<!-- OutputItemType=Analyzer runs these as source generators at compile time; the default
+		     ReferenceOutputAssembly=true keeps each assembly bindable so the test project can
+		     instantiate WarpHttpGenerator / WarpMediatorGenerator directly via Roslyn (see
+		     GeneratorTestHarness and MediatorGeneratorTestHarness). -->
 		<ProjectReference Include="..\..\core\Warp.Http.SourceGenerator\Warp.Http.SourceGenerator.csproj" OutputItemType="Analyzer" />
 		<ProjectReference Include="..\Warp.Tests.SourceGenerator\Warp.Tests.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,16 @@ sidebar_position: 6
 
 # Releases
 
+## Unreleased
+
+### Cross-assembly handler discovery (source generator)
+
+The mediator source generator now registers a handler whose message/request **contract lives in a referenced assembly** — the shared-contract layout where contracts sit in one project (e.g. `Contracts.dll`) and handlers in another (a separate worker or API). Discovery used to be driven only by message/request types *declared in the compilation being built*, so a handler such as `FooHandler : IMessageHandler<FooMessage>` whose `FooMessage` came from a referenced assembly was never DI-registered or routed, and the worker failed the job with `No handlers registered for message type FooMessage`. It only worked when the message and its handler lived in the same assembly.
+
+Discovery is now **handler-driven**: each assembly registers the handlers it declares, keyed by the message/request type read off the handler interface — regardless of where that type is declared. Only locally-declared handlers are registered (each assembly emits its own registration), so co-located handlers still register exactly once and a referenced assembly's handlers are not re-registered by a consumer. Applies symmetrically to `IJobHandler`, `IMessageHandler`, `IRequestHandler`, and `IStreamRequestHandler`.
+
+Generated mediator member names (wrapper fields, dispatch methods) are now derived from the fully-qualified type name, so two request/job types that share a simple name across different namespaces or assemblies no longer produce colliding members.
+
 ## 2.1.0
 
 *2026-06-25*


### PR DESCRIPTION
## Summary

The Warp mediator source generator discovered handlers only via message/request types **declared in the compilation being built**. In the shared-contract + separate-worker layout — contracts in one assembly (e.g. `Contracts.dll`), handlers in another (a worker or API) — a handler like `FooHandler : IMessageHandler<FooMessage>` whose `FooMessage` lives in a referenced assembly was never DI-registered or routed. At runtime the worker failed the job with `No handlers registered for message type FooMessage`. It only worked when the message and its handler were in the same assembly.

## Fix

- **Handler-driven discovery.** Each assembly registers the handlers it *declares*, keyed by the message/request type read off the handler interface (`TypeArguments`), regardless of where that type is declared. Emission already uses fully-qualified names, so cross-assembly contracts compile fine.
- **Local-only + dedup.** Only locally-declared handlers are registered (each assembly emits its own `[ModuleInitializer]`), so co-located handlers register exactly once and a referenced assembly's handlers are not re-registered by a consumer.
- **Applied symmetrically** to `IJobHandler`, `IMessageHandler`, `IRequestHandler`, and `IStreamRequestHandler`.
- **Generated member-name collision fix.** Wrapper fields / dispatch methods are now derived from the fully-qualified type name, so two request/job types sharing a simple name across namespaces or assemblies no longer emit duplicate members (CS0102/CS0111).

## Tests

- New `Warp.Tests.Contracts` fixture assembly (pure contracts, no generator) — the referenced-contract leg.
- `CrossAssemblyHandlerTests` (runtime): registration + discovery + dispatch for a referenced-assembly message contract.
- `MediatorGeneratorCrossAssemblyTests` (generator harness): emission for all four handler kinds, co-located-registers-once, referenced-handler-not-re-registered, and the same-simple-name collision case (compiles without CS0102/CS0111).

Full suite green locally: 579 NoDb, 760 PostgreSQL, build analyzer-clean.

Release notes updated under **Unreleased**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)