### PR TITLE
chore: bump CI actions to Node 24-native majors

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,10 +7,6 @@ on:
       - 'website/**'
   workflow_dispatch:
 
-env:
-  # Opt into Node.js 24 for JS-based actions (checkout, setup-node, deploy-pages).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 permissions:
   contents: read
   pages: write
@@ -27,18 +23,18 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
 
       - run: npm ci
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
 
@@ -50,4 +46,4 @@ jobs:
     needs: build
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 env:
   DOTNET_VERSION: '10.0'
   PACKAGE_VERSION: ${{ github.ref_name }}
-  # Opt into Node.js 24 for JS-based actions (checkout, setup-dotnet, setup-node, NuGet/login).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   publish:
@@ -20,17 +18,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 22
 
     - name: Install UI dependencies
       working-directory: src/ui

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ on:
 
 env:
   DOTNET_VERSION: '10.0'
-  # Opt into Node.js 24 for JS-based actions (setup-dotnet, setup-node, checkout).
-  # Node 20 is deprecated on GitHub Actions runners from 2026-06-02.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   test:
@@ -29,15 +26,15 @@ jobs:
             filter: --filter-trait "Category=NoDb"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Setup Node.js (for Warp.UI npm build)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -65,7 +62,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.database }}
           path: test-results/*.trx


### PR DESCRIPTION
## What

Bumps all JS-based GitHub Actions to their latest Node 24-native major versions and removes the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env workaround that was forcing the old Node 20 actions onto Node 24. Node 20 is removed from GitHub Actions runners on 2026-09-16.

| Action | From → To | Runtime |
|---|---|---|
| `actions/checkout` | v4 → v7 | node24 |
| `actions/setup-dotnet` | v4 → v5 | node24 |
| `actions/setup-node` | v4 → v6 | node24 |
| `actions/upload-artifact` | v4 → v7 | node24 |
| `actions/upload-pages-artifact` | v3 → v5 | composite |
| `actions/deploy-pages` | v4 → v5 | node24 |

Each target tag's `runs.using` was verified as `node24` directly from its `action.yml`, so the workaround is genuinely redundant.

## Left untouched, deliberately

- **`NuGet/login@v1`** — floating `@v1` already resolves to v1.2.0, which is node24-native.
- **`EnricoMi/publish-unit-test-result-action@v2.23.0`** — a Docker action (`runs.using: docker`); the Node deprecation never applied to it.

## Also

Aligns the npm-build `node-version` in `release.yml`/`deploy-docs.yml` from the now-EOL Node 20 up to 22, matching `test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)