### PR TITLE
fix: hide internal Warp server context from EF design-time tooling

### DIFF
--- a/src/core/Warp.Worker/ServiceConfiguration.cs
+++ b/src/core/Warp.Worker/ServiceConfiguration.cs
@@ -127,6 +127,13 @@ public static class ServiceConfiguration
         services.TryAddSingleton<IWarpServerModelNames>(sp =>
             new WarpServerModelNames<TContext>(sp.GetRequiredService<IServiceScopeFactory>()));
 
+        // Snapshot the non-generic DbContextOptions forwarders present before we register the server
+        // context, so we can identify (by reference) the one AddDbContext is about to append and remove
+        // exactly that — see the rationale below.
+        var forwardersBefore = services
+            .Where(x => x.ServiceType == typeof(DbContextOptions))
+            .ToList();
+
         services.AddDbContext<WarpServerContext<TContext>>((sp, options) =>
         {
             var configurator = sp.GetService<IWarpServerContextConfigurator>()
@@ -147,6 +154,23 @@ public static class ServiceConfiguration
                 options.ConfigureWarnings(w => w.Log((RelationalEventId.CommandExecuted, LogLevel.Debug)));
             }
         });
+
+        // AddDbContext also appends a non-generic DbContextOptions forwarder (plain Add, not TryAdd)
+        // carrying WarpServerContext<TContext> as its ContextType. That enumeration —
+        // GetServices<DbContextOptions>().Select(o => o.ContextType) — is the only vector EF's
+        // design-time tooling uses to discover this context (it's internal, open-generic, and outside
+        // the user's startup assembly, so the IDesignTimeDbContextFactory and assembly scans miss it).
+        // Left in, `dotnet ef` counts the runtime-only server context and demands --context. Warp only
+        // ever resolves DbContextOptions<WarpServerContext<TContext>>, so dropping the forwarder we just
+        // added leaves runtime untouched; the user's own AddDbContext keeps its separate forwarder
+        // (→ TContext), the correct design-time target. No property identifies a forwarder by its target
+        // context (the factory closure is opaque), so we remove it by identity: the one descriptor
+        // AddDbContext appended that wasn't present before.
+        var addedForwarder = services
+            .Where(x => x.ServiceType == typeof(DbContextOptions))
+            .Except(forwardersBefore)
+            .Single();
+        services.Remove(addedForwarder);
 
         // Server-internal components depend on IWarpServerContext (not the concrete generic type),
         // resolving the scoped WarpServerContext<TContext>.

--- a/src/tests/Warp.Tests/Admin/DeploymentShapeTests.cs
+++ b/src/tests/Warp.Tests/Admin/DeploymentShapeTests.cs
@@ -298,6 +298,42 @@ public class DeploymentShapeTests
         Should.NotThrow(() => ok.AddWarpServer<TestContext>(opt => opt.DisableWorker()));
     }
 
+    // Pins the design-time-discovery contract: AddWarpServer registers the runtime-only
+    // WarpServerContext<TContext>, but EF's `dotnet ef` tooling must NOT see it (else it errors
+    // "More than one DbContext was found" and demands --context). The only discovery vector that
+    // can reach the server context is the non-generic DbContextOptions enumeration
+    // (GetServices<DbContextOptions>().Select(o => o.ContextType)) — it's internal, open-generic, and
+    // outside the user's startup assembly, so the other two vectors miss it. AddWarpServer strips the
+    // forwarder it adds; this guards that strip. If a refactor reintroduces a second forwarder (or
+    // switches back to a plain AddDbContext without the Remove), the enumeration surfaces the server
+    // context and this fails before a broken `dotnet ef` ships.
+    [TimedFact]
+    public void ServerShape_AddWarpServer_HidesServerContextFromEfDiscovery()
+    {
+        var services = new ServiceCollection();
+        RegisterMinimalDependencies(services);
+        services.AddWarpServer<TestContext>();
+
+        var sp = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = sp.CreateScope();
+
+        // This is exactly what DbContextOperations.FindContextTypes() enumerates from DI.
+        var discovered = scope.ServiceProvider
+            .GetServices<DbContextOptions>()
+            .Select(x => x.ContextType)
+            .ToList();
+
+        discovered.ShouldContain(typeof(TestContext));
+        discovered.ShouldNotContain(
+            typeof(WarpServerContext<TestContext>),
+            "the runtime-only server context must stay invisible to `dotnet ef` discovery.");
+
+        // Sanity: hiding it from discovery must NOT break runtime resolution — the context still
+        // resolves via its generic options and IWarpServerContext.
+        scope.ServiceProvider.GetRequiredService<WarpServerContext<TestContext>>().ShouldNotBeNull();
+        scope.ServiceProvider.GetRequiredService<IWarpServerContext>().ShouldNotBeNull();
+    }
+
     private static bool HasHostedService<T>(IServiceCollection services)
         where T : IHostedService
         => services.Any(d => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(T));

--- a/website/docs/releases.md
+++ b/website/docs/releases.md
@@ -4,6 +4,12 @@ sidebar_position: 6
 
 # Releases
 
+## Unreleased
+
+### `dotnet ef` no longer sees the Warp server context
+
+The internal **Warp server context** introduced in 3.0 is now hidden from EF Core's design-time tooling. Because `AddWarpServer` registers `WarpServerContext<TContext>` in DI, `dotnet ef` discovered it alongside your own `DbContext` and failed every command with *"More than one DbContext was found"* unless you passed `--context YourDbContext`. The server context is a runtime-only implementation detail you can never migrate, so the tooling should never have offered it as a target. `AddWarpServer` now strips the design-time discovery hook (the non-generic `DbContextOptions` forwarder EF enumerates), so `dotnet ef` resolves cleanly to your context with no `--context` flag. Runtime resolution of the server context is unchanged.
+
 ## 3.0.0
 
 *2026-06-26*


### PR DESCRIPTION
## Problem

3.0 added an internal `WarpServerContext<TContext>` for all autonomous server-internal DB work. `AddWarpServer` registers it via `AddDbContext`, which appends a non-generic `DbContextOptions` forwarder. EF Core's design-time discovery (`DbContextOperations.FindContextTypes()`) enumerates those forwarders, so `dotnet ef` saw the runtime-only server context **alongside** the user's `DbContext` and errored:

> More than one DbContext was found…

Consumers had to pass `--context YourDbContext` on every `dotnet ef` command. The server context is excluded from migrations and can never be a valid migration target, so the tooling should never have surfaced it.

## Fix

`AddWarpServer` now removes the design-time discovery hook — the single non-generic `DbContextOptions` forwarder that `AddDbContext` appends for the server context. It's identified **by identity** (diffed against a snapshot of forwarders taken just before registration), not by position, and `.Single()` doubles as an assertion that `AddDbContext` added exactly one.

Why removal rather than a manual registration: `AddDbContext` adds the forwarder unconditionally with no opt-out, and the only way to avoid it is to hand-roll the options construction (reimplementing EF's `UseApplicationServiceProvider` / scoped-caching / interceptor wiring), which drifts across EF versions. Removing the one tooling-facing descriptor keeps EF owning construction.

Runtime is untouched: Warp only ever resolves `DbContextOptions<WarpServerContext<TContext>>` (generic, kept) via `IWarpServerContext`.

## Tests

`DeploymentShapeTests.ServerShape_AddWarpServer_HidesServerContextFromEfDiscovery` asserts the DI discovery enumeration sees `TestContext` but **not** `WarpServerContext<TestContext>`, while both still resolve at runtime. Verified red/green: removing the fix fails exactly this test (1/8), restoring it passes 8/8. Full NoDb suite green (583/583).

🤖 Generated with [Claude Code](https://claude.com/claude-code)