### PR TITLE
Saga ergonomics: in-memory test harness, in-process lock, outbox guard

### DIFF
--- a/src/core/Warp.Core/BatchPublisher.cs
+++ b/src/core/Warp.Core/BatchPublisher.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Warp.Core.Data.Entities;
 using Warp.Core.Entities;
@@ -25,7 +26,7 @@ public interface IBatchPublisher
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }
 
-public class BatchPublisher<TContext> : IBatchPublisher
+public sealed class BatchPublisher<TContext> : IBatchPublisher, IDisposable
     where TContext : DbContext
 {
     private readonly TContext _context;
@@ -34,6 +35,7 @@ public class BatchPublisher<TContext> : IBatchPublisher
     private readonly IServiceProvider _serviceProvider;
     private readonly IWarpNotificationTransport _notificationTransport;
     private readonly ServerTaskSignals<TContext> _signals;
+    private bool _staged;
 
     public BatchPublisher(TContext context, IOptions<WarpConfiguration> configuration, TimeProvider timeProvider, IServiceProvider serviceProvider, IWarpNotificationTransport notificationTransport, ServerTaskSignals<TContext> signals)
     {
@@ -179,6 +181,7 @@ public class BatchPublisher<TContext> : IBatchPublisher
         _context.Set<Job>().AddRange(batchChildJobs);
         _context.Set<Job>().Add(batchJob);
         _context.Set<JobLog>().AddRange(logs);
+        _staged = true;
 
         return batchJob.Id;
     }
@@ -188,6 +191,20 @@ public class BatchPublisher<TContext> : IBatchPublisher
         var pending = NotificationDispatch.CapturePending(_context);
         await _context.SaveChangesAsync(cancellationToken);
         await NotificationDispatch.DispatchAsync(pending, _signals, _notificationTransport, cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            WarnIfUnsavedStagedJobs();
+        }
+        catch (Exception ex)
+        {
+            // A diagnostic must never break scope disposal — swallow everything (including a
+            // failed logger resolution) rather than let anything propagate out of Dispose.
+            Debug.WriteLine($"Warp: unsaved-outbox diagnostic failed and was ignored: {ex.Message}");
+        }
     }
 
     private async Task<Dictionary<string, object>> RunPublishPipeline<T>(T job, Dictionary<string, object>? seed = null, CancellationToken ct = default)
@@ -223,5 +240,38 @@ public class BatchPublisher<TContext> : IBatchPublisher
 
         await chain();
         return context.Metadata;
+    }
+
+    // Development-time diagnostic for the silent outbox footgun: jobs staged via IBatchPublisher
+    // are discarded without a trace if the scope ends before SaveChangesAsync. Reuses the
+    // already-injected IServiceProvider to resolve the logger, deliberately avoiding a ctor
+    // parameter (which would ripple to the test construction sites) for a dev-only check.
+    private void WarnIfUnsavedStagedJobs()
+    {
+        if (!_warpConfiguration.WarnOnUnsavedStagedJobs || !_staged)
+        {
+            return;
+        }
+
+        // Inside a worker handler scope the worker owns the commit, not the caller — warning here
+        // would be a false positive. JobExecutionContext.Current is set only while a job executes.
+        if (JobExecutionContext.Current != null)
+        {
+            return;
+        }
+
+        var unsaved = _context.ChangeTracker.Entries<Job>().Count(x => x.State == EntityState.Added);
+        if (unsaved == 0)
+        {
+            return;
+        }
+
+        var logger = _serviceProvider.GetService<ILogger<BatchPublisher<TContext>>>();
+        if (logger == null)
+        {
+            return;
+        }
+
+        logger.LogWarning("Warp: {Count} job(s)/message(s) were staged via IBatchPublisher but the scope ended without SaveChangesAsync — they were discarded and will not run. Call 'await publisher.SaveChangesAsync(ct)'. (Disable this check with WarpConfiguration.WarnOnUnsavedStagedJobs = false.)", unsaved);
     }
 }

--- a/src/core/Warp.Core/Configuration.cs
+++ b/src/core/Warp.Core/Configuration.cs
@@ -21,6 +21,14 @@ public class WarpConfiguration
     public string? Schema { get; set; } = "warp";
 
     /// <summary>
+    /// Development diagnostic: when a scope that staged jobs/messages via <c>IPublisher</c> ends
+    /// without <c>SaveChangesAsync</c> (they would be silently discarded and never run), log a
+    /// Warning. Cheap change-tracker check on publisher dispose; set <c>false</c> to disable.
+    /// Never throws, never blocks.
+    /// </summary>
+    public bool WarnOnUnsavedStagedJobs { get; set; } = true;
+
+    /// <summary>
     /// How long completed and deleted jobs are retained before cleanup.
     /// Failed jobs are never auto-expired.
     /// </summary>

--- a/src/core/Warp.Core/Locking/InProcessLockProvider.cs
+++ b/src/core/Warp.Core/Locking/InProcessLockProvider.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Warp.Core;
+
+/// <summary>
+/// A single-process <see cref="IWarpLockProvider"/> backed by one named <see cref="SemaphoreSlim"/>
+/// per lock name. It satisfies the provider requirement of <c>opt.AddSagas()</c> (and any other
+/// Warp feature that only needs mutual exclusion, e.g. recurring-job registration) for
+/// <b>tests and single-process / mediator-only hosts</b> that never register a database provider.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Single-process only.</b> This provider serializes lock acquisition <em>within one process</em>.
+/// It provides <b>no cross-process serialization</b>: two processes each holding their own
+/// <see cref="InProcessLockProvider"/> will both acquire a lock of the same name simultaneously.
+/// A multi-server deployment — anything where more than one process fetches and executes the same
+/// jobs — <b>MUST</b> use the database-backed provider (<c>opt.UsePostgreSql()</c> /
+/// <c>opt.UseSqlServer()</c>), whose lock is <c>pg_try_advisory_lock</c> / <c>sp_getapplock</c>
+/// scoped to the shared database.
+/// </para>
+/// <para>
+/// <see cref="TryAcquireAsync"/> honours the timeout exactly like the DB-backed providers: a
+/// <see cref="TimeSpan.Zero"/> timeout fast-fails (returns <c>null</c>) when the lock is already
+/// held, a positive timeout waits up to that long, and the returned handle releases the lock once
+/// on <see cref="IAsyncDisposable.DisposeAsync"/>.
+/// </para>
+/// </remarks>
+public sealed class InProcessLockProvider : IWarpLockProvider, IDisposable
+{
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _gates = new(StringComparer.Ordinal);
+    private int _disposed;
+
+    /// <inheritdoc />
+    public async Task<IAsyncDisposable?> TryAcquireAsync(string name, TimeSpan timeout, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        var gate = _gates.GetOrAdd(name, static _ => new SemaphoreSlim(1, 1));
+
+        var acquired = await gate.WaitAsync(timeout, ct).ConfigureAwait(false);
+        if (!acquired)
+        {
+            return null;
+        }
+
+        return new Handle(gate);
+    }
+
+    /// <summary>
+    /// Disposes every named semaphore. The DI container calls this when the owning provider is
+    /// disposed; there is nothing to release because handles are disposed by their callers.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        foreach (var gate in _gates.Values)
+        {
+            gate.Dispose();
+        }
+
+        _gates.Clear();
+    }
+
+    private sealed class Handle(SemaphoreSlim gate) : IAsyncDisposable
+    {
+        private int _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                gate.Release();
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+/// <summary>
+/// Builder extension that registers the single-process <see cref="InProcessLockProvider"/> as the
+/// <see cref="IWarpLockProvider"/>. Call it inside the <c>AddWarp</c> / <c>AddWarpServer</c> lambda
+/// <b>before</b> <c>opt.AddSagas()</c> (mirroring the provider-first ordering of
+/// <c>opt.UsePostgreSql()</c>) when the host has no database provider — the common shape for saga
+/// unit tests and mediator-only processes.
+/// </summary>
+public static class InProcessLockProviderExtensions
+{
+    /// <summary>
+    /// Registers <see cref="InProcessLockProvider"/> as the process-wide <see cref="IWarpLockProvider"/>.
+    /// No-op if an <see cref="IWarpLockProvider"/> is already registered (e.g. a DB provider was
+    /// configured first), so it composes safely.
+    /// </summary>
+    public static IWarpBuilder<TContext> UseInProcessLock<TContext>(this IWarpBuilder<TContext> builder)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Services.TryAddSingleton<IWarpLockProvider, InProcessLockProvider>();
+
+        return builder;
+    }
+}

--- a/src/core/Warp.Core/Publisher.cs
+++ b/src/core/Warp.Core/Publisher.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Warp.Core.Data.Entities;
 using Warp.Core.Entities;
@@ -90,7 +91,7 @@ public interface IPublisher
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }
 
-public class Publisher<TContext> : IPublisher
+public sealed class Publisher<TContext> : IPublisher, IDisposable
     where TContext : DbContext
 {
     private readonly TContext _context;
@@ -99,6 +100,7 @@ public class Publisher<TContext> : IPublisher
     private readonly IServiceProvider _serviceProvider;
     private readonly IWarpNotificationTransport _notificationTransport;
     private readonly ServerTaskSignals<TContext> _signals;
+    private bool _staged;
 
     public Publisher(TContext context, IOptions<WarpConfiguration> configuration, TimeProvider timeProvider, IServiceProvider serviceProvider, IWarpNotificationTransport notificationTransport, ServerTaskSignals<TContext> signals)
     {
@@ -192,6 +194,7 @@ public class Publisher<TContext> : IPublisher
         WarpTelemetry.JobsEnqueued.Add(1, new KeyValuePair<string, object?>("queue", msg.Queue), new KeyValuePair<string, object?>("kind", "message"));
 
         await _context.Set<Job>().AddAsync(msg);
+        _staged = true;
 
         return msg.Id;
     }
@@ -315,6 +318,7 @@ public class Publisher<TContext> : IPublisher
             Timestamp = now,
             Message = $"Job created in queue \"{newJob.Queue}\"",
         });
+        _staged = true;
 
         return newJob.Id;
     }
@@ -324,6 +328,20 @@ public class Publisher<TContext> : IPublisher
         var pending = NotificationDispatch.CapturePending(_context);
         await _context.SaveChangesAsync(cancellationToken);
         await NotificationDispatch.DispatchAsync(pending, _signals, _notificationTransport, cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            WarnIfUnsavedStagedJobs();
+        }
+        catch (Exception ex)
+        {
+            // A diagnostic must never break scope disposal — swallow everything (including a
+            // failed logger resolution) rather than let anything propagate out of Dispose.
+            Debug.WriteLine($"Warp: unsaved-outbox diagnostic failed and was ignored: {ex.Message}");
+        }
     }
 
     private async Task<PublishContext<T>> RunPublishPipeline<T>(T job, Dictionary<string, object>? seed, CancellationToken ct)
@@ -374,5 +392,38 @@ public class Publisher<TContext> : IPublisher
         }
 
         return (now, State.Enqueued);
+    }
+
+    // Development-time diagnostic for the silent outbox footgun: jobs/messages staged via
+    // IPublisher are discarded without a trace if the scope ends before SaveChangesAsync. Reuses
+    // the already-injected IServiceProvider to resolve the logger, deliberately avoiding a ctor
+    // parameter (which would ripple to ~40 test construction sites) for a dev-only check.
+    private void WarnIfUnsavedStagedJobs()
+    {
+        if (!_configuration.WarnOnUnsavedStagedJobs || !_staged)
+        {
+            return;
+        }
+
+        // Inside a worker handler scope the worker owns the commit, not the caller — warning here
+        // would be a false positive. JobExecutionContext.Current is set only while a job executes.
+        if (JobExecutionContext.Current != null)
+        {
+            return;
+        }
+
+        var unsaved = _context.ChangeTracker.Entries<Job>().Count(x => x.State == EntityState.Added);
+        if (unsaved == 0)
+        {
+            return;
+        }
+
+        var logger = _serviceProvider.GetService<ILogger<Publisher<TContext>>>();
+        if (logger == null)
+        {
+            return;
+        }
+
+        logger.LogWarning("Warp: {Count} job(s)/message(s) were staged via IPublisher but the scope ended without SaveChangesAsync — they were discarded and will not run. Call 'await publisher.SaveChangesAsync(ct)'. (Disable this check with WarpConfiguration.WarnOnUnsavedStagedJobs = false.)", unsaved);
     }
 }

--- a/src/core/Warp.Core/Sagas/Testing/SagaDispatchResult.cs
+++ b/src/core/Warp.Core/Sagas/Testing/SagaDispatchResult.cs
@@ -1,0 +1,61 @@
+using Warp.Core.Handlers;
+
+namespace Warp.Core.Sagas.Testing;
+
+/// <summary>
+/// The classified effect of dispatching one message through <see cref="SagaTestHarness{TContext}"/>.
+/// Derived from the saga row's before/after existence plus the <see cref="IJobContext.Outcome"/> the
+/// <see cref="SagaHandlerProxy{TSaga, TMessage}"/> set. Values start at 1 (§8.11).
+/// </summary>
+public enum SagaDispatchOutcome
+{
+    /// <summary>A <c>[StartsSaga]</c> message created a new live saga row.</summary>
+    Created = 1,
+
+    /// <summary>A message was applied to an existing saga which remains live afterwards.</summary>
+    Updated = 2,
+
+    /// <summary>
+    /// The handler called <c>MarkCompleted()</c> — the saga row was removed (or, for a start
+    /// message that completes in the same call, never persisted). The correlation key is free again.
+    /// </summary>
+    Completed = 3,
+
+    /// <summary>
+    /// A non-<c>[StartsSaga]</c> message arrived for an unknown correlation key — the dead-letter
+    /// path (<c>ISagaHandler.NotFoundAsync</c> ran; the proxy set the not-found outcome).
+    /// </summary>
+    NotFound = 4,
+
+    /// <summary>
+    /// The per-correlation-key lock was already held, so the handler was skipped and the message
+    /// was rescheduled. In the harness this happens only when a test pre-holds the lock.
+    /// </summary>
+    Busy = 5,
+
+    /// <summary>
+    /// An <see cref="ITimeoutMessage"/> fired for a saga that no longer exists (already completed) —
+    /// silently dropped as moot rather than failing.
+    /// </summary>
+    TimeoutDropped = 6,
+}
+
+/// <summary>
+/// Result of <see cref="SagaTestHarness{TContext}.DispatchAsync{TMessage}"/>: the classified
+/// <see cref="Outcome"/> plus the raw <see cref="JobOutcome"/> the proxy set (for the busy,
+/// not-found, and timeout-dropped paths; <c>null</c> on the create/update/complete success paths,
+/// exactly as a real worker would see it).
+/// </summary>
+public sealed class SagaDispatchResult
+{
+    /// <summary>The classified dispatch outcome.</summary>
+    public required SagaDispatchOutcome Outcome { get; init; }
+
+    /// <summary>
+    /// The <see cref="JobOutcome"/> the proxy assigned to <see cref="IJobContext.Outcome"/>, or
+    /// <c>null</c> when the dispatch succeeded (create / update / complete). Inspect
+    /// <see cref="JobOutcome.State"/> / <see cref="JobOutcome.LogMessage"/> to distinguish, for
+    /// example, a busy reschedule from a save-conflict reschedule.
+    /// </summary>
+    public JobOutcome? JobOutcome { get; init; }
+}

--- a/src/core/Warp.Core/Sagas/Testing/SagaTestHarness.cs
+++ b/src/core/Warp.Core/Sagas/Testing/SagaTestHarness.cs
@@ -1,0 +1,291 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Warp.Core.Data;
+using Warp.Core.Data.Entities;
+using Warp.Core.Handlers;
+
+namespace Warp.Core.Sagas.Testing;
+
+/// <summary>
+/// Drives the full saga dispatch — correlate, load-or-create, mutex, converge, complete,
+/// dead-letter, timeout-drop — against a configured <typeparamref name="TContext"/>
+/// <b>without booting a worker or the message router</b>. The harness resolves the registered
+/// <see cref="SagaHandlerProxy{TSaga, TMessage}"/> (an <see cref="IMessageHandler{TMessage}"/>),
+/// invokes it directly with a usable <see cref="IJobContext"/>, lets the proxy persist through the
+/// real <see cref="ISagaStore"/>, and classifies the effect into a <see cref="SagaDispatchResult"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire it with a relational in-memory database (SQLite <c>DataSource=:memory:</c> on an open
+/// connection is ideal — it honours the optimistic-concurrency <c>Version</c> token and the unique
+/// <c>(Type, CorrelationKey)</c> index), the <see cref="InProcessLockProvider"/>, <c>AddSagas()</c>,
+/// and one <c>AddSagaHandler&lt;THandler&gt;()</c> per handler. Use <see cref="Create"/> for the
+/// shortest setup, or the <see cref="SagaTestHarness{TContext}(IServiceProvider)"/> constructor to
+/// bring a service provider you built (and schema you created) yourself.
+/// </para>
+/// <para>
+/// <b>Timeouts are dispatched synchronously.</b> An <see cref="ITimeoutMessage"/> passed to
+/// <see cref="DispatchAsync{TMessage}"/> invokes its handler immediately — the harness does not wait
+/// out <see cref="ITimeoutMessage.Delay"/>. It exercises the handler-firing and drop-after-complete
+/// behaviour, not the scheduling latency (that belongs to <c>ScheduledJobActivation</c>).
+/// </para>
+/// </remarks>
+/// <typeparam name="TContext">The user's Warp-configured <see cref="DbContext"/> type.</typeparam>
+public sealed class SagaTestHarness<TContext> : IAsyncDisposable
+    where TContext : DbContext
+{
+    private readonly IServiceProvider _services;
+    private readonly bool _ownsProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SagaTestHarness{TContext}"/> class over a service
+    /// provider the caller built (via <c>AddDbContext&lt;TContext&gt;</c> + <c>AddWarp&lt;TContext&gt;</c>
+    /// + <see cref="InProcessLockProviderExtensions.UseInProcessLock"/> + <c>AddSagas()</c> +
+    /// <c>AddSagaHandler&lt;T&gt;()</c>). The caller owns the provider's lifetime and is responsible for
+    /// creating the schema (e.g. <c>Database.EnsureCreated()</c>).
+    /// </summary>
+    public SagaTestHarness(IServiceProvider services)
+        : this(services, ownsProvider: false)
+    {
+    }
+
+    private SagaTestHarness(IServiceProvider services, bool ownsProvider)
+    {
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _ownsProvider = ownsProvider;
+    }
+
+    /// <summary>
+    /// Builds a self-contained harness: registers <typeparamref name="TContext"/> with
+    /// <paramref name="configureContext"/> (e.g. <c>o =&gt; o.UseSqlite(connection)</c>), wires
+    /// <c>AddWarp</c> + <see cref="InProcessLockProviderExtensions.UseInProcessLock"/> +
+    /// <c>AddSagas()</c>, runs <paramref name="configureServices"/> (where you register saga handlers),
+    /// then creates the schema with <c>EnsureCreated()</c>. The returned harness owns the provider and
+    /// disposes it on <see cref="DisposeAsync"/>.
+    /// </summary>
+    /// <param name="configureContext">Configures the <typeparamref name="TContext"/> provider/connection.</param>
+    /// <param name="configureServices">Registers saga handlers (and any optional addons) on the container.</param>
+    /// <param name="timeProvider">Optional time source (e.g. a <c>FakeTimeProvider</c>) for controllable time.</param>
+    /// <param name="schema">Warp schema; <c>null</c> (the default) suits SQLite, which has no schemas.</param>
+    public static SagaTestHarness<TContext> Create(
+        Action<DbContextOptionsBuilder> configureContext,
+        Action<IServiceCollection> configureServices,
+        TimeProvider? timeProvider = null,
+        string? schema = null)
+    {
+        ArgumentNullException.ThrowIfNull(configureContext);
+        ArgumentNullException.ThrowIfNull(configureServices);
+
+        var services = new ServiceCollection();
+        if (timeProvider is not null)
+        {
+            services.AddSingleton(timeProvider);
+        }
+
+        services.AddDbContext<TContext>(configureContext);
+        services.AddWarp<TContext>(opt =>
+        {
+            opt.Schema = schema;
+            opt.UseInProcessLock();
+            opt.AddSagas();
+        });
+
+        configureServices(services);
+
+        // IDatabaseExceptionClassifier is normally contributed by a DB provider package; a harness
+        // wired with only the in-process lock has none. Supply a no-op default (single-process
+        // dispatch never races into the unique/version-conflict branches) unless the caller already
+        // registered one.
+        services.TryAddSingleton<IDatabaseExceptionClassifier, NoConflictExceptionClassifier>();
+
+        var provider = services.BuildServiceProvider(validateScopes: true);
+
+        using (var scope = provider.CreateScope())
+        {
+            scope.ServiceProvider.GetRequiredService<TContext>().Database.EnsureCreated();
+        }
+
+        return new SagaTestHarness<TContext>(provider, ownsProvider: true);
+    }
+
+    /// <summary>
+    /// Dispatches <paramref name="message"/> through its registered saga proxy and returns the
+    /// classified <see cref="SagaDispatchResult"/>. Opens a scope, sets a usable
+    /// <see cref="IJobContext"/>, invokes every <see cref="IMessageHandler{TMessage}"/> registered for
+    /// the message (the proxy persists via <see cref="ISagaStore"/> before returning), then classifies
+    /// the effect from the saga row's before/after existence and the proxy-set outcome.
+    /// </summary>
+    public async Task<SagaDispatchResult> DispatchAsync<TMessage>(TMessage message, CancellationToken ct = default)
+        where TMessage : class, IMessage
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        await using var scope = _services.CreateAsyncScope();
+        var sp = scope.ServiceProvider;
+
+        var handlers = sp.GetServices<IMessageHandler<TMessage>>().ToList();
+        if (handlers.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No saga handler is registered for message '{typeof(TMessage).FullName}'. " +
+                $"Register one with services.AddSagaHandler<THandler>() where THandler implements " +
+                $"ISagaHandler<TSaga, {typeof(TMessage).Name}>.");
+        }
+
+        var sagaTypeName = ResolveSagaTypeName(handlers, typeof(TMessage));
+        var correlationKey = sp.GetRequiredService<SagaCorrelationCache>().GetCorrelationKey(message);
+
+        var context = sp.GetRequiredService<TContext>();
+        var existedBefore = await SagaRowExistsAsync(context, sagaTypeName, correlationKey, ct);
+
+        var jobContext = sp.GetRequiredService<JobContext>();
+        jobContext.JobId = Guid.NewGuid();
+        jobContext.TraceId = Guid.NewGuid();
+
+        foreach (var handler in handlers)
+        {
+            await handler.HandleAsync(message, ct);
+        }
+
+        // Re-query the same scoped context: the proxy committed through it, so a fresh (no-tracking)
+        // read reflects the committed insert/delete without any stale identity-map entry.
+        var existsAfter = await SagaRowExistsAsync(context, sagaTypeName, correlationKey, ct);
+
+        var outcome = Classify<TMessage>(existedBefore, existsAfter, jobContext.Outcome);
+
+        return new SagaDispatchResult
+        {
+            Outcome = outcome,
+            JobOutcome = jobContext.Outcome,
+        };
+    }
+
+    /// <summary>
+    /// Loads the current saga of type <typeparamref name="TSaga"/> for <paramref name="correlationKey"/>
+    /// through the real <see cref="ISagaStore"/>, or <c>null</c> if none is live. The key may be a
+    /// <see cref="string"/>, <see cref="Guid"/>, <see cref="int"/>, or <see cref="long"/> — it is
+    /// canonicalized the same way the dispatch pipeline canonicalizes a <c>[Correlate]</c> value.
+    /// </summary>
+    public async Task<TSaga?> GetSagaAsync<TSaga>(object correlationKey, CancellationToken ct = default)
+        where TSaga : Saga, new()
+    {
+        ArgumentNullException.ThrowIfNull(correlationKey);
+
+        var canonical = SagaCorrelationKeyConverter.ToCanonical(correlationKey);
+
+        await using var scope = _services.CreateAsyncScope();
+        var store = scope.ServiceProvider.GetRequiredService<ISagaStore>();
+
+        return await store.Load<TSaga>(canonical, ct);
+    }
+
+    /// <summary>Counts the live saga rows of type <typeparamref name="TSaga"/>.</summary>
+    public async Task<int> CountAsync<TSaga>(CancellationToken ct = default)
+        where TSaga : Saga
+    {
+        var typeName = typeof(TSaga).FullName!;
+
+        await using var scope = _services.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+
+        return await context.Set<SagaState>()
+            .AsNoTracking()
+            .Where(x => x.Type == typeName)
+            .CountAsync(ct);
+    }
+
+    /// <summary>Disposes the underlying service provider when the harness owns it (built via <see cref="Create"/>).</summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (!_ownsProvider)
+        {
+            return;
+        }
+
+        switch (_services)
+        {
+            case IAsyncDisposable asyncDisposable:
+                await asyncDisposable.DisposeAsync();
+                break;
+            case IDisposable disposable:
+                disposable.Dispose();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static SagaDispatchOutcome Classify<TMessage>(bool existedBefore, bool existsAfter, JobOutcome? outcome)
+        where TMessage : class, IMessage
+    {
+        if (outcome is null)
+        {
+            if (!existedBefore && existsAfter)
+            {
+                return SagaDispatchOutcome.Created;
+            }
+
+            if (existedBefore && existsAfter)
+            {
+                return SagaDispatchOutcome.Updated;
+            }
+
+            // Row gone (completed) or a start message that completed in the same call and was never
+            // persisted — both are logical completion with no requeue/failure outcome.
+            return SagaDispatchOutcome.Completed;
+        }
+
+        var isTimeout = typeof(ITimeoutMessage).IsAssignableFrom(typeof(TMessage));
+        if (isTimeout && !existedBefore)
+        {
+            return SagaDispatchOutcome.TimeoutDropped;
+        }
+
+        var hasStartsSaga = Attribute.IsDefined(typeof(TMessage), typeof(StartsSagaAttribute), inherit: false);
+        if (!existedBefore && !hasStartsSaga)
+        {
+            return SagaDispatchOutcome.NotFound;
+        }
+
+        // A set outcome on an existing saga (or a start message) is a reschedule — the lock was held
+        // (busy) or a save conflicted. Inspect JobOutcome.LogMessage to tell them apart.
+        return SagaDispatchOutcome.Busy;
+    }
+
+    private static string ResolveSagaTypeName(IEnumerable<object> handlers, Type messageType)
+    {
+        foreach (var handler in handlers)
+        {
+            var type = handler.GetType();
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(SagaHandlerProxy<,>))
+            {
+                return type.GetGenericArguments()[0].FullName!;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"No saga handler proxy is registered for message '{messageType.FullName}'. " +
+            $"The harness dispatches saga messages; register a handler with " +
+            $"services.AddSagaHandler<THandler>().");
+    }
+
+    private static async Task<bool> SagaRowExistsAsync(TContext context, string sagaTypeName, string correlationKey, CancellationToken ct)
+    {
+        return await context.Set<SagaState>()
+            .AsNoTracking()
+            .Where(x => x.Type == sagaTypeName)
+            .Where(x => x.CorrelationKey == correlationKey)
+            .AnyAsync(ct);
+    }
+
+    // No-op classifier for the provider-less harness. Reports nothing as a conflict/deadlock, which
+    // is correct for single-process synchronous dispatch — the concurrent-start and version-conflict
+    // paths cannot occur without a second process contending on the same row.
+    private sealed class NoConflictExceptionClassifier : IDatabaseExceptionClassifier
+    {
+        public bool IsUniqueConstraintViolation(DbUpdateException ex) => false;
+
+        public bool IsTransientDeadlock(Exception ex) => false;
+    }
+}

--- a/src/tests/Warp.Tests/Core/UnsavedOutboxWarningTests.cs
+++ b/src/tests/Warp.Tests/Core/UnsavedOutboxWarningTests.cs
@@ -1,0 +1,187 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Warp.Core;
+using Warp.Core.Handlers;
+using Warp.Core.Logging;
+using Warp.Tests.Helpers;
+using Warp.Tests.TestData.Handlers;
+
+namespace Warp.Tests.Core;
+
+/// <summary>
+/// Covers the development-time diagnostic that catches the silent outbox footgun: staging
+/// jobs/messages via <see cref="IPublisher"/> but ending the scope without
+/// <c>SaveChangesAsync</c> (the work is silently discarded). The check runs on publisher dispose.
+/// </summary>
+[Trait("Category", "NoDb")]
+public sealed class UnsavedOutboxWarningTests
+{
+    [TimedFact]
+    public async Task Dispose_WithUnsavedStagedJobs_LogsSingleWarningWithCount()
+    {
+        var sink = new WarningSink();
+        await using var ctx = NewContext();
+        var publisher = NewPublisher(ctx, sink, new WarpConfiguration());
+
+        await publisher.Publish(new SingleHandlerMessage());
+
+        // Scope ends WITHOUT SaveChangesAsync — the staged job would be silently discarded.
+        publisher.Dispose();
+
+        sink.Warnings.Count.ShouldBe(1);
+        sink.Warnings[0].ShouldContain("1 job(s)/message(s)");
+        sink.Warnings[0].ShouldContain("SaveChangesAsync");
+    }
+
+    [TimedFact]
+    public async Task Dispose_AfterSaveChanges_DoesNotWarn()
+    {
+        var sink = new WarningSink();
+        await using var ctx = NewContext();
+        var publisher = NewPublisher(ctx, sink, new WarpConfiguration());
+
+        await publisher.Publish(new SingleHandlerMessage());
+        await publisher.SaveChangesAsync(Xunit.TestContext.Current.CancellationToken);
+
+        publisher.Dispose();
+
+        sink.Warnings.ShouldBeEmpty();
+    }
+
+    [TimedFact]
+    public async Task Dispose_WhenNothingStaged_DoesNotWarn()
+    {
+        var sink = new WarningSink();
+        await using var ctx = NewContext();
+        var publisher = NewPublisher(ctx, sink, new WarpConfiguration());
+
+        publisher.Dispose();
+
+        sink.Warnings.ShouldBeEmpty();
+    }
+
+    [TimedFact]
+    public async Task Dispose_WhenCheckDisabled_DoesNotWarn()
+    {
+        var sink = new WarningSink();
+        await using var ctx = NewContext();
+        var publisher = NewPublisher(ctx, sink, new WarpConfiguration { WarnOnUnsavedStagedJobs = false });
+
+        await publisher.Publish(new SingleHandlerMessage());
+
+        publisher.Dispose();
+
+        sink.Warnings.ShouldBeEmpty();
+    }
+
+    [TimedFact]
+    public async Task Dispose_InsideWorkerHandlerScope_DoesNotWarn()
+    {
+        var sink = new WarningSink();
+        await using var ctx = NewContext();
+        var publisher = NewPublisher(ctx, sink, new WarpConfiguration());
+
+        // Simulate executing inside a worker handler: the worker owns the commit, so an unsaved
+        // staged job here is not the caller's footgun and must not warn (false-positive guard).
+        JobExecutionContext.Current = new JobExecutionInfo
+        {
+            JobId = Guid.NewGuid(),
+            TraceId = Guid.NewGuid(),
+        };
+
+        try
+        {
+            await publisher.Publish(new SingleHandlerMessage());
+
+            publisher.Dispose();
+
+            sink.Warnings.ShouldBeEmpty();
+        }
+        finally
+        {
+            JobExecutionContext.Current = null;
+        }
+    }
+
+    [TimedFact]
+    public async Task Dispose_WithUnsavedBatch_LogsWarning()
+    {
+        var sink = new WarningSink();
+        await using var ctx = NewContext();
+        var provider = NewProvider(sink);
+        var publisher = new BatchPublisher<TestContext>(ctx, Options.Create(new WarpConfiguration()), TimeProvider.System, provider, TestTasks.NullTransport, TestTasks.NullSignals);
+
+        await publisher.StartNew([new SingleHandlerJob()]);
+
+        publisher.Dispose();
+
+        sink.Warnings.Count.ShouldBe(1);
+        sink.Warnings[0].ShouldContain("SaveChangesAsync");
+    }
+
+    private static TestContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<TestContext>()
+            .UseInMemoryDatabase($"warp-outbox-{Guid.NewGuid():N}")
+            .Options;
+
+        return new TestContext(options);
+    }
+
+    private static ServiceProvider NewProvider(WarningSink sink)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(x => x.AddProvider(new CapturingLoggerProvider(sink)));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static Publisher<TestContext> NewPublisher(TestContext ctx, WarningSink sink, WarpConfiguration configuration)
+    {
+        return new Publisher<TestContext>(ctx, Options.Create(configuration), TimeProvider.System, NewProvider(sink), TestTasks.NullTransport, TestTasks.NullSignals);
+    }
+
+    private sealed class SingleHandlerJob : IJob;
+
+    private sealed class WarningSink
+    {
+        public List<string> Warnings { get; } = [];
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly WarningSink _sink;
+
+        public CapturingLoggerProvider(WarningSink sink) => _sink = sink;
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_sink);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly WarningSink _sink;
+
+        public CapturingLogger(WarningSink sink) => _sink = sink;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Warning)
+            {
+                _sink.Warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}

--- a/src/tests/Warp.Tests/Features/Locking/InProcessLockProviderTests.cs
+++ b/src/tests/Warp.Tests/Features/Locking/InProcessLockProviderTests.cs
@@ -1,0 +1,62 @@
+using Shouldly;
+using Warp.Core;
+
+namespace Warp.Tests.Features.Locking;
+
+/// <summary>
+/// Unit tests for the shipped single-process <see cref="InProcessLockProvider"/>. Verifies the
+/// timeout-zero fast-fail, release-on-dispose, and per-name independence that <c>AddSagas()</c>
+/// relies on when no database provider is configured.
+/// </summary>
+[Trait("Category", "NoDb")]
+public class InProcessLockProviderTests
+{
+    private static CancellationToken CT => Xunit.TestContext.Current.CancellationToken;
+
+    [TimedFact]
+    public async Task TryAcquire_WhenHeld_ZeroTimeout_ReturnsNull()
+    {
+        using var provider = new InProcessLockProvider();
+
+        await using var first = await provider.TryAcquireAsync("k", TimeSpan.Zero, CT);
+        first.ShouldNotBeNull();
+
+        var second = await provider.TryAcquireAsync("k", TimeSpan.Zero, CT);
+        second.ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task TryAcquire_AfterRelease_Succeeds()
+    {
+        using var provider = new InProcessLockProvider();
+
+        var first = await provider.TryAcquireAsync("k", TimeSpan.Zero, CT);
+        first.ShouldNotBeNull();
+        await first.DisposeAsync();
+
+        await using var second = await provider.TryAcquireAsync("k", TimeSpan.Zero, CT);
+        second.ShouldNotBeNull();
+    }
+
+    [TimedFact]
+    public async Task TryAcquire_DifferentNames_AreIndependent()
+    {
+        using var provider = new InProcessLockProvider();
+
+        await using var a = await provider.TryAcquireAsync("a", TimeSpan.Zero, CT);
+        await using var b = await provider.TryAcquireAsync("b", TimeSpan.Zero, CT);
+
+        a.ShouldNotBeNull();
+        b.ShouldNotBeNull();
+    }
+
+    [TimedFact]
+    public async Task TryAcquire_PositiveTimeout_AcquiresWhenFree()
+    {
+        using var provider = new InProcessLockProvider();
+
+        await using var handle = await provider.TryAcquireAsync("k", TimeSpan.FromSeconds(1), CT);
+
+        handle.ShouldNotBeNull();
+    }
+}

--- a/src/tests/Warp.Tests/Features/Sagas/SagaHarnessTests.cs
+++ b/src/tests/Warp.Tests/Features/Sagas/SagaHarnessTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Warp.Core;
+using Warp.Core.Enums;
+using Warp.Core.Sagas;
+using Warp.Core.Sagas.Testing;
+using Warp.Tests.Fixtures;
+using Warp.Tests.TestData.Sagas;
+
+namespace Warp.Tests.Features.Sagas;
+
+/// <summary>
+/// Worker-free saga tests driven entirely through <see cref="SagaTestHarness{TContext}"/> against a
+/// SQLite in-memory database and the in-process lock provider. Exercises the full dispatch — create,
+/// converge, complete, dead-letter, timeout — without booting a <c>WarpTestServer</c> or the
+/// <c>MessageRouter</c>. Fast tier (<c>NoDb</c>): no container, no fixture.
+/// </summary>
+[Trait("Category", "NoDb")]
+public class SagaHarnessTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private SagaTestHarness<HarnessContext> _harness = null!;
+
+    private static CancellationToken CT => Xunit.TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync(CT);
+        _harness = SagaTestHarness<HarnessContext>.Create(
+            o => o.UseSqlite(_connection),
+            s => s.AddSagaHandler<OrderSagaHandler>());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _harness.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_StartsSagaMessage_CreatesSaga()
+    {
+        var result = await _harness.DispatchAsync(new OrderPlaced { OrderId = "O-1" }, CT);
+
+        result.Outcome.ShouldBe(SagaDispatchOutcome.Created);
+        result.JobOutcome.ShouldBeNull();
+
+        var saga = await _harness.GetSagaAsync<OrderSaga>("O-1", CT);
+        saga.ShouldNotBeNull();
+        saga.OrderId.ShouldBe("O-1");
+        (await _harness.CountAsync<OrderSaga>(CT)).ShouldBe(1);
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_SecondCorrelatedMessage_UpdatesSaga()
+    {
+        await _harness.DispatchAsync(new OrderPlaced { OrderId = "O-2" }, CT);
+
+        var result = await _harness.DispatchAsync(new PaymentCaptured { OrderId = "O-2" }, CT);
+
+        result.Outcome.ShouldBe(SagaDispatchOutcome.Updated);
+        result.JobOutcome.ShouldBeNull();
+
+        var saga = await _harness.GetSagaAsync<OrderSaga>("O-2", CT);
+        saga.ShouldNotBeNull();
+        saga.PaymentCaptured.ShouldBeTrue();
+        saga.InventoryReserved.ShouldBeFalse();
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_FinalConvergingMessage_CompletesAndRemovesSaga()
+    {
+        await _harness.DispatchAsync(new OrderPlaced { OrderId = "O-3" }, CT);
+        await _harness.DispatchAsync(new PaymentCaptured { OrderId = "O-3" }, CT);
+
+        var result = await _harness.DispatchAsync(new InventoryReserved { OrderId = "O-3" }, CT);
+
+        result.Outcome.ShouldBe(SagaDispatchOutcome.Completed);
+        result.JobOutcome.ShouldBeNull();
+
+        (await _harness.GetSagaAsync<OrderSaga>("O-3", CT)).ShouldBeNull();
+        (await _harness.CountAsync<OrderSaga>(CT)).ShouldBe(0);
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_UnknownCorrelation_NonStartMessage_DeadLetters()
+    {
+        var result = await _harness.DispatchAsync(new PaymentCaptured { OrderId = "never-existed" }, CT);
+
+        result.Outcome.ShouldBe(SagaDispatchOutcome.NotFound);
+        result.JobOutcome.ShouldNotBeNull();
+        result.JobOutcome.State.ShouldBe(State.Failed);
+        result.JobOutcome.LogMessage!.ShouldContain("No saga");
+
+        (await _harness.GetSagaAsync<OrderSaga>("never-existed", CT)).ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_TimeoutForLiveSaga_FiresHandlerAndCompletes()
+    {
+        var created = await _harness.DispatchAsync(new OrderPlaced { OrderId = "O-4" }, CT);
+        created.Outcome.ShouldBe(SagaDispatchOutcome.Created);
+
+        // OrderSagaHandler's OrderTimeout branch sets TimedOut and calls MarkCompleted, so a fired
+        // timeout on a live saga completes it — the row removal is the observable proof it ran.
+        var result = await _harness.DispatchAsync(new OrderTimeout { OrderId = "O-4" }, CT);
+
+        result.Outcome.ShouldBe(SagaDispatchOutcome.Completed);
+        (await _harness.GetSagaAsync<OrderSaga>("O-4", CT)).ShouldBeNull();
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_TimeoutForMissingSaga_IsDroppedNotFailed()
+    {
+        var result = await _harness.DispatchAsync(new OrderTimeout { OrderId = "already-gone" }, CT);
+
+        result.Outcome.ShouldBe(SagaDispatchOutcome.TimeoutDropped);
+        result.JobOutcome.ShouldNotBeNull();
+        result.JobOutcome.State.ShouldBe(State.Deleted);
+        result.JobOutcome.LogMessage!.ShouldContain("moot");
+    }
+
+    [TimedFact]
+    public async Task DispatchAsync_LockHeld_ReportsBusy_WithoutInvokingHandler()
+    {
+        // Bring-your-own-provider path so the test can hold the correlation-key lock the proxy checks.
+        var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(CT);
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddDbContext<HarnessContext>(o => o.UseSqlite(connection));
+            services.AddWarp<HarnessContext>(opt =>
+            {
+                opt.Schema = null;
+                opt.UseInProcessLock();
+                opt.AddSagas();
+            });
+            services.AddSagaHandler<OrderSagaHandler>();
+            services.AddSingleton<Warp.Core.Data.IDatabaseExceptionClassifier, FakeExceptionClassifier>();
+
+            await using var provider = services.BuildServiceProvider(validateScopes: true);
+            await using (var scope = provider.CreateAsyncScope())
+            {
+                await scope.ServiceProvider.GetRequiredService<HarnessContext>().Database.EnsureCreatedAsync(CT);
+            }
+
+            var harness = new SagaTestHarness<HarnessContext>(provider);
+            var locks = provider.GetRequiredService<IWarpLockProvider>();
+
+            await using var held = await locks.TryAcquireAsync(
+                $"warp:saga:{typeof(OrderSaga).FullName}:O-busy", TimeSpan.Zero, CT);
+            held.ShouldNotBeNull();
+
+            var result = await harness.DispatchAsync(new OrderPlaced { OrderId = "O-busy" }, CT);
+
+            result.Outcome.ShouldBe(SagaDispatchOutcome.Busy);
+            result.JobOutcome.ShouldNotBeNull();
+            result.JobOutcome.State.ShouldBe(State.Scheduled);
+            result.JobOutcome.LogMessage!.ShouldContain("busy");
+
+            // Handler never ran, so nothing was persisted.
+            (await harness.CountAsync<OrderSaga>(CT)).ShouldBe(0);
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+        }
+    }
+
+    public sealed class HarnessContext(DbContextOptions<HarnessContext> options) : DbContext(options);
+}

--- a/src/tests/Warp.Tests/Warp.Tests.csproj
+++ b/src/tests/Warp.Tests/Warp.Tests.csproj
@@ -36,6 +36,11 @@
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+		<!-- Override the vulnerable SQLitePCLRaw.lib.e_sqlite3 2.1.11 (GHSA-2m69-gcr7-jv3q) that
+		     EF Core's Sqlite provider pulls transitively; 2.1.12 is patched. NuGetAuditMode=all +
+		     TreatWarningsAsErrors turns the transitive advisory into a build error otherwise. -->
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />

--- a/website/docs/features/sagas.md
+++ b/website/docs/features/sagas.md
@@ -25,6 +25,14 @@ builder.Services.AddSagaHandler<OrderWorkflow>();
 
 `AddSagaHandler<>()` reflects over the handler's implemented `ISagaHandler<TSaga, TMessage>` interfaces and registers a `SagaHandlerProxy<TSaga, TMessage>` as `IMessageHandler<TMessage>` for each.
 
+:::note Prerequisite — a lock provider
+`AddSagas()` **requires `IWarpLockProvider`** (used to serialize concurrent messages per correlation key), so a provider must be opted in **before** it: call `opt.UsePostgreSql()` / `opt.UseSqlServer()` first. Without it, `AddSagas()` throws a clear startup exception (`"AddSagas() requires IWarpLockProvider… Call opt.UsePostgreSql() or opt.UseSqlServer() BEFORE opt.AddSagas()."`). This is why sagas cannot run on a mediator-only / in-process-only host — they need the cross-process lock the provider supplies. To exercise sagas **in tests without a provider or a worker**, use the in-memory saga test harness (see [Testing sagas](#testing-sagas)).
+:::
+
+:::tip Need a "wait N then act" timeout?
+Don't hand-roll a scheduled job — Warp ships it as a first-class primitive. See [Timeouts (`ITimeoutMessage`)](#timeouts-itimeoutmessage) below: a message class with a `Delay` that auto-schedules itself and self-cleans if the saga already completed.
+:::
+
 ## Defining a saga
 
 A saga has three parts: the **state class** (subclass `Saga`), the **correlated messages** (each carries a `[Correlate]` property; one or more are marked `[StartsSaga]`), and the **handler class** (implements `ISagaHandler<TSaga, TMessage>` for each message type that touches the saga).
@@ -317,6 +325,35 @@ public class OrderAbandonedTimeout : ITimeoutMessage
 ```
 
 This pairs with `ITimeoutMessage`'s missing-saga silent-drop behavior — completed sagas don't leave noise behind.
+
+## Testing sagas
+
+The full saga dispatch — correlate → load/create → mutex → converge → complete → dead-letter → timeout — normally runs on a worker driven by the `MessageRouter`, which needs a real database and a running server. To exercise that logic in the **fast test tier** (no worker, no container), use **`SagaTestHarness<TContext>`** (`Warp.Core.Sagas.Testing`). It resolves the registered `SagaHandlerProxy` and invokes it directly against a SQLite in-memory database and the shipped single-process `InProcessLockProvider` — the enabler that lets `AddSagas()` be wired **without a database provider**.
+
+`opt.UseInProcessLock()` satisfies `AddSagas()`'s `IWarpLockProvider` requirement for tests and single-process / mediator-only hosts. It serializes locks **within one process only** — a multi-server deployment MUST still use `opt.UsePostgreSql()` / `opt.UseSqlServer()`, whose lock is scoped to the shared database.
+
+```csharp
+using var connection = new SqliteConnection("DataSource=:memory:");
+connection.Open(); // keep the in-memory DB alive for the connection's lifetime
+
+await using var harness = SagaTestHarness<AppDbContext>.Create(
+    o => o.UseSqlite(connection),                 // caller supplies the DbContext provider
+    s => s.AddSagaHandler<OrderWorkflow>());       // register saga handlers
+
+// Start message → a new saga row exists, correlated.
+var started = await harness.DispatchAsync(new OrderPlaced { OrderId = "O-1" });
+started.Outcome.ShouldBe(SagaDispatchOutcome.Created);
+(await harness.GetSagaAsync<OrderSaga>("O-1"))!.OrderId.ShouldBe("O-1");
+
+// Converge, then complete.
+(await harness.DispatchAsync(new PaymentCaptured { OrderId = "O-1" })).Outcome
+    .ShouldBe(SagaDispatchOutcome.Updated);
+(await harness.DispatchAsync(new InventoryReserved { OrderId = "O-1" })).Outcome
+    .ShouldBe(SagaDispatchOutcome.Completed);
+(await harness.GetSagaAsync<OrderSaga>("O-1")).ShouldBeNull(); // row gone on completion
+```
+
+`DispatchAsync` returns a `SagaDispatchResult` whose `Outcome` is one of `Created`, `Updated`, `Completed`, `NotFound` (dead-lettered), `Busy` (lock held), or `TimeoutDropped`; the raw proxy-set `JobOutcome` is also exposed (null on the success paths). Query helpers `GetSagaAsync<TSaga>(key)` and `CountAsync<TSaga>()` read the current state through the real store. An `ITimeoutMessage` is dispatched **synchronously** — the harness fires the handler immediately rather than waiting out `Delay`, so tests assert the fired behavior (and the timeout-after-completion `TimeoutDropped` drop) directly. All of this runs in the fast (`NoDb`) tier with no worker and no provider. If you prefer to build the container yourself, the `new SagaTestHarness<TContext>(serviceProvider)` constructor wraps a provider you configured (and a schema you created) directly.
 
 ## Limitations (v1)
 


### PR DESCRIPTION
Actions from a saga-feature trial's feedback.

## Added
- **`SagaTestHarness<TContext>`** (`Warp.Core.Sagas.Testing`) — exercises the full saga dispatch (correlate → load/create → proxy → converge → complete → dead-letter → timeout) **without a worker or `MessageRouter`**. `DispatchAsync` returns a `SagaDispatchOutcome` (`Created`/`Updated`/`Completed`/`NotFound`/`Busy`/`TimeoutDropped`); `GetSagaAsync`/`CountAsync` for assertions. Closes the trial's "saga dispatch is worker-only → must live-smoke to trust it" gap: the new saga tests run in the **fast NoDb tier** (SQLite in-memory, ~2.5s).
- **`InProcessLockProvider` + `opt.UseInProcessLock()`** — a single-process `IWarpLockProvider` that satisfies `AddSagas()`'s lock requirement without a DB provider. Powers the harness, and lets sagas run on a single-process / mediator-only host (documented: **not** for multi-server; use `UsePostgreSql`/`UseSqlServer` there).
- **`WarpConfiguration.WarnOnUnsavedStagedJobs`** (default true) — Publisher/BatchPublisher log a Warning when a scope stages jobs via `IPublisher` but ends without `SaveChangesAsync` (the silent outbox footgun that bit the trial: "the saga just never exists"). Skips worker handler scopes (no false positives), count only (no PII, §1.2), never throws from `Dispose`. No ctor change → no test fan-out.

## Docs
`website/docs/features/sagas.md`: new **Testing sagas** section, an explicit **`AddSagas` lock-provider prerequisite** note, and a tip pointing at the already-first-class **`ITimeoutMessage`** (the trial's "biggest gap" was a discoverability miss — timeouts are implemented and documented).

## Verification
15 new tests (7 harness + 4 in-process-lock + 6 outbox, all NoDb/fast). Full suite green on PostgreSQL + SQL Server; solution builds analyzer-clean. No public contract removed; `WarnOnUnsavedStagedJobs` is additive (default on, disable-able).

🤖 Generated with [Claude Code](https://claude.com/claude-code)