### PR TITLE
docs: cross-link sink page from adapters & endpoint observability

### DIFF
--- a/website/docs/features/adapters.md
+++ b/website/docs/features/adapters.md
@@ -308,6 +308,10 @@ The OTel histogram carries exact per-call latency for external backends. The das
 
 Statistics are written as `Counter` rows (per adapter/operation/outcome and per group/outcome, successes included, plus per-outcome duration-sum and latency-bucket counters) that `CounterAggregator` collapses into `Statistic` rows — never a direct `Statistic` write from the call path. Because average latency and the percentiles are read from these aggregates rather than the raw `AdapterCallLog` rows, they stay correct after retention prunes the rows.
 
+### Routing to OpenTelemetry instead of the database
+
+By default the per-call detail lands as `AdapterCallLog` rows and the aggregates as `Counter`→`Statistic` rows in your database. On a hot adapter that write volume is the expensive part. `opt.AddAdapters(o => o.Sink = RecordingSink.Otel)` routes the captured detail onto the adapter `Client` span (as `warp.adapter.*` attributes) and relies on the always-on meters for the aggregates — **no call-log rows and no `Counter` writes**, keeping the database out of the hot path. `Both` does both; `Database` (default) is unchanged. See [Observability sinks](./observability-sinks.md).
+
 ## Multi-application provenance
 
 In a shared-database deployment with [multi-application observability](./applications.md) enabled (`opt.ApplicationName` set), every `AdapterCallLog` row is stamped with the **producing application** — the app that made the call — as a nullable `Application` column, and per-application adapter metrics (calls, error rate, latency) accrue alongside the app-agnostic totals under a disjoint counter-key namespace. The dashboard's global application filter then scopes the Adapters surfaces to one app. When `ApplicationName` is unset the column is `null` and nothing changes.

--- a/website/docs/features/endpoint-observability.md
+++ b/website/docs/features/endpoint-observability.md
@@ -110,6 +110,10 @@ Rows are handed to a **bounded in-memory channel** and drained to the database b
 
 Call counts, error rate, **average latency**, and the **latency percentiles** are read from aggregated `Counter`→`Statistic` rows (a duration-sum counter backs the average, a bucket histogram backs the percentiles), so they persist after the raw `EndpointCallLog` rows are cleaned up — the same model jobs and adapters use. The recent-calls list and per-caller last-failure timestamp read the retained rows and degrade to empty/null once logs age out.
 
+## Routing to OpenTelemetry instead of the database
+
+By default the per-request detail lands as `EndpointCallLog` rows and the aggregates as `Counter`→`Statistic` rows in your database. `opt.AddEndpointObservability(o => o.Sink = RecordingSink.Otel)` routes the captured detail onto the ambient ASP.NET request span (as `warp.endpoint.*` attributes) and relies on the always-on `warp.endpoint.*` meters for the aggregates — **no call-log rows and no `Counter` writes**, keeping the database out of the hot path. `Both` does both; `Database` (default) is unchanged. See [Observability sinks](./observability-sinks.md).
+
 ## Retention
 
 `EndpointCallLog` rows are cleaned up by `ExpirationCleanup` on **both** an age cap and a count cap, whichever trims first:
@@ -129,4 +133,4 @@ Dashboard-only / publisher-only processes resolve `IEndpointQueryService` (regis
 
 ## Not in scope
 
-Endpoint observability records diagnostics, not an audit trail (same stance as `AdapterCallLog` / `JobLog`): the raw call rows are lossy under load (a full buffer drops the record, never blocking the request), and there is no per-request guaranteed delivery. The **aggregate metrics** (counts, error rate, latency percentiles) are exact regardless. For high-volume export, use the OpenTelemetry ASP.NET Core instrumentation alongside it.
+Endpoint observability records diagnostics, not an audit trail (same stance as `AdapterCallLog` / `JobLog`): the raw call rows are lossy under load (a full buffer drops the record, never blocking the request), and there is no per-request guaranteed delivery. The **aggregate metrics** (counts, error rate, latency percentiles) are exact regardless. For high-volume export, route the surface to OpenTelemetry with `Sink = RecordingSink.Otel` (see [Observability sinks](./observability-sinks.md)) — or run the standard OpenTelemetry ASP.NET Core instrumentation alongside it.


### PR DESCRIPTION
Follow-up to #249. Both telemetry sections described DB recording + always-on meters but never surfaced the `RecordingSink` option. Adds a short "Routing to OpenTelemetry instead of the database" pointer to each, and updates the endpoint-observability "Not in scope" note (which pointed only at external ASP.NET instrumentation for high-volume export — the built-in Otel sink is now the first answer).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)