### PR TITLE
Fix broken docs link in queue-metrics page

### DIFF
--- a/website/docs/features/queue-metrics.md
+++ b/website/docs/features/queue-metrics.md
@@ -33,7 +33,7 @@ Queue-wait folds into `Counter` → `Statistic` rows the same way execution and 
 
 ## Queue-wait on the hot path
 
-Queue-wait is measured where a worker flips a job `Enqueued → Processing`. The wait is `claimTime − Job.ScheduleTime` (`ScheduleTime` advances on requeue, so a requeued job's wait is measured from its requeue, not its original enqueue). The Counter rows are added to the **same `SaveChanges` that already writes the "Processing" `JobLog`** — the hot path gains a Counter write, never a query or a round-trip ([§0.2 / §6.1](../../CLAUDE.md)).
+Queue-wait is measured where a worker flips a job `Enqueued → Processing`. The wait is `claimTime − Job.ScheduleTime` (`ScheduleTime` advances on requeue, so a requeued job's wait is measured from its requeue, not its original enqueue). The Counter rows are added to the **same `SaveChanges` that already writes the "Processing" `JobLog`** — the hot path gains a Counter write, never a query or a round-trip (the worker fetch/execute path stays sacred).
 
 ## Backlog sampling (off the hot path)
 


### PR DESCRIPTION
Follow-up to #252. The queue-metrics feature doc linked to `../../CLAUDE.md`, which resolves outside the Docusaurus `website/docs` tree — Docusaurus (`onBrokenLinks: throw`) flagged it as a broken link and **failed the Deploy Docs to GitHub Pages build** on the push to main (the feature/release itself was unaffected). Replaced the link with a plain-text reference to the hot-path rule. Local `npm run build` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)