### PR TITLE
Test host: silence non-essential metrics loops to cut SQL Server pool contention

### DIFF
--- a/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
+++ b/src/tests/Warp.Tests/Fixtures/WarpTestServer.cs
@@ -283,6 +283,19 @@ public class WarpTestServer : IAsyncDisposable
                     // Leaving it on creates a 5s race against any test that reads Counter rows.
                     config.CounterAggregationInterval = null;
 
+                    // Same rationale for the other periodic metrics loops (§8.26/§8.30/§8.31): no ordinary
+                    // integration test needs them firing, and every extra server-task loop borrows a pooled
+                    // SqlConnection against the shared SQL Server instance. Under load a command cancelled by
+                    // the 5s CommandTimeout returns its connection to the pool in a busy/attention-sent state,
+                    // so the next borrower hits SqlException 3980 ("another request is running in the same
+                    // session" — MARS is off in the test connection string) and the worker/save fails
+                    // transiently. Their feature tests drive the task directly (StatisticRollupTestsBase,
+                    // BacklogSamplerTestsBase, SloEvaluatorTestsBase), so disabling the loops here costs no
+                    // coverage; a test that needs one re-enables it via the configure callback (which runs next).
+                    config.StatisticRollupInterval = null;
+                    config.BacklogSampleInterval = null;
+                    config.SloEvaluationInterval = null;
+
                     configure?.Invoke(config);
 
                     config.AddRetry(o =>


### PR DESCRIPTION
## Root cause

Investigation into the intermittent **SQL Server** CI failures (e.g. `WebhookExecutionTests_SqlServer.Send_FailedAttemptWithRetriesLeft_StaysPendingAndSchedulesNext` failing on an empty-list assertion, with a `Worker fetch failed` / transient-`SqlException` storm in the log).

**It is not a product bug.** Two passes over the worker loop, notification listener, webhook executor, and every server task confirmed they all use the safe *fresh-scope-per-operation* pattern — `IWarpServerContext` is `Scoped`, connection-string-based, never a shared `DbContext`. The new SLO tasks match `CounterAggregator` exactly.

The failures are **test-harness connection-pool contention**:
- The SQL Server test connection string has **MARS disabled**, so SQL Server rejects a second concurrent command on one session with **error 3980**.
- With the 5s `CommandTimeout` + cancellation, a command killed mid-flight returns its pooled `SqlConnection` busy; the next borrower hits 3980.
- Amplified by `maxParallelThreads=4` × a full host each (`WorkerCount=5` + ~19 background loops) against **one shared SQL Server instance**.
- Chain for the failing test: 3980 storm → worker fetch/save fails → retry Job never scheduled → `ShouldHaveSingleItem` sees an empty list. PostgreSQL runs the same test and passes.

## Fix

Extend the existing `CounterAggregationInterval = null` precedent (already in `WarpTestServer`) to the other periodic metrics loops in the **default** test host — `StatisticRollup`, `BacklogSampler`, `SloEvaluator`. They don't affect job/webhook execution correctness, and their feature tests drive the task **directly** (`StatisticRollupTestsBase`, `BacklogSamplerTestsBase`, `SloEvaluatorTestsBase`) rather than through the host loop — so no coverage is lost. A test that needs a loop re-enables it via the `configure` callback (runs after these defaults). Removes three connection-borrowing loops from every integration-test host.

## Verification

501 tests green on **both** providers across the highest-risk namespaces: Metrics, Slo, Webhooks, EndToEnd, Applications. Full solution builds analyzer-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)