### PR TITLE
CI: never publish packages for a draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ env:
 jobs:
   publish:
     name: Pack and Publish
+    # Never publish for a draft release. The `published` event can fire for a draft in some flows;
+    # this guard guarantees packages reach NuGet only when the release is actually published.
+    if: ${{ github.event.release.draft == false }}
     runs-on: ubuntu-latest
     environment: production
     permissions:


### PR DESCRIPTION
Guards the NuGet publish job with `if: ${{ github.event.release.draft == false }}` so a draft release can never push packages — they go to NuGet only when a release is actually published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)